### PR TITLE
Disambiguate types that would be different on 32/64 bit machines.

### DIFF
--- a/src/API/PythonAPI.cpp
+++ b/src/API/PythonAPI.cpp
@@ -201,7 +201,7 @@ void PythonAPI::init(int argc, const char** argv) {
           }
       }
   }
-  Py_SetProgramName((wchar_t*)argv[0]); /* optional but recommended */
+  Py_SetProgramName(L"surelog"); /* optional but recommended */
 
   PyImport_AppendInittab("slapi", &PyInit_slapi);
 
@@ -273,7 +273,7 @@ std::string PythonAPI::evalScript(std::string module, std::string function,
       pValue = PyObject_CallObject(pFunc, pArgs);
       Py_DECREF(pArgs);
       if (pValue != NULL) {
-        long int size;
+        Py_ssize_t size;
         const char* compName = PyUnicode_AsUTF8AndSize(pValue, &size);
         if (compName == NULL) {
           std::cout << "PYTHON API ERROR: Incorrect function return type, "

--- a/src/Cache/ParseCache.cpp
+++ b/src/Cache/ParseCache.cpp
@@ -20,6 +20,14 @@
  *
  * Created on April 29, 2017, 4:20 PM
  */
+
+#include <stdint.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+
+#include <cstdio>
+#include <ctime>
+
 #include "CommandLine/CommandLineParser.h"
 #include "ErrorReporting/ErrorContainer.h"
 #include "SourceCompile/SymbolTable.h"
@@ -32,13 +40,10 @@
 #include "Utils/FileUtils.h"
 #include "Cache/Cache.h"
 #include "flatbuffers/util.h"
-#include <cstdio>
-#include <ctime>
-#include <sys/types.h>
-#include <sys/stat.h>
 #include "Cache/ParseCache.h"
 #include "Design/FileContent.h"
 #include "Package/Precompiled.h"
+
 using namespace SURELOG;
 
 ParseCache::ParseCache(ParseFile* parser)
@@ -264,7 +269,7 @@ bool ParseCache::save() {
   /* Cache the design objects */
   // std::vector<flatbuffers::Offset<PARSECACHE::VObject>> object_vec;
   std::vector<PARSECACHE::VObject> object_vec;
-  for (unsigned int i = 0; i < fcontent->getVObjects().size(); i++) {
+  for (size_t i = 0; i < fcontent->getVObjects().size(); i++) {
     VObject& object = fcontent->getVObjects()[i];
 
     // Lets compress this struct into 20 and 16 bits fields:
@@ -278,9 +283,9 @@ bool ParseCache::save() {
     //                                               object.m_child,
     //                                               object.m_sibling));
 
-    unsigned long field1 = 0;
-    unsigned long field2 = 0;
-    unsigned long field3 = 0;
+    uint64_t field1 = 0;
+    uint64_t field2 = 0;
+    uint64_t field3 = 0;
     SymbolId name = canonicalSymbols.getId(
         m_parse->getCompileSourceFile()->getSymbolTable()->getSymbol(
             object.m_name));
@@ -290,18 +295,18 @@ bool ParseCache::save() {
     // UNUSED: field1 |= (((unsigned long) object.m_line)   << (20 + 12)); // 16
     // Bits => Filled 48 Bits (Of 64)
     field1 |=
-        ((unsigned long)object.m_parent
+        ((uint64_t)object.m_parent
          << (20 + 12 + 16));  // 16 Bits => Filled 64 Bits (Of 64) , Word Full
     field2 |= (object.m_parent >> (16));  //  4 Bits => Filled  4 Bits (Of 64)
     field2 |=
         (object.m_definition << (4));  // 20 Bits => Filled 24 Bits (Of 64)
-    field2 |= (((unsigned long)object.m_child)
+    field2 |= (((uint64_t)object.m_child)
                << (4 + 20));  // 20 Bits => Filled 44 Bits (Of 64)
     field2 |=
-        (((unsigned long)object.m_sibling)
+        (((uint64_t)object.m_sibling)
          << (4 + 20 + 20));  // 20 Bits => Filled 64 Bits (Of 64) , Word Full
     field3 |= object.m_fileId;
-    field3 |= (((unsigned long)object.m_line) << (32));
+    field3 |= (((uint64_t)object.m_line) << (32));
     PARSECACHE::VObject vostruct(field1, field2, field3);
     object_vec.push_back(vostruct);
   }

--- a/src/DesignCompile/CompileDesign.cpp
+++ b/src/DesignCompile/CompileDesign.cpp
@@ -20,6 +20,8 @@
  *
  * Created on July 1, 2017, 1:11 PM
  */
+#include <stdint.h>
+
 #include "SourceCompile/SymbolTable.h"
 #include "Library/Library.h"
 #include "Design/FileContent.h"
@@ -100,7 +102,7 @@ void CompileDesign::compileMT_(ObjectMapType& objects, int maxThreadCount) {
       unsigned int size = mod.second->getSize();
       if (size == 0) size = 100;
       unsigned int newJobIndex = 0;
-      unsigned long minJobQueue = ULLONG_MAX;
+      unsigned long long minJobQueue = ULLONG_MAX;
       for (unsigned short ii = 0; ii < maxThreadCount; ii++) {
         if (jobSize[ii] < minJobQueue) {
           newJobIndex = ii;

--- a/src/Expression/ExprBuilder.cpp
+++ b/src/Expression/ExprBuilder.cpp
@@ -20,11 +20,14 @@
  *
  * Created on November 2, 2017, 9:45 PM
  */
+#include <stdint.h>
+
+#include <iostream>
+#include <sstream>
+
 #include "ErrorReporting/ErrorContainer.h"
 #include "Expression/ExprBuilder.h"
 #include "SourceCompile/VObjectTypes.h"
-#include <iostream>
-#include <sstream>
 
 using namespace SURELOG;
 
@@ -276,7 +279,7 @@ Value* ExprBuilder::evalExpr(FileContent* fC, NodeId parent,
       case VObjectType::slIntConst: {
         std::string val = fC->SymName(child);
         if (strstr(val.c_str(), "'")) {
-          unsigned long hex_value = 0;
+          uint64_t hex_value = 0;
           char base = 'h';
           unsigned int i = 0;
           for (i = 0; i < val.size(); i++) {
@@ -304,7 +307,7 @@ Value* ExprBuilder::evalExpr(FileContent* fC, NodeId parent,
           }
           value->set(hex_value);
         } else {
-          value->set(atol(val.c_str()));
+          value->set((int64_t)atol(val.c_str()));
         }
         break;
       }
@@ -317,7 +320,7 @@ Value* ExprBuilder::evalExpr(FileContent* fC, NodeId parent,
         break;
       }
       case VObjectType::slNull_keyword: {
-        value->set((unsigned long)0);
+        value->set((uint64_t)0);
         break;
       }
       case VObjectType::slStringConst: {

--- a/src/Expression/Value.cpp
+++ b/src/Expression/Value.cpp
@@ -29,7 +29,7 @@
 using namespace SURELOG;
 
 unsigned int Value::nbWords_(unsigned int size) {
-  unsigned long nb = size / 64;
+  uint64_t nb = size / 64;
   if ((nb * 64) != size) nb++;
   return nb;
 }
@@ -131,19 +131,19 @@ void ValueFactory::deleteValue(Value* value) {
   }
 }
 
-void SValue::set(unsigned long val) {
+void SValue::set(uint64_t val) {
   m_value = val;
   m_size = 64;
 }
-void SValue::set(long val) {
+void SValue::set(int64_t val) {
   m_value = val;
   m_size = 64;
 }
 void SValue::set(double val) {
-  m_value = (unsigned long)val;
+  m_value = (uint64_t)val;
   m_size = 64;
 }
-void SValue::set(unsigned long val, ValueType type, unsigned short size) {
+void SValue::set(uint64_t val, ValueType type, unsigned short size) {
   m_value = val;
   m_size = size;
 }
@@ -321,7 +321,7 @@ LValue::LValue(LValue& val) {
   }
 }
 
-LValue::LValue(unsigned long val) {
+LValue::LValue(uint64_t val) {
   m_type = Unsigned;
   m_nbWords = 1;
   m_valueArray = new SValue[1];
@@ -331,11 +331,11 @@ LValue::LValue(unsigned long val) {
   m_next = NULL;
 }
 
-LValue::LValue(long val) {
+LValue::LValue(int64_t val) {
   m_type = Integer;
   m_nbWords = 1;
   m_valueArray = new SValue[1];
-  m_valueArray[0].m_value = (unsigned long)val;
+  m_valueArray[0].m_value = (uint64_t)val;
   m_valueArray[0].m_size = 64;
   m_prev = NULL;
   m_next = NULL;
@@ -345,13 +345,13 @@ LValue::LValue(double val) {
   m_type = Double;
   m_nbWords = 1;
   m_valueArray = new SValue[1];
-  m_valueArray[0].m_value = (unsigned long)val;
+  m_valueArray[0].m_value = (uint64_t)val;
   m_valueArray[0].m_size = 64;
   m_prev = NULL;
   m_next = NULL;
 }
 
-LValue::LValue(unsigned long val, ValueType type, unsigned short size) {
+LValue::LValue(uint64_t val, ValueType type, unsigned short size) {
   m_type = type;
   m_nbWords = 1;
   m_valueArray = new SValue[1];
@@ -361,7 +361,7 @@ LValue::LValue(unsigned long val, ValueType type, unsigned short size) {
   m_next = NULL;
 }
 
-void LValue::set(unsigned long val) {
+void LValue::set(uint64_t val) {
   m_type = Unsigned;
   m_nbWords = 1;
   if (!m_valueArray) m_valueArray = new SValue[1];
@@ -369,11 +369,11 @@ void LValue::set(unsigned long val) {
   m_valueArray[0].m_size = 64;
 }
 
-void LValue::set(long val) {
+void LValue::set(int64_t val) {
   m_type = Integer;
   m_nbWords = 1;
   if (!m_valueArray) m_valueArray = new SValue[1];
-  m_valueArray[0].m_value = (unsigned long)val;
+  m_valueArray[0].m_value = (uint64_t)val;
   m_valueArray[0].m_size = 64;
 }
 
@@ -381,11 +381,11 @@ void LValue::set(double val) {
   m_type = Double;
   m_nbWords = 1;
   if (!m_valueArray) m_valueArray = new SValue[1];
-  m_valueArray[0].m_value = (unsigned long)val;
+  m_valueArray[0].m_value = (uint64_t)val;
   m_valueArray[0].m_size = 64;
 }
 
-void LValue::set(unsigned long val, ValueType type, unsigned short size) {
+void LValue::set(uint64_t val, ValueType type, unsigned short size) {
   m_type = type;
   m_nbWords = 1;
   if (!m_valueArray) m_valueArray = new SValue[1];
@@ -510,8 +510,8 @@ void LValue::equiv(Value* a, Value* b) {
 void LValue::logAnd(Value* a, Value* b) {
   adjust(a);
   adjust(b);
-  unsigned long tmp1 = 0;
-  unsigned long tmp2 = 0;
+  uint64_t tmp1 = 0;
+  uint64_t tmp2 = 0;
   for (unsigned int i = 0; i < m_nbWords; i++) {
     tmp1 |= a->getValueUL(i);
     tmp2 |= b->getValueUL(i);
@@ -522,8 +522,8 @@ void LValue::logAnd(Value* a, Value* b) {
 void LValue::logOr(Value* a, Value* b) {
   adjust(a);
   adjust(b);
-  unsigned long tmp1 = 0;
-  unsigned long tmp2 = 0;
+  uint64_t tmp1 = 0;
+  uint64_t tmp2 = 0;
   for (unsigned int i = 0; i < m_nbWords; i++) {
     tmp1 |= a->getValueUL(i);
     tmp2 |= b->getValueUL(i);

--- a/src/Expression/Value.h
+++ b/src/Expression/Value.h
@@ -24,6 +24,7 @@
 #ifndef VALUE_H
 #define VALUE_H
 
+#include <stdint.h>
 #include <string>
 
 namespace SURELOG {
@@ -54,14 +55,14 @@ class Value {
   getNbWords() = 0;  // nb of 64 bits words necessary to encode the size
   virtual ValueType getType() = 0;
   virtual bool isLValue() = 0;  // is large value (more than one 64 bit word)
-  virtual unsigned long getValueUL(unsigned short index = 0) = 0;
-  virtual long getValueL(unsigned short index = 0) = 0;
+  virtual uint64_t getValueUL(unsigned short index = 0) = 0;
+  virtual int64_t getValueL(unsigned short index = 0) = 0;
   virtual double getValueD(unsigned short index = 0) = 0;
   virtual std::string getValueS() = 0;
-  virtual void set(unsigned long val) = 0;
-  virtual void set(long val) = 0;
+  virtual void set(uint64_t val) = 0;
+  virtual void set(int64_t val) = 0;
   virtual void set(double val) = 0;
-  virtual void set(unsigned long val, ValueType type, unsigned short size) = 0;
+  virtual void set(uint64_t val, ValueType type, unsigned short size) = 0;
   virtual void set(std::string val) = 0;
   virtual bool operator<(Value& rhs) = 0;
   bool operator>(Value& rhs) { return rhs < (*this); }
@@ -106,19 +107,19 @@ class SValue : public Value {
     m_value = 0;
     m_size = 0;
   }
-  SValue(unsigned long val) {
+  SValue(uint64_t val) {
     m_value = val;
     m_size = 64;
   }
-  SValue(long val) {
+  SValue(int64_t val) {
     m_value = val;
     m_size = 64;
   }
   SValue(double val) {
-    m_value = (unsigned long)val;
+    m_value = (uint64_t)val;
     m_size = 64;
   }
-  SValue(unsigned long val, unsigned short size) {
+  SValue(uint64_t val, unsigned short size) {
     m_value = val;
     m_size = size;
   }
@@ -126,10 +127,10 @@ class SValue : public Value {
   unsigned short getNbWords() { return 1; }
   bool isLValue() { return false; }
   ValueType getType() { return None; }
-  void set(unsigned long val);
-  void set(long val);
+  void set(uint64_t val);
+  void set(int64_t val);
   void set(double val);
-  void set(unsigned long val, ValueType type, unsigned short size);
+  void set(uint64_t val, ValueType type, unsigned short size);
   void set(std::string val) {
     m_value = 6969696969;
     m_size = 6969;
@@ -140,8 +141,8 @@ class SValue : public Value {
   bool operator==(Value& rhs) {
     return m_value == (dynamic_cast<SValue*>(&rhs))->m_value;
   }
-  unsigned long getValueUL(unsigned short index = 0) { return m_value; }
-  long getValueL(unsigned short index = 0) { return (long)m_value; }
+  uint64_t getValueUL(unsigned short index = 0) { return m_value; }
+  int64_t getValueL(unsigned short index = 0) { return (int64_t)m_value; }
   double getValueD(unsigned short index = 0) { return (double)m_value; }
   std::string getValueS() { return "NOT_A_STRING_VALUE"; }
   virtual ~SValue();
@@ -172,7 +173,7 @@ class SValue : public Value {
   void shiftRight(Value* a, Value* b);
 
  private:
-  unsigned long m_value;
+  uint64_t m_value;
   unsigned short m_size;
 };
 
@@ -206,29 +207,29 @@ class LValue : public Value {
     m_type = type, m_valueArray = values;
     m_nbWords = nbWords;
   }
-  LValue(unsigned long val);
-  LValue(long val);
+  LValue(uint64_t val);
+  LValue(int64_t val);
   LValue(double val);
-  LValue(unsigned long val, ValueType type, unsigned short size);
+  LValue(uint64_t val, ValueType type, unsigned short size);
   unsigned short getSize();
   unsigned short getNbWords() { return m_nbWords; }
   bool isLValue() { return true; }
   ValueType getType() { return (ValueType)m_type; }
   virtual ~LValue();
 
-  void set(unsigned long val);
-  void set(long val);
+  void set(uint64_t val);
+  void set(int64_t val);
   void set(double val);
-  void set(unsigned long val, ValueType type, unsigned short size);
+  void set(uint64_t val, ValueType type, unsigned short size);
   void set(std::string val) {}
   bool operator<(Value& rhs);
   bool operator==(Value& rhs);
 
-  unsigned long getValueUL(unsigned short index = 0) {
+  uint64_t getValueUL(unsigned short index = 0) {
     return ((index < m_nbWords) ? m_valueArray[index].m_value : 0);
   }
-  long getValueL(unsigned short index = 0) {
-    return ((index < m_nbWords) ? (long)m_valueArray[index].m_value : 0);
+  int64_t getValueL(unsigned short index = 0) {
+    return ((index < m_nbWords) ? (int64_t)m_valueArray[index].m_value : 0);
   }
   double getValueD(unsigned short index = 0) {
     return ((index < m_nbWords) ? (double)m_valueArray[index].m_value : 0);
@@ -285,10 +286,10 @@ class StValue : public Value {
   unsigned short getNbWords() { return 1; }
   bool isLValue() { return false; }
   ValueType getType() { return String; }
-  void set(unsigned long val) { m_value = std::to_string(val); }
-  void set(long val) { m_value = std::to_string(val); }
+  void set(uint64_t val) { m_value = std::to_string(val); }
+  void set(int64_t val) { m_value = std::to_string(val); }
   void set(double val) { m_value = std::to_string(val); }
-  void set(unsigned long val, ValueType type, unsigned short size) {
+  void set(uint64_t val, ValueType type, unsigned short size) {
     m_value = std::to_string(val);
   }
   void set(std::string val) {
@@ -301,11 +302,11 @@ class StValue : public Value {
   bool operator==(Value& rhs) {
     return m_value == (dynamic_cast<StValue*>(&rhs))->m_value;
   }
-  unsigned long getValueUL(unsigned short index = 0) {
+  uint64_t getValueUL(unsigned short index = 0) {
     return atol(m_value.c_str());
   }
-  long getValueL(unsigned short index = 0) {
-    return (long)atol(m_value.c_str());
+  int64_t getValueL(unsigned short index = 0) {
+    return (int64_t)atol(m_value.c_str());
   }
   double getValueD(unsigned short index = 0) {
     return (double)atof(m_value.c_str());

--- a/src/SourceCompile/Compiler.cpp
+++ b/src/SourceCompile/Compiler.cpp
@@ -20,6 +20,8 @@
  *
  * Created on March 4, 2017, 5:16 PM
  */
+#include <stdint.h>
+
 #include "CommandLine/CommandLineParser.h"
 #include "ErrorReporting/ErrorContainer.h"
 #include "SourceCompile/SymbolTable.h"
@@ -448,7 +450,7 @@ bool Compiler::compileFileSet_(CompileSourceFile::Action action,
     for (unsigned int i = 0; i < container.size(); i++) {
       unsigned int size = container[i]->getJobSize(action);
       unsigned int newJobIndex = 0;
-      unsigned long minJobQueue = ULLONG_MAX;
+      uint64_t minJobQueue = ULLONG_MAX;
       for (unsigned short ii = 0; ii < maxThreadCount; ii++) {
         if (jobSize[ii] < minJobQueue) {
           newJobIndex = ii;


### PR DESCRIPTION
Also: use a wchar string literal instead of casting a 8-bit char*
when setting Python program name. The latter is likely to only
work 'by accident'.

Signed-off-by: Henner Zeller <h.zeller@acm.org>