### PR TITLE
Issue #376: Fix to incorporate changes to UHDM cmake file.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # -*- mode:cmake -*-
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Detect build type, fallback to release and throw a warning if use didn't
 # specify any
@@ -30,7 +30,7 @@ add_subdirectory(third_party/antlr4/runtime/Cpp EXCLUDE_FROM_ALL)
 add_subdirectory(third_party/UHDM)
 add_subdirectory(third_party/googletest EXCLUDE_FROM_ALL)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,5 @@
 # -*- mode:cmake -*-
-cmake_minimum_required(VERSION 3.5.1)
-
-set(FLATBUFFERS_BUILD_TESTS OFF CACHE BOOL "Skip flatbuffers' tests")
-add_subdirectory(third_party/flatbuffers EXCLUDE_FROM_ALL)
-add_subdirectory(third_party/antlr4/runtime/Cpp EXCLUDE_FROM_ALL)
-add_subdirectory(third_party/UHDM)
-add_subdirectory(third_party/googletest EXCLUDE_FROM_ALL)
-
-find_package(SWIG REQUIRED)
+cmake_minimum_required(VERSION 3.15)
 
 # Detect build type, fallback to release and throw a warning if use didn't
 # specify any
@@ -28,7 +20,26 @@ option(
 
 project(SURELOG)
 
-set(CMAKE_CXX_STANDARD 11)
+# NOTE: Policy changes has to happen before adding any subprojects
+cmake_policy(SET CMP0091 NEW)
+set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+
+set(FLATBUFFERS_BUILD_TESTS OFF CACHE BOOL "Skip flatbuffers' tests")
+add_subdirectory(third_party/flatbuffers EXCLUDE_FROM_ALL)
+add_subdirectory(third_party/antlr4/runtime/Cpp EXCLUDE_FROM_ALL)
+add_subdirectory(third_party/UHDM)
+add_subdirectory(third_party/googletest EXCLUDE_FROM_ALL)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+# NOTE: Set the global output directories after the subprojects have had their go at it
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin)
+
+find_package(SWIG REQUIRED)
 
 # Python
 find_package(PythonLibs 3.3 REQUIRED)
@@ -38,26 +49,16 @@ message(STATUS "PYTHON_EXECUTABLE = ${PYTHON_EXECUTABLE}")
 message(STATUS "PYTHON_INCLUDE_DIRS = ${PYTHON_INCLUDE_DIRS}")
 
 # Includes
-include_directories(
-  "${PROJECT_SOURCE_DIR}/third_party/antlr4/runtime/Cpp/runtime/src/")
+include_directories("${PROJECT_SOURCE_DIR}/third_party/antlr4/runtime/Cpp/runtime/src/")
 include_directories("${PROJECT_SOURCE_DIR}/third_party/flatbuffers/include/")
-
 include_directories("${PROJECT_SOURCE_DIR}/third_party/UHDM/include/")
 include_directories("${PROJECT_SOURCE_DIR}/third_party/UHDM/")
 include_directories("${PROJECT_SOURCE_DIR}/third_party/UHDM/headers/")
 include_directories("${PROJECT_SOURCE_DIR}/third_party/UHDM/src/")
-include_directories(
-  "${PROJECT_SOURCE_DIR}/third_party/UHDM/third_party/capnproto/c++/src/")
-include_directories(
-  "${PROJECT_SOURCE_DIR}/third_party/UHDM/third_party/UHDM/src/")
+include_directories("${PROJECT_SOURCE_DIR}/third_party/UHDM/third_party/capnproto/c++/src/")
+include_directories("${PROJECT_SOURCE_DIR}/third_party/UHDM/third_party/UHDM/src/")
 include_directories("${PROJECT_SOURCE_DIR}/third_party/googletest/googletest/include/")
 include_directories("${PROJECT_SOURCE_DIR}/third_party/googletest/googlemock/include/")
-
-# Directories
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY
-    ${CMAKE_BINARY_DIR}/dist/${CMAKE_BUILD_TYPE}/)
-set(CMAKE_BUILD_FILES_DIRECTORY ${dir})
-set(CMAKE_BUILD_DIRECTORY ${dir})
 
 # Use tcmalloc if installed and not NO_TCMALLOC is on. TODO: don't use negative
 # names, but positive. -DWITH_TCMALLOC=Off is easier to understand than
