### PR TITLE
Issue #354 - CMake install fails

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -386,8 +386,8 @@ install(
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/surelog/ErrorReporting)
 install(
   FILES ${PROJECT_SOURCE_DIR}/dist/libantlr4-runtime.a
-        ${PROJECT_SOURCE_DIR}/build/third_party/flatbuffers/libflatbuffers.a
-        ${PROJECT_SOURCE_DIR}/build/third_party/UHDM/libuhdm.a
+        ${CMAKE_BINARY_DIR}/third_party/flatbuffers/libflatbuffers.a
+        ${CMAKE_BINARY_DIR}/third_party/UHDM/libuhdm.a
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/surelog)
 install(
   FILES ${PROJECT_SOURCE_DIR}/src/API/PythonAPI.h


### PR DESCRIPTION
CMake install fails with error when release isn't built before debug.

Problem
CMakeLists file had hardcoded paths to libflatbuffers.a

Resolution
Updated the paths to use CMake environment variables so the files
get picked up regardless of the change in output folder.