### PR TITLE
Unify two almost identical addVObject() functions.

### DIFF
--- a/src/Design/TimeInfo.h
+++ b/src/Design/TimeInfo.h
@@ -24,6 +24,8 @@
 #ifndef TIMEINFO_H
 #define TIMEINFO_H
 
+#include "SourceCompile/SymbolTable.h"
+
 namespace SURELOG {
 
 class TimeInfo {

--- a/src/Library/SVLibShapeListener.cpp
+++ b/src/Library/SVLibShapeListener.cpp
@@ -41,26 +41,25 @@ using namespace SURELOG;
 SVLibShapeListener::SVLibShapeListener(ParseLibraryDef *parser,
                                        antlr4::CommonTokenStream *tokens,
                                        std::string relativePath)
-  : SV3_1aTreeShapeHelper(
-			  new ParseFile(parser->getFileId(), parser->getSymbolTable(),
+  : SV3_1aTreeShapeHelper(new ParseFile(parser->getFileId(),
+                                        parser->getSymbolTable(),
 					parser->getErrorContainer()),
 			  tokens, 0),
     m_parser(parser),
     m_tokens(tokens),
     m_currentConfig(NULL),
     m_relativePath(relativePath) {
-    m_fileContent = new FileContent(
-				    m_parser->getFileId(), NULL,
-				    m_parser->getSymbolTable(),
-				    m_parser->getErrorContainer(), NULL, 0);
+  m_fileContent = new FileContent(m_parser->getFileId(), NULL,
+                                  m_parser->getSymbolTable(),
+                                  m_parser->getErrorContainer(), NULL, 0);
   m_pf->setFileContent(m_fileContent);
   IncludeFileInfo info(1, m_pf->getFileId(0), 0, 1);
   m_includeFileInfo.push(info);
-    }
+}
 
 SVLibShapeListener::~SVLibShapeListener() {}
 
-SymbolId SVLibShapeListener::registerSymbol(std::string symbol) {
+SymbolId SVLibShapeListener::registerSymbol(const std::string &symbol) {
   return m_parser->getSymbolTable()->registerSymbol(symbol);
 }
 
@@ -172,7 +171,7 @@ void SVLibShapeListener::exitIdentifier(
     ident = ctx->RANDOMIZE()->getText();
   else if (ctx->SAMPLE())
     ident = ctx->SAMPLE()->getText();
-  
+
   // !!! Don't forget to change CompileModule.cpp type checker !!!
   addVObject(ctx, ident, VObjectType::slStringConst);
 

--- a/src/Library/SVLibShapeListener.h
+++ b/src/Library/SVLibShapeListener.h
@@ -29,12 +29,12 @@
 
 namespace SURELOG {
 
-  class SVLibShapeListener : public SV3_1aParserBaseListener, public SV3_1aTreeShapeHelper {
- public:
+class SVLibShapeListener : public SV3_1aParserBaseListener, public SV3_1aTreeShapeHelper {
+public:
   SVLibShapeListener(ParseLibraryDef* parser, antlr4::CommonTokenStream* tokens,
                      std::string relativePath);
 
-  SymbolId registerSymbol(std::string symbol) final;
+  SymbolId registerSymbol(const std::string &symbol) final;
 
   antlr4::CommonTokenStream* getTokenStream() { return m_tokens; }
   virtual ~SVLibShapeListener();
@@ -45,7 +45,7 @@ namespace SURELOG {
   // enterTop_level_library_rule(SV3_1aParser::Top_level_library_ruleContext *
   // /*ctx*/) override;
   void enterTop_level_library_rule(SV3_1aParser::Top_level_library_ruleContext * /*ctx*/) final {}
- 
+
   void exitTop_level_library_rule(
       SV3_1aParser::Top_level_library_ruleContext* ctx) final {
     addVObject(ctx, VObjectType::slTop_level_library_rule);
@@ -53,7 +53,7 @@ namespace SURELOG {
 
   void enterNull_rule(
       SV3_1aParser::Null_ruleContext* /*ctx*/) final {}
-  
+
   void exitNull_rule(SV3_1aParser::Null_ruleContext* ctx) final {
     addVObject(ctx, VObjectType::slNull_rule);
   }
@@ -132,22 +132,22 @@ namespace SURELOG {
    void exitInst_clause(SV3_1aParser::Inst_clauseContext * ctx) final { addVObject (ctx, VObjectType::slInst_clause); }
 
    void exitInst_name(SV3_1aParser::Inst_nameContext * ctx) final { addVObject (ctx, VObjectType::slInst_name); }
- 
+
    void exitCell_clause(SV3_1aParser::Cell_clauseContext * ctx) final { addVObject (ctx, VObjectType::slCell_clause); }
- 
+
    void exitLiblist_clause(SV3_1aParser::Liblist_clauseContext * ctx) final { addVObject (ctx, VObjectType::slLiblist_clause); }
- 
+
    void exitUse_clause_config(SV3_1aParser::Use_clause_configContext * ctx) final { addVObject (ctx, VObjectType::slUse_clause_config); }
- 
+
    void exitUse_clause(SV3_1aParser::Use_clauseContext * ctx) final { addVObject (ctx, VObjectType::slUse_clause); }
 
    void exitString_value(SV3_1aParser::String_valueContext *ctx) final;
- 
+
    void exitIdentifier(SV3_1aParser::IdentifierContext *ctx) final;
 
    void exitHierarchical_identifier(SV3_1aParser::Hierarchical_identifierContext *ctx) final;
-  
-  private:
+
+private:
   ParseLibraryDef* m_parser;
   antlr4::CommonTokenStream* m_tokens;
   Config* m_currentConfig;

--- a/src/SourceCompile/CommonListenerHelper.h
+++ b/src/SourceCompile/CommonListenerHelper.h
@@ -1,12 +1,12 @@
 /*
  Copyright 2019 Alain Dargelas
- 
+
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
- 
+
  http://www.apache.org/licenses/LICENSE-2.0
- 
+
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,7 +14,7 @@
  limitations under the License.
  */
 
-/* 
+/*
  * File:   CommonListenerHelper.h
  * Author: alain
  *
@@ -27,10 +27,11 @@
 #include <stack>
 #include <map>
 #include <unordered_map>
-#include "Utils/ParseUtils.h"
-#include "SourceCompile/SymbolTable.h"
+
 #include "Design/FileContent.h"
+#include "SourceCompile/SymbolTable.h"
 #include "SourceCompile/VObjectTypes.h"
+#include "Utils/ParseUtils.h"
 
 namespace SURELOG {
 
@@ -41,8 +42,8 @@ public:
   CommonListenerHelper() : m_fileContent(NULL), m_tokens(NULL){}
 
   virtual ~CommonListenerHelper();
-    
-  virtual SymbolId registerSymbol(std::string symbol) = 0;
+
+  virtual SymbolId registerSymbol(const std::string &symbol) = 0;
 
   int registerObject(VObject& object);
 
@@ -68,7 +69,7 @@ public:
 
   unsigned int& Line(NodeId index);
 
-  int addVObject(ParserRuleContext* ctx, std::string name, VObjectType objtype);
+  int addVObject(ParserRuleContext* ctx, const std::string &name, VObjectType objtype);
 
   int addVObject(ParserRuleContext* ctx, VObjectType objtype);
 
@@ -79,17 +80,18 @@ public:
   FileContent* getFileContent() { return m_fileContent; }
 
   virtual unsigned int getFileLine(ParserRuleContext* ctx, SymbolId& fileId) = 0;
-     
-protected:  
+
+private:
+  int addVObject(ParserRuleContext* ctx, SymbolId sym, VObjectType objtype);
+
+protected:
   FileContent* m_fileContent;
   typedef std::unordered_map<tree::ParseTree*, NodeId> ContextToObjectMap;
   ContextToObjectMap m_contextToObjectMap;
   antlr4::CommonTokenStream* m_tokens;
-
 };
 
 };
 
 
 #endif /* COMMONLISTENERHELPER_H */
-

--- a/src/SourceCompile/SV3_1aPpTreeListenerHelper.cpp
+++ b/src/SourceCompile/SV3_1aPpTreeListenerHelper.cpp
@@ -1,12 +1,12 @@
 /*
  Copyright 2019 Alain Dargelas
- 
+
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
- 
+
  http://www.apache.org/licenses/LICENSE-2.0
- 
+
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,10 +14,10 @@
  limitations under the License.
  */
 
-/* 
+/*
  * File:   SV3_1aPpTreeListenerHelper.cpp
  * Author: alain
- * 
+ *
  * Created on December 4, 2019, 8:17 PM
  */
 
@@ -52,7 +52,7 @@ SV3_1aPpTreeListenerHelper::~SV3_1aPpTreeListenerHelper()
 {
 }
 
-SymbolId SV3_1aPpTreeListenerHelper::registerSymbol(std::string symbol) {
+SymbolId SV3_1aPpTreeListenerHelper::registerSymbol(const std::string &symbol) {
   return m_pp->getCompileSourceFile()->getSymbolTable()->registerSymbol(symbol);
 }
 
@@ -286,4 +286,3 @@ bool SV3_1aPpTreeListenerHelper::isPreviousBranchActive() {
   }
   return previousBranchActive;
 }
-

--- a/src/SourceCompile/SV3_1aPpTreeListenerHelper.h
+++ b/src/SourceCompile/SV3_1aPpTreeListenerHelper.h
@@ -1,12 +1,12 @@
 /*
  Copyright 2019 Alain Dargelas
- 
+
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
- 
+
  http://www.apache.org/licenses/LICENSE-2.0
- 
+
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,7 +14,7 @@
  limitations under the License.
  */
 
-/* 
+/*
  * File:   SV3_1aPpTreeListenerHelper.h
  * Author: alain
  *
@@ -49,10 +49,10 @@ protected:
     std::vector<std::string> m_reservedMacroNames;
     std::set<std::string> m_reservedMacroNamesSet;
     ParserRuleContext* m_append_paused_context;
-    PreprocessFile::SpecialInstructions m_instructions;    
-    
+    PreprocessFile::SpecialInstructions m_instructions;
+
 public:
-    SV3_1aPpTreeListenerHelper(PreprocessFile* pp, PreprocessFile::SpecialInstructions& instructions) : 
+    SV3_1aPpTreeListenerHelper(PreprocessFile* pp, PreprocessFile::SpecialInstructions& instructions) :
     CommonListenerHelper(), m_pp(pp), m_inActiveBranch(true), m_inMacroDefinitionParsing(false),
     m_inProtectedRegion(false), m_filterProtectedRegions(false), m_append_paused_context(NULL), m_instructions(instructions)
     {
@@ -74,16 +74,15 @@ public:
     SymbolTable* getSymbolTable() {
       return m_pp->getCompileSourceFile()->getSymbolTable();
     }
-    
-    SymbolId registerSymbol(std::string symbol) final;
-    
+
+    SymbolId registerSymbol(const std::string &symbol) final;
+
     unsigned int getFileLine(ParserRuleContext* ctx, SymbolId& fileId);
-    
+
     virtual ~SV3_1aPpTreeListenerHelper();
-    
+
 };
 
 };
 
 #endif /* SV3_1APPTREELISTENERHELPER_H */
-

--- a/src/SourceCompile/SV3_1aTreeShapeHelper.cpp
+++ b/src/SourceCompile/SV3_1aTreeShapeHelper.cpp
@@ -108,7 +108,7 @@ NodeId SV3_1aTreeShapeHelper::generateNodeId() {
   return m_pf->getCompilationUnit()->generateUniqueNodeId();
 }
 
-SymbolId SV3_1aTreeShapeHelper::registerSymbol(std::string symbol) {
+SymbolId SV3_1aTreeShapeHelper::registerSymbol(const std::string &symbol) {
   return m_pf->getSymbolTable()->registerSymbol(symbol);
 }
 

--- a/src/SourceCompile/SV3_1aTreeShapeHelper.h
+++ b/src/SourceCompile/SV3_1aTreeShapeHelper.h
@@ -46,7 +46,7 @@ namespace SURELOG {
 
 class SV3_1aTreeShapeHelper : public CommonListenerHelper {
  public:
- 
+
   SV3_1aTreeShapeHelper(ParseFile* pf, antlr4::CommonTokenStream* tokens,
                         unsigned int lineOffset);
   SV3_1aTreeShapeHelper(ParseLibraryDef* pf, antlr4::CommonTokenStream* tokens);
@@ -66,7 +66,7 @@ class SV3_1aTreeShapeHelper : public CommonListenerHelper {
 
   NodeId generateNodeId();
 
-  virtual SymbolId registerSymbol(std::string symbol) override;
+  SymbolId registerSymbol(const std::string &symbol) override;
 
   void addNestedDesignElement(ParserRuleContext* ctx, std::string name,
                               DesignElement::ElemType elemtype,

--- a/src/SourceCompile/SymbolTable.h
+++ b/src/SourceCompile/SymbolTable.h
@@ -23,18 +23,21 @@
 
 #ifndef SYMBOLTABLE_H
 #define SYMBOLTABLE_H
-#include <string>
+
+#include <stdint.h>
+
 #include <map>
+#include <string>
 #include <unordered_map>
 #include <vector>
 
 namespace SURELOG {
 
-typedef unsigned long SymbolId;  // 64 bit
+typedef uint64_t SymbolId;
 
-typedef unsigned int NodeId;  // 32 bit
+typedef uint32_t NodeId;
 
-#define InvalidNodeId 969696
+static constexpr NodeId InvalidNodeId = 969696;
 
 class SymbolTable {
  public:


### PR DESCRIPTION
(in general just a small set of little cleanups here and there while looking through the code).

Also: make CommonListenerHelper::registerSymbol() accept
const std::string & and change implementations.

Use system independent definition of int64/int32 bit integers in
SymbolTable.

Organize headers in the associated files according to style-guide:
  - in compilation unit: associated header first.
  - General: sorted c-system-includes, sorted c++-system-includes
    then sorted project includes.

Signed-off-by: Henner Zeller <h.zeller@acm.org>