@@ -77,12 +78,23 @@ endif()
 
 set(CMAKE_CXX_FLAGS
     "${CMAKE_CXX_FLAGS} ${TCMALLOC_COMPILE_OPTIONS} ${MY_CXX_WARNING_FLAGS}")
-set(CMAKE_CXX_FLAGS_DEBUG
-    "${CMAKE_CXX_FLAGS_DEBUG} ${TCMALLOC_COMPILE_OPTIONS} -Wall -O0 -g ${MY_CXX_WARNING_FLAGS}"
-)
-set(CMAKE_CXX_FLAGS_RELEASE
-    "${CMAKE_CXX_FLAGS_RELEASE} ${TCMALLOC_COMPILE_OPTIONS} -Wall -O3 -DNDEBUG ${MY_CXX_WARNING_FLAGS}"
-)
+
+if(MSVC)
+    set(CMAKE_CXX_FLAGS_DEBUG
+        "${CMAKE_CXX_FLAGS_DEBUG} ${TCMALLOC_COMPILE_OPTIONS} /W0 /bigobj /DPLI_DLLISPEC= /DANTLR4CPP_STATIC /D_CRT_NONSTDC_NO_WARNINGS ${MY_CXX_WARNING_FLAGS}"
+    )
+    set(CMAKE_CXX_FLAGS_RELEASE
+        "${CMAKE_CXX_FLAGS_RELEASE} ${TCMALLOC_COMPILE_OPTIONS}/W0 /bigobj /DPLI_DLLISPEC= /DANTLR4CPP_STATIC /D_CRT_NONSTDC_NO_WARNINGS ${MY_CXX_WARNING_FLAGS}"
+    )
+    set(CMAKE_EXE_LINKER_FLAGS /STACK:8388608)  # 8MB stack size
+else()
+    set(CMAKE_CXX_FLAGS_DEBUG
+        "${CMAKE_CXX_FLAGS_DEBUG} ${TCMALLOC_COMPILE_OPTIONS} -Wall -O0 -g ${MY_CXX_WARNING_FLAGS}"
+    )
+    set(CMAKE_CXX_FLAGS_RELEASE
+        "${CMAKE_CXX_FLAGS_RELEASE} ${TCMALLOC_COMPILE_OPTIONS} -Wall -O3 -DNDEBUG ${MY_CXX_WARNING_FLAGS}"
+    )
+endif()
 
 # Flatbuffer
 set(flatbuffer-GENERATED_SRC
@@ -103,7 +115,7 @@ add_custom_command(
     ${PROJECT_SOURCE_DIR}/src/Cache/parser.fbs
     ${PROJECT_SOURCE_DIR}/src/Cache/preproc.fbs
     ${PROJECT_SOURCE_DIR}/src/Cache/python_api.fbs
-  WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
+  WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
   DEPENDS ${PROJECT_SOURCE_DIR}/src/Cache/parser.fbs
           ${PROJECT_SOURCE_DIR}/src/Cache/header.fbs
           ${PROJECT_SOURCE_DIR}/src/Cache/preproc.fbs
@@ -142,11 +154,11 @@ add_custom_command(
   OUTPUT ${PROJECT_SOURCE_DIR}/src/SourceCompile/dummy2
   WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/src/"
   COMMAND echo "       Serializer, Parser Listener, code generation..."
-  COMMAND SourceCompile/generate_parser_listener.tcl ;
-  COMMAND API/generate_python_listener_api.tcl ;
+  COMMAND tclsh SourceCompile/generate_parser_listener.tcl ;
+  COMMAND tclsh API/generate_python_listener_api.tcl ;
   COMMAND echo "       Python API Generation..."
   COMMAND ${SWIG_EXECUTABLE} -c++ -python -o API/slapi_wrap.cxx API/slapi_scripts.i ;
-  COMMAND API/embed_python_api.tcl
+  COMMAND tclsh API/embed_python_api.tcl
   COMMAND touch ${PROJECT_SOURCE_DIR}/src/SourceCompile/dummy2
   COMMAND echo "       Code Generation completed"
   DEPENDS ${PROJECT_SOURCE_DIR}/grammar/SV3_1aPpLexer.g4
@@ -241,100 +253,74 @@ set_target_properties(surelog-bin PROPERTIES OUTPUT_NAME surelog)
 add_executable(hellosureworld ${PROJECT_SOURCE_DIR}/src/hellosureworld.cpp)
 add_executable(hellouhdm ${PROJECT_SOURCE_DIR}/src/hellouhdm.cpp)
 
-add_dependencies(surelog-bin surelog)
+target_link_libraries(surelog-bin PUBLIC surelog)
+target_link_libraries(surelog PUBLIC antlr4_static)
+target_link_libraries(surelog PUBLIC flatbuffers)
+target_link_libraries(surelog PUBLIC uhdm)
 add_dependencies(surelog flatc)
-add_dependencies(surelog antlr4_static)
-add_dependencies(surelog flatbuffers)
 add_dependencies(GenerateSerializer uhdm)
 add_dependencies(GenerateParser antlr4_static)
 add_dependencies(surelog GenerateParser)
 add_dependencies(surelog GenerateSerializer)
 
-set(ALL_LIBRARIES_FOR_SURELOG
-    surelog
-    ${PYTHON_LIBRARIES}
-    -L${PROJECT_SOURCE_DIR}/dist/
-    libantlr4-runtime.a
-    -L${CMAKE_BINARY_DIR}/third_party/flatbuffers
-    libflatbuffers.a
-    -L${CMAKE_BINARY_DIR}/third_party/UHDM
-    libuhdm.a
-    -L${CMAKE_BINARY_DIR}/third_party/UHDM/third_party/capnproto/c++/src/capnp
-    libcapnp.a
-    -L${CMAKE_BINARY_DIR}/third_party/UHDM/third_party/capnproto/c++/src/kj
-    libkj.a
-    dl
-    util
-    m
-    rt
-    pthread
-    ${TCMALLOC_LIBRARY})
+target_link_libraries(surelog PRIVATE ${PYTHON_LIBRARIES})
+target_link_libraries(surelog PRIVATE ${TCMALLOC_LIBRARY})
 
-# Linkage instructions
-target_link_libraries(surelog-bin ${ALL_LIBRARIES_FOR_SURELOG})
+if (UNIX)
+  target_link_libraries(surelog PRIVATE dl)
+  target_link_libraries(surelog PRIVATE util)
+  target_link_libraries(surelog PRIVATE m)
+  target_link_libraries(surelog PRIVATE rt)
+  target_link_libraries(surelog PRIVATE pthread)
+endif()
 
 # Unit tests
 enable_testing()
 
 add_executable(CompileHelper-Test EXCLUDE_FROM_ALL
-  ${surelog_SRC}
   ${PROJECT_SOURCE_DIR}/src/DesignCompile/CompileHelper_test.cpp
-  )
+)
 target_link_libraries(CompileHelper-Test
-  ${ALL_LIBRARIES_FOR_SURELOG}
-  gtest
-  gmock
-  gtest_main)
-#add_test(NAME test_CompileHelper COMMAND CompileHelper-Test WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/dist/${CMAKE_BUILD_TYPE} )
+  PRIVATE surelog
+  PRIVATE gtest
+  PRIVATE gmock
+  PRIVATE gtest_main)
+#add_test(NAME test_CompileHelper COMMAND CompileHelper-Test WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} )
 
 add_custom_target(UnitTests
   DEPENDS CompileHelper-Test
   # Add further test binaries above
-  )
+)
 
