### PR TITLE
Update compile dependencies.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -13,10 +13,10 @@
 
 * Please install the following package updates:
 
-   * sudo apt-get install build-essential pkg-config tcsh swig google-perftools python3 python3-dev
+   * sudo apt-get install build-essential pkg-config tcsh swig uuid-dev libgoogle-perftools-dev python3 python3-dev
 
    * If you don't intent to change the grammar:
-     * sudo apt-get install default-jre 
+     * sudo apt-get install default-jre
    * If you do intent to change the grammar:
      * sudo apt-get install default-jdk ant
 
@@ -28,4 +28,3 @@
 * Build
   * make
   * or see [`src/README`](./src/README.md)
-  


### PR DESCRIPTION
  * uuid-dev is indirectly needed by flatbuffers.
  * tcmalloc is in libgoogle-perftools-dev.

Signed-off-by: Henner Zeller <h.zeller@acm.org>