### PR TITLE
Bump required CMake version to 3.5.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # -*- mode:cmake -*-
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5.1)
 
 set(FLATBUFFERS_BUILD_TESTS OFF CACHE BOOL "Skip flatbuffers' tests")
 add_subdirectory(third_party/flatbuffers EXCLUDE_FROM_ALL)


### PR DESCRIPTION
Version used in Travis is 3.12.4, but it uses xenial for build. Default version in xenial repos is 3.5.1.