### PR TITLE
Issue: CMake builds create symlink within a symlink

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -392,9 +392,9 @@ else()
     TARGET surelog-bin
     POST_BUILD
     COMMAND echo "       Creating platform depdendent staging for precompiled packages"
-    COMMAND ln -fs ${PROJECT_SOURCE_DIR}/third_party/UVM/ovm-2.1.2 ovm-2.1.2
-    COMMAND ln -fs ${PROJECT_SOURCE_DIR}/third_party/UVM/1800.2-2017-1.0 1800.2-2017-1.0
-    COMMAND ln -fs ${PROJECT_SOURCE_DIR}/third_party/UVM/vmm-1.1.1a vmm-1.1.1a
+    COMMAND ln -fs ${PROJECT_SOURCE_DIR}/third_party/UVM/ovm-2.1.2
+    COMMAND ln -fs ${PROJECT_SOURCE_DIR}/third_party/UVM/1800.2-2017-1.0
+    COMMAND ln -fs ${PROJECT_SOURCE_DIR}/third_party/UVM/vmm-1.1.1a
     COMMAND echo "       Platform depdendent staging completed"
     WORKING_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
 endif()


### PR DESCRIPTION
Issue
CMake builds create symlink within a symlink

Cause
As per the unix docs for 'ln' command -
When the last argument to ln is a directory, the links
are made in that directory.

Resolution
Don't add the directory at the end of the command.