### PR TITLE
Always use 'override' specifier for methods that are overriden

### DIFF
--- a/src/Cache/PPCache.h
+++ b/src/Cache/PPCache.h
@@ -37,7 +37,7 @@ class PPCache : Cache {
   PPCache(const PPCache& orig);
   bool restore();
   bool save();
-  virtual ~PPCache();
+  ~PPCache() override;
 
  private:
   PreprocessFile* m_pp;

--- a/src/Cache/ParseCache.h
+++ b/src/Cache/ParseCache.h
@@ -38,7 +38,7 @@ class ParseCache : Cache {
   bool restore();
   bool save();
   bool isValid();
-  virtual ~ParseCache();
+  ~ParseCache() override;
 
  private:
   ParseFile* m_parse;

--- a/src/Cache/PythonAPICache.h
+++ b/src/Cache/PythonAPICache.h
@@ -38,7 +38,7 @@ class PythonAPICache : Cache {
   bool restore();
   bool save();
   bool isValid();
-  virtual ~PythonAPICache();
+  ~PythonAPICache() override;
 
  private:
   PythonListen* m_listener;

--- a/src/Design/DesignComponent.h
+++ b/src/Design/DesignComponent.h
@@ -40,7 +40,7 @@ class Variable;
 class DesignComponent : public ValuedComponentI {
  public:
   DesignComponent(DesignComponent* parent) : ValuedComponentI(parent) {}
-  virtual ~DesignComponent() {}
+  ~DesignComponent() override {}
 
   virtual unsigned int getSize() = 0;
   virtual VObjectType getType() = 0;

--- a/src/Design/Enum.h
+++ b/src/Design/Enum.h
@@ -42,7 +42,7 @@ class Enum : public DataType {
   VObjectType getBaseType() { return m_baseType; }
   typedef std::map<std::string, Value*> NameValueMap;
 
-  virtual ~Enum();
+  ~Enum() override;
 
  private:
   NameValueMap m_values;

--- a/src/Design/FileContent.h
+++ b/src/Design/FileContent.h
@@ -65,7 +65,7 @@ class FileContent : public DesignComponent {
         m_parentFile(parent),
         m_fileChunkId(fileChunkId) {}
   void setLibrary(Library* lib) { m_library = lib; }
-  virtual ~FileContent();
+  ~FileContent() override;
 
   typedef std::unordered_map<std::string, NodeId> NameIdMap;
 
@@ -107,10 +107,10 @@ class FileContent : public DesignComponent {
                                      bool first = false);
   // Recursively search for all items of types
   // and stops at types stopPoints
-  unsigned int getSize();
-  VObjectType getType() { return VObjectType::slNoType; }
-  bool isInstance() { return false; }
-  std::string getName() { return m_symbolTable->getSymbol(m_fileId); }
+  unsigned int getSize() override;
+  VObjectType getType() override { return VObjectType::slNoType; }
+  bool isInstance() override { return false; }
+  std::string getName() override { return m_symbolTable->getSymbol(m_fileId); }
   NodeId getRootNode();
   std::string printObjects();                    // The whole file content
   std::string printSubTree(NodeId parentIndex);  // Print subtree from parent

--- a/src/Design/Function.h
+++ b/src/Design/Function.h
@@ -48,7 +48,7 @@ class Procedure : public Scope, public Statement {
         m_nodeId(id),
         m_name(name) {}
 
-  ~Procedure() {}
+  ~Procedure() override {}
 
   DesignComponent* getParent() { return m_parent; }
 
@@ -83,7 +83,7 @@ class Function : public Procedure {
            std::string name, DataType* returnType)
       : Procedure(parent, fC, id, name), m_returnType(returnType) {}
   bool compile(CompileHelper& compile_helper);
-  virtual ~Function();
+  ~Function() override;
 
   DataType* getReturnType() { return m_returnType; }
 

--- a/src/Design/ModuleDefinition.h
+++ b/src/Design/ModuleDefinition.h
@@ -43,15 +43,15 @@ class ModuleDefinition : public DesignComponent, public ClockingBlockHolder,
  public:
   ModuleDefinition(FileContent* fileContent, NodeId nodeId, std::string& name);
 
-  virtual ~ModuleDefinition();
+  ~ModuleDefinition() override;
 
-  std::string getName() { return m_name; }
-  VObjectType getType() {
+  std::string getName() override { return m_name; }
+  VObjectType getType() override {
     return (m_fileContents.size()) ? m_fileContents[0]->Type(m_nodeIds[0])
                                    : VObjectType::slN_input_gate_instance;
   }
-  bool isInstance();
-  unsigned int getSize();
+  bool isInstance() override;
+  unsigned int getSize() override;
 
   typedef std::map<std::string, ClockingBlock> ClockingBlockMap;
   typedef std::map<std::string, ModPort> ModPortSignalMap;

--- a/src/Design/ModuleInstance.h
+++ b/src/Design/ModuleInstance.h
@@ -36,7 +36,7 @@ class ModuleInstance : public ValuedComponentI {
   ModuleInstance(DesignComponent* definition, FileContent* fileContent,
                  NodeId nodeId, ModuleInstance* parent, std::string instName,
                  std::string moduleName);
-  virtual ~ModuleInstance();
+  ~ModuleInstance() override;
   void addSubInstances(ModuleInstance** subInstances,
                        unsigned int nbSubInstances);
   DesignComponent* getDefinition() { return m_definition; }

--- a/src/Design/Parameter.h
+++ b/src/Design/Parameter.h
@@ -33,8 +33,8 @@ class Parameter : public DataType {
  public:
   Parameter(FileContent* fC, NodeId nodeId, std::string name, NodeId node_type);
 
-  VObjectType getType() { return getFileContent()->Type(m_ntype); }
-  virtual ~Parameter();
+  VObjectType getType() override { return getFileContent()->Type(m_ntype); }
+  ~Parameter() override;
 
  private:
   NodeId m_ntype;

--- a/src/Design/Statement.h
+++ b/src/Design/Statement.h
@@ -100,8 +100,8 @@ class SubRoutineCallStmt : public Statement {
   std::string getFunc() { return m_func; }
   bool isStatic() { return m_static; }
   bool isSystemCall() { return m_system; }
-  Function* getFunction() { return m_function; }
-  void setFunction(Function* function) { m_function = function; }
+  Function* getFunction() override { return m_function; }
+  void setFunction(Function* function) override { m_function = function; }
 
  private:
   std::vector<NodeId> m_var_chain;

--- a/src/Design/Task.h
+++ b/src/Design/Task.h
@@ -35,7 +35,7 @@ class Task : public Procedure {
   Task(DesignComponent* parent, FileContent* fC, NodeId id, std::string name)
       : Procedure(parent, fC, id, name) {}
   bool compile(CompileHelper& compile_helper);
-  virtual ~Task();
+  ~Task() override;
 
  private:
 };

--- a/src/Design/TfPortItem.h
+++ b/src/Design/TfPortItem.h
@@ -39,7 +39,7 @@ class TfPortItem : public Variable {
         m_parent(parent),
         m_default(default_value),
         m_direction(direction) {}
-  virtual ~TfPortItem();
+  ~TfPortItem() override;
 
   Procedure* getParent() { return m_parent; }
   Value* getDefault() { return m_default; }

--- a/src/DesignCompile/CompileProgram.h
+++ b/src/DesignCompile/CompileProgram.h
@@ -62,7 +62,7 @@ class CompileProgram : public CompileToolbox {
 
   bool compile();
 
-  virtual ~CompileProgram();
+  ~CompileProgram() override;
 
  private:
   CompileDesign* m_compileDesign;

--- a/src/DesignCompile/DesignElaboration.h
+++ b/src/DesignCompile/DesignElaboration.h
@@ -34,14 +34,14 @@ class DesignElaboration : public TestbenchElaboration {
  public:
   DesignElaboration(CompileDesign* compileDesign);
   DesignElaboration(const DesignElaboration& orig) = delete;
-  virtual ~DesignElaboration();
+  ~DesignElaboration() override;
 
   bool createModuleAndPackageDefinitions();
 
-  bool elaborate();
+  bool elaborate() override;
 
  private:
-  bool bindDataTypes_();
+  bool bindDataTypes_() override;
   bool createBuiltinPrimitives_();
   bool setupConfigurations_();
   bool identifyTopModules_();

--- a/src/DesignCompile/PackageAndRootElaboration.h
+++ b/src/DesignCompile/PackageAndRootElaboration.h
@@ -33,9 +33,9 @@ class PackageAndRootElaboration : public ElaborationStep {
   PackageAndRootElaboration(CompileDesign* compileDesign)
       : ElaborationStep(compileDesign) {}
 
-  virtual ~PackageAndRootElaboration();
+  ~PackageAndRootElaboration() override;
 
-  bool elaborate();
+  bool elaborate() override;
 
  private:
   bool bindTypedefs_();

--- a/src/DesignCompile/ResolveSymbols.h
+++ b/src/DesignCompile/ResolveSymbols.h
@@ -76,49 +76,49 @@ class ResolveSymbols : public CompileStep {
 
   bool resolve();
 
-  VObject& Object(NodeId index);
+  VObject& Object(NodeId index) override;
 
-  NodeId UniqueId(NodeId index);
+  NodeId UniqueId(NodeId index) override;
 
-  SymbolId Name(NodeId index);
+  SymbolId Name(NodeId index) override;
 
-  NodeId Child(NodeId index);
+  NodeId Child(NodeId index) override;
 
-  NodeId Sibling(NodeId index);
+  NodeId Sibling(NodeId index) override;
 
-  NodeId& Definition(NodeId index);
+  NodeId& Definition(NodeId index) override;
 
-  NodeId Parent(NodeId index);
+  NodeId Parent(NodeId index) override;
 
-  unsigned short& Type(NodeId index);
+  unsigned short& Type(NodeId index) override;
 
-  unsigned int Line(NodeId index);
+  unsigned int Line(NodeId index) override;
 
-  std::string Symbol(SymbolId id);
+  std::string Symbol(SymbolId id) override;
 
-  std::string SymName(NodeId index);
+  std::string SymName(NodeId index) override;
 
-  NodeId sl_get(NodeId parent, VObjectType type);  // Get first item of type
+  NodeId sl_get(NodeId parent, VObjectType type) override;  // Get first item of type
 
   NodeId sl_parent(NodeId parent,
-                   VObjectType type);  // Get first parent item of type
+                   VObjectType type) override;  // Get first parent item of type
 
   NodeId sl_parent(NodeId parent, std::vector<VObjectType> types,
-                   VObjectType& actualType);
+                   VObjectType& actualType) override;
 
   std::vector<NodeId> sl_get_all(NodeId parent,
-                                 VObjectType type);  // get all items of type
+                                 VObjectType type) override;  // get all items of type
 
   NodeId sl_collect(
       NodeId parent,
-      VObjectType type);  // Recursively search for first item of type
+      VObjectType type) override;  // Recursively search for first item of type
 
   std::vector<NodeId> sl_collect_all(
       NodeId parent,
-      VObjectType type);  // Recursively search for all items of type
+      VObjectType type) override;  // Recursively search for all items of type
 
   ResolveSymbols(const ResolveSymbols& orig);
-  virtual ~ResolveSymbols();
+  ~ResolveSymbols() override;
 
   Compiler* getCompiler() { return m_compileDesign->getCompiler(); }
 

--- a/src/DesignCompile/TestbenchElaboration.h
+++ b/src/DesignCompile/TestbenchElaboration.h
@@ -36,7 +36,7 @@ class TestbenchElaboration : public ElaborationStep {
 
   TestbenchElaboration(const TestbenchElaboration& orig);
 
-  virtual ~TestbenchElaboration();
+  ~TestbenchElaboration() override;
 
  protected:
   bool bindTypedefs_();

--- a/src/DesignCompile/UVMElaboration.h
+++ b/src/DesignCompile/UVMElaboration.h
@@ -32,9 +32,9 @@ class UVMElaboration : public TestbenchElaboration {
  public:
   UVMElaboration(CompileDesign* compileDesign);
   UVMElaboration(const UVMElaboration& orig) = delete;
-  virtual ~UVMElaboration();
+  ~UVMElaboration() override;
 
-  bool elaborate();
+  bool elaborate() override;
 
  private:
 };

--- a/src/Library/AntlrLibParserErrorListener.h
+++ b/src/Library/AntlrLibParserErrorListener.h
@@ -30,25 +30,25 @@ class AntlrLibParserErrorListener : public ANTLRErrorListener {
  public:
   AntlrLibParserErrorListener(ParseLibraryDef *parser) : m_parser(parser) {}
 
-  ~AntlrLibParserErrorListener(){};
+  ~AntlrLibParserErrorListener() override{};
 
   void syntaxError(Recognizer *recognizer, Token *offendingSymbol, size_t line,
                    size_t charPositionInLine, const std::string &msg,
-                   std::exception_ptr e);
+                   std::exception_ptr e) override;
 
   void reportAmbiguity(Parser *recognizer, const dfa::DFA &dfa,
                        size_t startIndex, size_t stopIndex, bool exact,
                        const antlrcpp::BitSet &ambigAlts,
-                       atn::ATNConfigSet *configs);
+                       atn::ATNConfigSet *configs) override;
 
   void reportAttemptingFullContext(Parser *recognizer, const dfa::DFA &dfa,
                                    size_t startIndex, size_t stopIndex,
                                    const antlrcpp::BitSet &conflictingAlts,
-                                   atn::ATNConfigSet *configs);
+                                   atn::ATNConfigSet *configs) override;
 
   void reportContextSensitivity(Parser *recognizer, const dfa::DFA &dfa,
                                 size_t startIndex, size_t stopIndex,
-                                size_t prediction, atn::ATNConfigSet *configs);
+                                size_t prediction, atn::ATNConfigSet *configs) override;
 
   ParseLibraryDef *m_parser;
 };

--- a/src/Library/SVLibShapeListener.h
+++ b/src/Library/SVLibShapeListener.h
@@ -37,7 +37,7 @@ namespace SURELOG {
   SymbolId registerSymbol(std::string symbol) final;
 
   antlr4::CommonTokenStream* getTokenStream() { return m_tokens; }
-  virtual ~SVLibShapeListener();
+  ~SVLibShapeListener() override;
 
   // *** LIBRARY DEFINITION PARSING ***
 

--- a/src/Package/Package.h
+++ b/src/Package/Package.h
@@ -43,14 +43,14 @@ class Package : public DesignComponent {
   }
   void append(Package* package);
 
-  virtual ~Package();
+  ~Package() override;
 
   Library* getLibrary() { return m_library; }
 
-  unsigned int getSize();
-  VObjectType getType() { return VObjectType::slPackage_declaration; }
-  bool isInstance() { return false; }
-  std::string getName() { return m_name; }
+  unsigned int getSize() override;
+  VObjectType getType() override { return VObjectType::slPackage_declaration; }
+  bool isInstance() override { return false; }
+  std::string getName() override { return m_name; }
 
   ClassNameClassDefinitionMultiMap& getClassDefinitions() {
     return m_classDefinitions;

--- a/src/SourceCompile/AntlrParserErrorListener.h
+++ b/src/SourceCompile/AntlrParserErrorListener.h
@@ -37,25 +37,25 @@ class AntlrParserErrorListener : public ANTLRErrorListener {
         m_lineOffset(lineOffset),
         m_fileName(fileName) {}
 
-  ~AntlrParserErrorListener(){};
+  ~AntlrParserErrorListener() override{};
 
   void syntaxError(Recognizer *recognizer, Token *offendingSymbol, size_t line,
                    size_t charPositionInLine, const std::string &msg,
-                   std::exception_ptr e);
+                   std::exception_ptr e) override;
 
   void reportAmbiguity(Parser *recognizer, const dfa::DFA &dfa,
                        size_t startIndex, size_t stopIndex, bool exact,
                        const antlrcpp::BitSet &ambigAlts,
-                       atn::ATNConfigSet *configs);
+                       atn::ATNConfigSet *configs) override;
 
   void reportAttemptingFullContext(Parser *recognizer, const dfa::DFA &dfa,
                                    size_t startIndex, size_t stopIndex,
                                    const antlrcpp::BitSet &conflictingAlts,
-                                   atn::ATNConfigSet *configs);
+                                   atn::ATNConfigSet *configs) override;
 
   void reportContextSensitivity(Parser *recognizer, const dfa::DFA &dfa,
                                 size_t startIndex, size_t stopIndex,
-                                size_t prediction, atn::ATNConfigSet *configs);
+                                size_t prediction, atn::ATNConfigSet *configs) override;
 
   ParseFile *m_parser;
   bool m_reportedSyntaxError;

--- a/src/SourceCompile/PreprocessFile.cpp
+++ b/src/SourceCompile/PreprocessFile.cpp
@@ -112,21 +112,21 @@ class PreprocessFile::DescriptiveErrorListener : public ANTLRErrorListener {
 
   void syntaxError(Recognizer* recognizer, Token* offendingSymbol, size_t line,
                    size_t charPositionInLine, const std::string& msg,
-                   std::exception_ptr e);
+                   std::exception_ptr e) override;
 
   void reportAmbiguity(Parser* recognizer, const dfa::DFA& dfa,
                        size_t startIndex, size_t stopIndex, bool exact,
                        const antlrcpp::BitSet& ambigAlts,
-                       atn::ATNConfigSet* configs);
+                       atn::ATNConfigSet* configs) override;
 
   void reportAttemptingFullContext(Parser* recognizer, const dfa::DFA& dfa,
                                    size_t startIndex, size_t stopIndex,
                                    const antlrcpp::BitSet& conflictingAlts,
-                                   atn::ATNConfigSet* configs);
+                                   atn::ATNConfigSet* configs) override;
 
   void reportContextSensitivity(Parser* recognizer, const dfa::DFA& dfa,
                                 size_t startIndex, size_t stopIndex,
-                                size_t prediction, atn::ATNConfigSet* configs);
+                                size_t prediction, atn::ATNConfigSet* configs) override;
 
   PreprocessFile* m_pp;
   std::string m_fileName;

--- a/src/SourceCompile/SV3_1aPpTreeListenerHelper.h
+++ b/src/SourceCompile/SV3_1aPpTreeListenerHelper.h
@@ -77,9 +77,9 @@ public:
     
     SymbolId registerSymbol(std::string symbol) final;
     
-    unsigned int getFileLine(ParserRuleContext* ctx, SymbolId& fileId);
+    unsigned int getFileLine(ParserRuleContext* ctx, SymbolId& fileId) override;
     
-    virtual ~SV3_1aPpTreeListenerHelper();
+    ~SV3_1aPpTreeListenerHelper() override;
     
 };
 

--- a/src/SourceCompile/SV3_1aTreeShapeHelper.h
+++ b/src/SourceCompile/SV3_1aTreeShapeHelper.h
@@ -51,7 +51,7 @@ class SV3_1aTreeShapeHelper : public CommonListenerHelper {
                         unsigned int lineOffset);
   SV3_1aTreeShapeHelper(ParseLibraryDef* pf, antlr4::CommonTokenStream* tokens);
 
-  virtual ~SV3_1aTreeShapeHelper();
+  ~SV3_1aTreeShapeHelper() override;
 
   void logError(ErrorDefinition::ErrorType error, ParserRuleContext* ctx,
                 std::string object, bool printColumn = false);
@@ -66,7 +66,7 @@ class SV3_1aTreeShapeHelper : public CommonListenerHelper {
 
   NodeId generateNodeId();
 
-  virtual SymbolId registerSymbol(std::string symbol) override;
+  SymbolId registerSymbol(std::string symbol) override;
 
   void addNestedDesignElement(ParserRuleContext* ctx, std::string name,
                               DesignElement::ElemType elemtype,
@@ -78,7 +78,7 @@ class SV3_1aTreeShapeHelper : public CommonListenerHelper {
   std::pair<double, TimeInfo::Unit> getTimeValue(
       SV3_1aParser::Time_literalContext* ctx);
 
-  unsigned int getFileLine(ParserRuleContext* ctx, SymbolId& fileId);
+  unsigned int getFileLine(ParserRuleContext* ctx, SymbolId& fileId) override;
 
  protected:
   ParseFile* m_pf;

--- a/src/Testbench/ClassDefinition.h
+++ b/src/Testbench/ClassDefinition.h
@@ -46,12 +46,12 @@ class ClassDefinition : public DesignComponent, public DataType {
                   DesignComponent* container, FileContent* fC, NodeId nodeId,
                   ClassDefinition* parent);
 
-  virtual ~ClassDefinition();
+  ~ClassDefinition() override;
 
-  unsigned int getSize();
-  VObjectType getType() { return VObjectType::slClass_declaration; }
-  bool isInstance() { return false; }
-  std::string getName() { return m_name; }
+  unsigned int getSize() override;
+  VObjectType getType() override { return VObjectType::slClass_declaration; }
+  bool isInstance() override { return false; }
+  std::string getName() override { return m_name; }
   Library* getLibrary() { return m_library; }
   DesignComponent* getContainer() { return m_container; }
   void setContainer(DesignComponent* container) { m_container = container; }
@@ -69,7 +69,7 @@ class ClassDefinition : public DesignComponent, public DataType {
   Property* getProperty(const std::string& name);
   void insertProperty(Property* p);
 
-  Function* getFunction(const std::string& name);
+  Function* getFunction(const std::string& name) override;
 
   TaskMap& getTaskMap() { return m_tasks; }
   TaskMethod* getTask(const std::string& name);

--- a/src/Testbench/FunctionMethod.h
+++ b/src/Testbench/FunctionMethod.h
@@ -41,7 +41,7 @@ class FunctionMethod : public Function {
         m_local(is_local),
         m_protected(is_protected),
         m_pure(is_pure) {}
-  virtual ~FunctionMethod();
+  ~FunctionMethod() override;
   bool isVirtual() { return m_virtual; }
   bool isExtern() { return m_extern; }
   bool isStatic() { return m_static; }

--- a/src/Testbench/Program.h
+++ b/src/Testbench/Program.h
@@ -41,12 +41,12 @@ class Program : public DesignComponent, public ClockingBlockHolder,
     addFileContent(fC, nodeId);
   }
 
-  virtual ~Program();
+  ~Program() override;
 
-  unsigned int getSize();
-  VObjectType getType() { return (m_fileContents[0]->Type(m_nodeIds[0])); }
-  bool isInstance() { return true; }
-  std::string getName() { return m_name; }
+  unsigned int getSize() override;
+  VObjectType getType() override { return (m_fileContents[0]->Type(m_nodeIds[0])); }
+  bool isInstance() override { return true; }
+  std::string getName() override { return m_name; }
 
   ClassNameClassDefinitionMultiMap& getClassDefinitions() {
     return m_classDefinitions;

--- a/src/Testbench/Property.h
+++ b/src/Testbench/Property.h
@@ -40,7 +40,7 @@ class Property : public Variable {
         m_is_protected(is_protected),
         m_is_rand(is_rand),
         m_is_randc(is_randc) {}
-  virtual ~Property();
+  ~Property() override;
 
   bool isLocal() { return m_is_local; }
   bool isStatic() { return m_is_static; }

--- a/src/Testbench/TaskMethod.h
+++ b/src/Testbench/TaskMethod.h
@@ -33,7 +33,7 @@ class TaskMethod : public Task {
   TaskMethod(DesignComponent* parent, FileContent* fC, NodeId id,
              std::string name, bool is_extern)
       : Task(parent, fC, id, name), m_extern(is_extern) {}
-  virtual ~TaskMethod();
+  ~TaskMethod() override;
   bool isExtern() { return m_extern; }
   bool compile(CompileHelper& compile_helper);
 

--- a/src/Testbench/TypeDef.h
+++ b/src/Testbench/TypeDef.h
@@ -37,7 +37,7 @@ class TypeDef : public DataType {
   TypeDef(FileContent* fC, NodeId id, NodeId the_def, std::string name);
 
   void setEnum(Enum* the_enum) { m_enum = the_enum; }
-  virtual ~TypeDef();
+  ~TypeDef() override;
   NodeId getDefinitionNode() { return m_the_def; }
   Enum* getEnum() { return m_enum; }
 


### PR DESCRIPTION
from base classes. This makes it easier to read and refactor code.

Signed-off-by: Henner Zeller <h.zeller@acm.org>