-add_dependencies(hellosureworld surelog)
-add_dependencies(hellosureworld flatc)
-add_dependencies(hellosureworld antlr4_static)
-add_dependencies(hellosureworld flatbuffers)
-add_dependencies(hellosureworld GenerateParser)
-add_dependencies(hellosureworld GenerateSerializer)
-add_dependencies(hellouhdm surelog)
-add_dependencies(hellouhdm flatc)
-add_dependencies(hellouhdm antlr4_static)
-add_dependencies(hellouhdm flatbuffers)
-add_dependencies(hellouhdm GenerateParser)
-add_dependencies(hellouhdm GenerateSerializer)
-target_link_libraries(hellosureworld ${ALL_LIBRARIES_FOR_SURELOG})
-target_link_libraries(hellouhdm ${ALL_LIBRARIES_FOR_SURELOG})
+target_link_libraries(hellosureworld surelog)
+target_link_libraries(hellouhdm surelog)
 
 # Creation of the distribution directory, Precompiled package creation
 add_custom_command(
   TARGET surelog-bin
   POST_BUILD
   COMMAND echo "       Creating staging for precompiled packages"
-  COMMAND mkdir -p ${CMAKE_BINARY_DIR}/dist/${CMAKE_BUILD_TYPE}/sv
-  COMMAND mkdir -p ${CMAKE_BINARY_DIR}/dist/${CMAKE_BUILD_TYPE}/python
-  COMMAND ln -fs ${CMAKE_BINARY_DIR}/../third_party/UVM/ovm-2.1.2 ovm-2.1.2
-  COMMAND ln -fs ${CMAKE_BINARY_DIR}/../third_party/UVM/1800.2-2017-1.0
-          1800.2-2017-1.0
-  COMMAND ln -fs ${CMAKE_BINARY_DIR}/../third_party/UVM/vmm-1.1.1a vmm-1.1.1a
+  COMMAND mkdir -p ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/sv
+  COMMAND mkdir -p ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/python
+  COMMAND ln -fs ${PROJECT_SOURCE_DIR}/third_party/UVM/ovm-2.1.2 ovm-2.1.2
+  COMMAND ln -fs ${PROJECT_SOURCE_DIR}/third_party/UVM/1800.2-2017-1.0 1800.2-2017-1.0
+  COMMAND ln -fs ${PROJECT_SOURCE_DIR}/third_party/UVM/vmm-1.1.1a vmm-1.1.1a
   COMMAND rm -rf slpp_all slpp_unit
-  COMMAND cp -f ${CMAKE_BINARY_DIR}/../src/API/builtin.sv
-          ${CMAKE_BINARY_DIR}/dist/${CMAKE_BUILD_TYPE}/sv
-  COMMAND cp -f ${CMAKE_BINARY_DIR}/../src/API/slSV3_1aPythonListener.py
-          ${CMAKE_BINARY_DIR}/dist/${CMAKE_BUILD_TYPE}/python/
-  COMMAND cp -f ${CMAKE_BINARY_DIR}/../src/API/slformatmsg.py
-          ${CMAKE_BINARY_DIR}/dist/${CMAKE_BUILD_TYPE}/python/slformatmsg.py
-  COMMAND cp -f ${CMAKE_BINARY_DIR}/../src/API/slwaivers.py
-          ${CMAKE_BINARY_DIR}/dist/${CMAKE_BUILD_TYPE}/python/
+  COMMAND cp -f ${PROJECT_SOURCE_DIR}/src/API/builtin.sv ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/sv/builtin.sv
+  COMMAND cp -f ${PROJECT_SOURCE_DIR}/src/API/slSV3_1aPythonListener.py
+          ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/python/slSV3_1aPythonListener.py
+  COMMAND cp -f ${PROJECT_SOURCE_DIR}/src/API/slformatmsg.py
+          ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/python/slformatmsg.py
+  COMMAND cp -f ${PROJECT_SOURCE_DIR}/src/API/slwaivers.py
+          ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/python/slwaivers.py
   COMMAND echo "       Staging created"
-  WORKING_DIRECTORY "${CMAKE_BINARY_DIR}")
+  WORKING_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
 
