### PR TITLE
Don't redeclare ANSI ports in OneNet tests

### DIFF
--- a/tests/OneNet/OneNet.log
+++ b/tests/OneNet/OneNet.log
@@ -21,30 +21,16 @@
 [NOTE :EL0511] Nb leaf instances: 1.
 
 ====== UHDM =======
-design: work@top
-\_module: work@top, file:top.v, line:1, parent:work@top
-  \_port: i, line:1, parent:work@top
+design: work@DUT
+\_module: work@DUT, file:tests/OneNet/top.v, line:1, parent:work@DUT
+  \_port: i, line:1, parent:work@DUT
     |vpiDirection:1
-    \_ref_obj: 
-      \_logic_net: i, line:2, parent:work@top
-        |vpiNetType:1
-  \_port: o, line:1, parent:work@top
+  \_port: o, line:1, parent:work@DUT
     |vpiDirection:2
-    \_ref_obj: 
-      \_logic_net: o, line:3, parent:work@top
-        |vpiNetType:48
-  \_cont_assign: , line:4
+  \_cont_assign: , line:2
     \_ref_obj: i
-      \_logic_net: i, line:2, parent:work@top
-        |vpiNetType:1
     \_ref_obj: o
-      \_logic_net: o, line:3, parent:work@top
-        |vpiNetType:48
-  \_logic_net: i, line:2, parent:work@top
-    |vpiNetType:1
-  \_logic_net: o, line:3, parent:work@top
-    |vpiNetType:48
-\_package: builtin, parent:work@top
+\_package: builtin, parent:work@DUT
 \_class_defn: builtin::array, parent:builtin
 \_class_defn: builtin::queue, parent:builtin
 \_class_defn: builtin::string, parent:builtin

--- a/tests/OneNet/top.v
+++ b/tests/OneNet/top.v
@@ -1,5 +1,3 @@
-module DUT (input i, output o);
-  wire i;
-  wire o;
+module DUT (input wire i, output wire o);
   assign o = i;
 endmodule

--- a/tests/OneNetSim/OneNetSim.log
+++ b/tests/OneNetSim/OneNetSim.log
@@ -32,42 +32,28 @@
 
 ====== UHDM =======
 design: work@TOP
-\_module: work@DUT, file:top.v, line:11, parent:work@TOP
+\_module: work@DUT, file:tests/OneNetSim/top.v, line:11, parent:work@TOP
   \_port: i, line:11, parent:work@DUT
     |vpiDirection:1
-    \_ref_obj: 
-      \_logic_net: i, line:12, parent:work@DUT
-        |vpiNetType:1
   \_port: o, line:11, parent:work@DUT
     |vpiDirection:2
-    \_ref_obj: 
-      \_logic_net: o, line:13, parent:work@DUT
-        |vpiNetType:48
-  \_cont_assign: , line:14
+  \_cont_assign: , line:12
     \_ref_obj: i
-      \_logic_net: i, line:12, parent:work@DUT
-        |vpiNetType:1
     \_ref_obj: o
-      \_logic_net: o, line:13, parent:work@DUT
-        |vpiNetType:48
-  \_logic_net: i, line:12, parent:work@DUT
+\_module: work@TOP, file:tests/OneNetSim/top.v, line:15, parent:work@TOP
+  \_logic_net: i, line:16, parent:work@TOP
     |vpiNetType:1
-  \_logic_net: o, line:13, parent:work@DUT
-    |vpiNetType:48
-\_module: work@TOP, file:top.v, line:17, parent:work@TOP
-  \_logic_net: i, line:18, parent:work@TOP
+  \_logic_net: o, line:16, parent:work@TOP
     |vpiNetType:1
-  \_logic_net: o, line:18, parent:work@TOP
-    |vpiNetType:1
-\_program: work@TESTBENCH, file:top.v, line:1, parent:work@TOP
+\_program: work@TESTBENCH, file:tests/OneNetSim/top.v, line:1, parent:work@TOP
   \_port: observe, line:1, parent:work@TESTBENCH
     |vpiDirection:1
-    \_ref_obj: 
+    \_ref_obj:
       \_logic_net: observe, line:3, parent:work@TESTBENCH
         |vpiNetType:1
   \_port: drive, line:1, parent:work@TESTBENCH
     |vpiDirection:2
-    \_ref_obj: 
+    \_ref_obj:
       \_logic_net: drive, line:2, parent:work@TESTBENCH
         |vpiNetType:48
   \_logic_net: drive, line:2, parent:work@TESTBENCH

--- a/tests/OneNetSim/top.v
+++ b/tests/OneNetSim/top.v
@@ -8,9 +8,7 @@ program TESTBENCH(input observe, output drive);
   end
 endprogram
 
-module DUT (input i, output o);
-  wire i;
-  reg o;
+module DUT (input wire i, output reg o);
   assign o = i;
 endmodule
 


### PR DESCRIPTION
IEEE Std 1800-2017 23.2.2.2: The port identifier shall not be
redeclared, in part or in full, inside the module body.

Signed-off-by: Rafal Kapuscik <rkapuscik@antmicro.com>