### PR TITLE
Continue regression test even if uhdm-dump fails.

### DIFF
--- a/tests/regression.tcl
+++ b/tests/regression.tcl
@@ -399,9 +399,15 @@ proc run_regression { } {
 		}
 		catch {set time_result [exec sh -c "$SURELOG_COMMAND $command > $REGRESSION_PATH/tests/$test/${testname}.log"]} time_result
 		if [file exist $REGRESSION_PATH/tests/$test/slpp_all/surelog.uhdm] {
-		    exec sh -c "$UHDM_DUMP_COMMAND $REGRESSION_PATH/tests/$test/slpp_all/surelog.uhdm > $REGRESSION_PATH/tests/$test/uhdm.dump"
+		    if [catch {exec sh -c "$UHDM_DUMP_COMMAND $REGRESSION_PATH/tests/$test/slpp_all/surelog.uhdm > $REGRESSION_PATH/tests/$test/uhdm.dump"}] {
+			set passstatus "FAILDUMP"
+			set overrallpass "FAIL"
+		    }
 		} elseif [file exist $REGRESSION_PATH/tests/$test/slpp_unit/surelog.uhdm] {
-		    exec sh -c "$UHDM_DUMP_COMMAND $REGRESSION_PATH/tests/$test/slpp_unit/surelog.uhdm > $REGRESSION_PATH/tests/$test/uhdm.dump"
+		    if [catch {exec sh -c "$UHDM_DUMP_COMMAND $REGRESSION_PATH/tests/$test/slpp_unit/surelog.uhdm > $REGRESSION_PATH/tests/$test/uhdm.dump"}] {
+			set passstatus "FAILDUMP"
+			set overrallpass "FAIL"
+		    }
 		}
 	    }
 	}


### PR DESCRIPTION
I've seen udhm-dump fail for me on a couple of tests, but the single-threaded
regression run then stops immediately when the first crash happens.

Catch the failure so that we can continue safely.

(Don't know yet what is wrong with the dump in the first place, that
will be another patch :) ).

Signed-off-by: Henner Zeller <h.zeller@acm.org>