### PR TITLE
Add missing or fix old file headers in a couple of files.

### DIFF
--- a/src/API/SV3_1aPythonListener.cpp
+++ b/src/API/SV3_1aPythonListener.cpp
@@ -1,14 +1,23 @@
 /*
- * Copyright 2017 ACE Cloud LLC
- * This file is the sole propriety of ACE Cloud LLC
- * Use/modify only with explicit written authorization of ACE Cloud LLC 
- *  Alain Dargelas, President  * 
+ Copyright 2019 Alain Dargelas
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
  */
 
-/* 
+/*
  * File:   SV3_1aPythonListener.cpp
  * Author: alain
- * 
+ *
  * Created on April 16, 2017, 8:28 PM
  */
 #include "SourceCompile/SymbolTable.h"
@@ -36,7 +45,7 @@ using namespace antlr4;
 #include "Utils/FileUtils.h"
 #include "API/PythonAPI.h"
 
-SV3_1aPythonListener::SV3_1aPythonListener (PythonListen* pl, PyThreadState* interpState, antlr4::CommonTokenStream* tokens, unsigned int lineOffset) : 
+SV3_1aPythonListener::SV3_1aPythonListener (PythonListen* pl, PyThreadState* interpState, antlr4::CommonTokenStream* tokens, unsigned int lineOffset) :
 m_pl(pl), m_interpState(interpState), m_tokens(tokens), m_lineOffset(lineOffset) { }
 
 SV3_1aPythonListener::SV3_1aPythonListener (const SV3_1aPythonListener& orig) { }
@@ -70,4 +79,3 @@ SV3_1aPythonListener::logError (ErrorDefinition::ErrorType error, Location& loc,
   Error err (error, loc, &extras);
   m_pl->getCompileSourceFile ()->getErrorContainer ()->addError (err, showDuplicates);
 }
-

--- a/src/API/Surelog.cpp
+++ b/src/API/Surelog.cpp
@@ -1,3 +1,19 @@
+/*
+ Copyright 2019 Alain Dargelas
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
 #include "CommandLine/CommandLineParser.h"
 #include "SourceCompile/SymbolTable.h"
 #include "SourceCompile/CompilationUnit.h"
@@ -16,7 +32,7 @@ SURELOG::scompiler* SURELOG::start_compiler (SURELOG::CommandLineParser* clp) {
   bool status = the_compiler->compile();
   if (!status)
     return nullptr;
-  return (SURELOG::scompiler*) the_compiler;          
+  return (SURELOG::scompiler*) the_compiler;
 }
 
 SURELOG::Design* SURELOG::get_design(SURELOG::scompiler* the_compiler) {
@@ -37,4 +53,3 @@ vpiHandle SURELOG::get_uhdm_design(SURELOG::scompiler* compiler) {
   }
   return design_handle;
 }
-

--- a/src/Common/PortNetHolder.cpp
+++ b/src/Common/PortNetHolder.cpp
@@ -1,13 +1,23 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ Copyright 2019 Alain Dargelas
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
  */
 
-/* 
+/*
  * File:   PortNetHolder.cpp
  * Author: alain
- * 
+ *
  * Created on January 30, 2020, 8:31 PM
  */
 #include "SourceCompile/SymbolTable.h"
@@ -17,4 +27,3 @@ using namespace SURELOG;
 PortNetHolder::~PortNetHolder()
 {
 }
-

--- a/src/Common/PortNetHolder.h
+++ b/src/Common/PortNetHolder.h
@@ -1,7 +1,17 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ Copyright 2019 Alain Dargelas
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
  */
 
 /*
@@ -21,7 +31,7 @@ namespace SURELOG {
 
 class PortNetHolder {
 public:
-    PortNetHolder() : m_contAssigns(NULL), m_processes(NULL), 
+    PortNetHolder() : m_contAssigns(NULL), m_processes(NULL),
                       m_parameters(NULL), m_param_assigns(NULL), m_task_funcs(NULL) {}
     virtual ~PortNetHolder();
 
@@ -44,7 +54,7 @@ public:
     {
         m_contAssigns = cont_assigns;
     }
-    
+
     std::vector<UHDM::process_stmt*>* getProcesses()
     {
         return m_processes;
@@ -97,4 +107,3 @@ protected:
 };
 
 #endif /* PORTNETHOLDER_H */
-

--- a/src/Design/ModPort.cpp
+++ b/src/Design/ModPort.cpp
@@ -1,13 +1,23 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ Copyright 2019 Alain Dargelas
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
  */
 
-/* 
+/*
  * File:   ModPort.cpp
  * Author: alain
- * 
+ *
  * Created on January 31, 2020, 9:46 PM
  */
 #include "SourceCompile/SymbolTable.h"
@@ -27,4 +37,4 @@ Signal* ModPort::getPort(std::string& name) {
     }
   }
   return NULL;
-}  
+}

--- a/src/Design/ModPort.h
+++ b/src/Design/ModPort.h
@@ -1,10 +1,20 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ Copyright 2019 Alain Dargelas
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
  */
 
-/* 
+/*
  * File:   ModPort.h
  * Author: alain
  *
@@ -25,17 +35,16 @@ class ModPort {
 public:
   ModPort(ModuleDefinition* parent, const std::string& name) : m_parent(parent), m_name(name) {}
   virtual ~ModPort();
-  const std::string& getName() { return m_name; } 
-  void addSignal(Signal& sig) { m_ports.push_back(sig); }  
+  const std::string& getName() { return m_name; }
+  void addSignal(Signal& sig) { m_ports.push_back(sig); }
   std::vector<Signal>& getPorts() { return m_ports; }
-  Signal* getPort(std::string& name);  
-  ModuleDefinition* getParent () { return m_parent; }  
+  Signal* getPort(std::string& name);
+  ModuleDefinition* getParent () { return m_parent; }
 private:
   ModuleDefinition* m_parent;
-  std::string m_name;  
+  std::string m_name;
   std::vector<Signal> m_ports;
 };
 };
 
 #endif /* MODPORT_H */
-

--- a/src/DesignCompile/CompileHelper_test.cpp
+++ b/src/DesignCompile/CompileHelper_test.cpp
@@ -1,3 +1,19 @@
+/*
+ Copyright 2019 Alain Dargelas
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
 #include "SourceCompile/SymbolTable.h"
 #include "Library/Library.h"
 #include "Design/FileContent.h"
@@ -373,4 +389,3 @@ TEST(TestCompileTfCall, FirstTest) {
     ASSERT_EQ(parsed, expected);
   }
 }
-


### PR DESCRIPTION
Also, while at it, remove trailing whitespaces in files that have been touched. This makes patches less likely to generate conflicts.