-add_custom_target(PrecompileOVM DEPENDS ${CMAKE_BINARY_DIR}/dist/${CMAKE_BUILD_TYPE}/pkg/work/ovm_pkg.sv.slpa)
+add_custom_target(PrecompileOVM DEPENDS ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/pkg/work/ovm_pkg.sv.slpa)
 add_custom_command(
   #TARGET surelog-bin
   #POST_BUILD
-  OUTPUT  ${CMAKE_BINARY_DIR}/dist/${CMAKE_BUILD_TYPE}/pkg/work/ovm_pkg.sv.slpa
+  OUTPUT  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/pkg/work/ovm_pkg.sv.slpa
   COMMAND echo "       Creating OVM precompiled package..."
   DEPENDS surelog-bin
   COMMAND
@@ -342,13 +328,13 @@ add_custom_command(
     +incdir+ovm-2.1.2/src/ +incdir+vmm-1.1.1a/sv ovm-2.1.2/src/ovm_pkg.sv
     -writepp -mt 0 -parse -nocomp -noelab -nostdout  
   COMMAND echo "       Package OVM created"
-  WORKING_DIRECTORY "${CMAKE_BINARY_DIR}")
+  WORKING_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
 
-add_custom_target(PrecompileUVM DEPENDS ${CMAKE_BINARY_DIR}/dist/${CMAKE_BUILD_TYPE}/pkg/work/uvm_pkg.sv.slpa)
+add_custom_target(PrecompileUVM DEPENDS ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/pkg/work/uvm_pkg.sv.slpa)
 add_custom_command(
   #TARGET surelog-bin
   #POST_BUILD
-  OUTPUT  ${CMAKE_BINARY_DIR}/dist/${CMAKE_BUILD_TYPE}/pkg/work/uvm_pkg.sv.slpa
+  OUTPUT  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/pkg/work/uvm_pkg.sv.slpa
   COMMAND echo "       Creating UVM precompiled package..."
   DEPENDS surelog-bin
   COMMAND
@@ -356,7 +342,7 @@ add_custom_command(
     +incdir+.+1800.2-2017-1.0/src/ 1800.2-2017-1.0/src/uvm_pkg.sv -writepp -mt 0
     -parse -nocomp -noelab -nostdout
   COMMAND echo "       Package UVM created"
-  WORKING_DIRECTORY "${CMAKE_BINARY_DIR}")
+  WORKING_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
 add_dependencies(hellosureworld PrecompileOVM)
 add_dependencies(hellosureworld PrecompileUVM)
 
@@ -367,9 +353,9 @@ install(
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/surelog
   PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/surelog)
 install(
-  DIRECTORY ${CMAKE_BINARY_DIR}/dist/${CMAKE_BUILD_TYPE}/python
-            ${CMAKE_BINARY_DIR}/dist/${CMAKE_BUILD_TYPE}/sv
-            ${CMAKE_BINARY_DIR}/dist/${CMAKE_BUILD_TYPE}/pkg
+  DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/python
+            ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/sv
+            ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/pkg
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/surelog)
 install(FILES ${PROJECT_SOURCE_DIR}/src/CommandLine/CommandLineParser.h
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/surelog/CommandLine)
@@ -387,7 +373,6 @@ install(
 install(
   FILES ${PROJECT_SOURCE_DIR}/dist/libantlr4-runtime.a
         ${CMAKE_BINARY_DIR}/third_party/flatbuffers/libflatbuffers.a
-        ${CMAKE_BINARY_DIR}/third_party/UHDM/libuhdm.a
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/surelog)
 install(
   FILES ${PROJECT_SOURCE_DIR}/src/API/PythonAPI.h
@@ -451,3 +436,4 @@ install(
         ${PROJECT_SOURCE_DIR}/src/Expression/Expr.h
         ${PROJECT_SOURCE_DIR}/src/Expression/Value.h
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/surelog/Expression)
+

--- a/tests/regression.tcl
+++ b/tests/regression.tcl
@@ -146,7 +146,7 @@ set COMMIT_TEXT ""
 if [regexp {commit=([A-Za-z0-9_ \.]+)} $argv tmp COMMIT_TEXT] {
 }
 
-set EXE_PATH "[pwd]/dist/$BUILD"
+set EXE_PATH "[pwd]/bin"
 
 if [regexp {path=([A-Za-z0-9_/\.-]+)} $argv tmp EXE_PATH] {
 }


### PR DESCRIPTION
Issue #376
Fix to incorporate changes to UHDM cmake file.

Highlights -
* Generate output files in location where the dev tools expect
  instead of moving them to custom location. Rationale being that
  dev tools work better when the files aren't moved around.
  Visual Studio fails to find the generated test binaries if
  they aren't in the expected location. Plus, on windows, CMake
  works in multi-configuration mode and so having a single "dist"
  folder doesn't work well.
* Upgrade minimum CMake version required to 3.15
  This is required for the policy CMP0091 which was introduced in
  this version.
* Also, upgraded minimum C++ version to 17 to support filesystem
  module. This change will help cross-platform support.

IMPORTANT: This change is blocked by -
https://github.com/alainmarcel/UHDM/pull/236