### PR TITLE
Issue #431: Installing Pyenv that's already installed fails with error

### DIFF
--- a/.github/kokoro/steps/hostsetup.sh
+++ b/.github/kokoro/steps/hostsetup.sh
@@ -76,7 +76,7 @@ sudo update-alternatives --set c++ /usr/bin/g++
 pyenv versions
 
 # Globally set the version we wish to use
-pyenv install 3.7.2
+# pyenv install 3.7.2
 pyenv global 3.7.2
 
 if [ -z "${BUILD_TOOL}" ]; then


### PR DESCRIPTION
Issue #431
Installing Pyenv that's already installed fails with error. Why does it have to fail if something is already installed?