### PR TITLE
Create file list after preprocessing

### DIFF
--- a/src/SourceCompile/Compiler.h
+++ b/src/SourceCompile/Compiler.h
@@ -74,6 +74,7 @@ class Compiler {
   bool parseLibrariesDef_();
 
   bool ppinit_();
+  bool createFileList_();
   bool parseinit_();
   bool pythoninit_();
   bool compileFileSet_(CompileSourceFile::Action action, bool allowMultithread,


### PR DESCRIPTION
Signed-off-by: Alain <alainmarcel@yahoo.com>

Fixes #95 

Add -writepp command line option, don't use -parse option
The file will be either slpp_all/file.lst or sllpp_unit/file.lst depending if -fileunit option is used.
