### PR TITLE
Make dependency on capnp and libkj self-contained.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,8 +259,10 @@ set(ALL_LIBRARIES_FOR_SURELOG
     libflatbuffers.a
     -L${CMAKE_BINARY_DIR}/third_party/UHDM
     libuhdm.a
-    capnp
-    kj
+    -L${CMAKE_BINARY_DIR}/third_party/UHDM/third_party/capnproto/c++/src/capnp
+    libcapnp.a
+    -L${CMAKE_BINARY_DIR}/third_party/UHDM/third_party/capnproto/c++/src/kj
+    libkj.a
     dl
     util
     m

--- a/tests/TestInstall/CMakeLists.txt
+++ b/tests/TestInstall/CMakeLists.txt
@@ -49,11 +49,17 @@ if(NOT NO_TCMALLOC)
   set (TCMALLOC_LIBRARY tcmalloc)
 endif(NOT NO_TCMALLOC)
 
-set (INSTALL_LIBRARIES_FOR_SURELOG -L${LIB_DIR} surelog antlr4-runtime flatbuffers uhdm capnp kj
+set (INSTALL_LIBRARIES_FOR_SURELOG
+  -L${LIB_DIR} surelog
+  antlr4-runtime
+  flatbuffers
+  uhdm
+  -L${LIB_DIR}/../uhdm
+  capnp kj
   ${PYTHON_LIBRARIES} dl util m rt pthread ${TCMALLOC_LIBRARY}
 )
 
 add_executable(test_hellosureworld ${PROJECT_SOURCE_DIR}/../../src/hellosureworld.cpp)
 target_link_libraries(
-  test_hellosureworld ${INSTALL_LIBRARIES_FOR_SURELOG} 
+  test_hellosureworld ${INSTALL_LIBRARIES_FOR_SURELOG}
 )


### PR DESCRIPTION
Always make sure to link the Capnproto version that was
compiled with UHDM to avoid compatibility issues by
accidentally linking it to a version that might be on the
host system.

While at it: update to latest UHDM that has tighter
control on installing these libraries.

Signed-off-by: Henner Zeller <h.zeller@acm.org>