### PR TITLE
Issue #410: Implementation of FileUtils::collectFiles isn't thread safe

### DIFF
--- a/src/Utils/FileUtils.cpp
+++ b/src/Utils/FileUtils.cpp
@@ -206,7 +206,7 @@ std::vector<SymbolId> FileUtils::collectFiles(const std::string& pathSpec,
       R"([a-zA-Z0-9_\-.]+)" + escaped + R"([a-zA-Z0-9_\-.]+)" + escaped);  // separator NOT allowed
   regexp = StringUtils::replaceAll(regexp, ".", "\\.");  // escape it
   regexp = StringUtils::replaceAll(regexp, "?", R"([a-zA-Z0-9_\-\.])"); // at most one
-  regexp = StringUtils::replaceAll(regexp, "*", ".*"); // free for all
+  regexp = StringUtils::replaceAll(regexp, "*", "[^" + escaped + "]*"); // free for all
 
   const std::regex regex(regexp);
   const fs::directory_options options =

--- a/src/Utils/FileUtils.h
+++ b/src/Utils/FileUtils.h
@@ -51,14 +51,8 @@ class FileUtils {
   static std::vector<SymbolId> collectFiles(SymbolId dirPath,
                                             SymbolId extension,
                                             SymbolTable* symbols);
-  static std::vector<SymbolId> collectFilesRegexp(const std::string dirPath,
-                                                  const std::string regexp,
-                                                  SymbolTable* symbols);
-  static void collectFiles(const std::string dirPath,
-                           std::vector<std::string>& dirs, unsigned int level,
-                           SymbolTable* symbols, std::vector<SymbolId>& files);
-  static std::vector<SymbolId> collectFiles(std::string pathSpec,
-                                            SymbolTable* symbols);
+  static std::vector<SymbolId> collectFiles(const std::string &pathSpec,
+                                            SymbolTable *const symbols);
   static std::string getFileContent(const std::string name);
   static std::string getPreferredPath(const std::string &path);
   static std::string makeRelativePath(std::string path);


### PR DESCRIPTION
Issue #410
Implementation of FileUtils::collectFiles isn't thread safe.

Cause
The use of 'chdir' makes the implementation non-thread-safe.

Resolution
Reimplemented the function to work with filesystem and strings
only i.e. without any OS calls (except calls to scan for files)