### PR TITLE
Avoid typedef enum {...} SomeName and use enum SomeName {...} instead.

### DIFF
--- a/src/Config/Config.h
+++ b/src/Config/Config.h
@@ -32,7 +32,7 @@ namespace SURELOG {
 
 class UseClause {
  public:
-  typedef enum { UseLib, UseConfig, UseModule, UseParam } Type;
+  enum Type { UseLib, UseConfig, UseModule, UseParam };
   UseClause(Type type, std::string name, FileContent* fC, NodeId id)
       : m_type(type),
         m_name(name),

--- a/src/Design/DesignElement.h
+++ b/src/Design/DesignElement.h
@@ -28,7 +28,7 @@ namespace SURELOG {
 
 class DesignElement {
  public:
-  typedef enum {
+   enum ElemType {
     Module,
     Primitive,
     Interface,
@@ -42,7 +42,7 @@ class DesignElement {
                // package it is a element worth tracking
     Task,
     SLline  // Used to split files with correct file info
-  } ElemType;
+  };
 
   DesignElement(SymbolId name, SymbolId fileId, ElemType type,
                 SymbolId uniqueId, unsigned int line, SymbolId parent);

--- a/src/Design/TimeInfo.h
+++ b/src/Design/TimeInfo.h
@@ -39,15 +39,15 @@ class TimeInfo {
         m_timePrecision(Second),
         m_timePrecisionValue(0.0f) {}
   virtual ~TimeInfo();
-  typedef enum { None, Timescale, TimeUnitTimePrecision } Type;
-  typedef enum {
+  enum Type { None, Timescale, TimeUnitTimePrecision };
+  enum Unit {
     Second,
     Millisecond,
     Microsecond,
     Nanosecond,
     Picosecond,
     Femtosecond
-  } Unit;
+  };
 
   Type m_type;
   SymbolId m_fileId;

--- a/src/ErrorReporting/ErrorDefinition.h
+++ b/src/ErrorReporting/ErrorDefinition.h
@@ -30,9 +30,9 @@ namespace SURELOG {
 
 class ErrorDefinition {
  public:
-  typedef enum { FATAL, SYNTAX, ERROR, WARNING, INFO, NOTE } ErrorSeverity;
+  enum ErrorSeverity { FATAL, SYNTAX, ERROR, WARNING, INFO, NOTE };
 
-  typedef enum {
+  enum ErrorCategory {
     CMD,
     PP,
     PARSE,
@@ -44,9 +44,9 @@ class ErrorDefinition {
     LIB,
     LINT,
     USER,
-  } ErrorCategory;
+  };
 
-  typedef enum {
+  enum ErrorType {
     NO_ERROR_MESSAGE = 0,
     CMD_FILE_DOES_NOT_EXIST = 1,
     CMD_CANNOT_OPEN_FILE_FOR_READ = 2,
@@ -181,7 +181,7 @@ class ErrorDefinition {
     ELAB_UNDEFINED_PACKAGE = 528,
     ELAB_OUT_OF_RANGE_PARAM_INDEX = 530,
     LIB_FILE_MAPS_TO_MULTIPLE_LIBS = 600,
-  } ErrorType;
+  };
 
   class ErrorInfo {
    public:

--- a/src/Expression/Expr.h
+++ b/src/Expression/Expr.h
@@ -53,7 +53,7 @@ class Expr {
         m_rightExpr(NULL),
         m_type(Range) {}
   Expr(const Expr& orig);
-  typedef enum {
+  enum ExprType {
     None,
     Scalar,
     Range,
@@ -63,7 +63,7 @@ class Expr {
     Div,
     Modulo,
     Neg
-  } ExprType;
+  };
 
   Expr* makeExpr(Expr* leftExpr, Expr* rightExpr, ExprType type) {
     m_leftExpr = leftExpr;

--- a/src/SourceCompile/CompileSourceFile.h
+++ b/src/SourceCompile/CompileSourceFile.h
@@ -40,7 +40,7 @@ class PythonListen;
 class CompileSourceFile {
  public:
   friend PreprocessFile;
-  typedef enum { Preprocess, PostPreprocess, Parse, PythonAPI } Action;
+  enum Action { Preprocess, PostPreprocess, Parse, PythonAPI };
 
   CompileSourceFile(SymbolId fileId, CommandLineParser* clp,
                     ErrorContainer* errors, Compiler* compiler,

--- a/src/SourceCompile/PreprocessFile.h
+++ b/src/SourceCompile/PreprocessFile.h
@@ -44,14 +44,14 @@ class FileContent;
 
 #define LINE1 1
 
-typedef enum {
+enum VerilogVersion {
     NoVersion,
     Verilog1995,
     Verilog2001,
     Verilog2005,
     Verilog2009,
     SystemVerilog
-} VerilogVersion;
+};
 
 
 /* Can be either an include file or a macro definition being evaluated */

--- a/src/SourceCompile/VObjectTypes.h
+++ b/src/SourceCompile/VObjectTypes.h
@@ -4,7 +4,7 @@
 
 #ifndef VOBJECTTYPES_H
 #define VOBJECTTYPES_H
-typedef enum {
+enum VObjectType {
       sl0 = 0,
       sl1 = 1,
       slAccelerate_directive = 2,
@@ -980,7 +980,7 @@ typedef enum {
       slX = 972,
       slXor_call = 973,
       slZ = 974,
-} VObjectType;
+};
 
 #endif /* VOBJECTTYPES_H */
 

--- a/src/SourceCompile/generate_parser_listener.tcl
+++ b/src/SourceCompile/generate_parser_listener.tcl
@@ -233,13 +233,13 @@ puts $oid ""
 puts $oid "#ifndef VOBJECTTYPES_H"
 puts $oid "#define VOBJECTTYPES_H"
 
-puts $oid "typedef enum {"
+puts $oid "enum VObjectType {"
 set id 0
 foreach type [lsort -dictionary [array names TYPES]] {
     puts $oid "      $type = $id,"
     incr id
 }
-puts $oid "} VObjectType;"
+puts $oid "};"
 puts $oid ""
 puts $oid "#endif /* VOBJECTTYPES_H */"
 puts $oid ""

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -101,11 +101,11 @@ unsigned int executeCompilation(int argc, const char ** argv, bool diff_comp_mod
   else 
     return codedReturn;  
 }
-typedef enum {
+enum COMP_MODE {
     NORMAL,
     DIFF,
-    BATCH        
-} COMP_MODE;
+    BATCH,
+};
 
 int batchCompilation(const char* argv0, std::string batchFile)
 {


### PR DESCRIPTION
This is easier to read. The 'typedef'-style of doing things was needed
in good ol' C-times to avoid mentioning every use of the type with
the prefixed 'enum', which is not needed in C++.

Signed-off-by: Henner Zeller <h.zeller@acm.org>