### PR TITLE
Start using std::string_view in StringUtils.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,7 +274,10 @@ file(GLOB surelog_SRC
   ${PROJECT_SOURCE_DIR}/src/CommandLine/*.cpp
   ${PROJECT_SOURCE_DIR}/src/Common/*.cpp
   ${PROJECT_SOURCE_DIR}/src/ErrorReporting/*.cpp
-  ${PROJECT_SOURCE_DIR}/src/Utils/*.cpp
+  ${PROJECT_SOURCE_DIR}/src/Utils/FileUtils.cpp
+  ${PROJECT_SOURCE_DIR}/src/Utils/ParseUtils.cpp
+  ${PROJECT_SOURCE_DIR}/src/Utils/StringUtils.cpp
+  ${PROJECT_SOURCE_DIR}/src/Utils/Timer.cpp
   ${PROJECT_SOURCE_DIR}/src/Cache/*.cpp
   ${PROJECT_SOURCE_DIR}/src/Config/*.cpp
   ${PROJECT_SOURCE_DIR}/src/Expression/*.cpp
@@ -526,7 +529,7 @@ install(
         ${PROJECT_SOURCE_DIR}/src/Expression/Expr.h
         ${PROJECT_SOURCE_DIR}/src/Expression/Value.h
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/surelog/Expression)
-  
+
 if (WIN32)
   install(
     FILES $<TARGET_PDB_FILE:surelog-bin>

--- a/src/Utils/StringUtils.cpp
+++ b/src/Utils/StringUtils.cpp
@@ -39,8 +39,8 @@ std::string StringUtils::to_string(double a_value, const int n) {
   return out.str();
 }
 
-void StringUtils::tokenizeMulti(const std::string_view str,
-				const std::string_view separator,
+void StringUtils::tokenizeMulti(std::string_view str,
+                                std::string_view separator,
                                 std::vector<std::string>& args) {
   std::string tmp;
   const unsigned int sepSize = separator.size();
@@ -69,8 +69,8 @@ void StringUtils::tokenizeMulti(const std::string_view str,
   }
 }
 
-void StringUtils::tokenize(const std::string_view str,
-			   const std::string_view separator,
+void StringUtils::tokenize(std::string_view str,
+                           std::string_view separator,
                            std::vector<std::string>& args) {
   std::string tmp;
   const unsigned int sepSize = separator.size();
@@ -97,8 +97,8 @@ void StringUtils::tokenize(const std::string_view str,
   }
 }
 
-void StringUtils::tokenizeBalanced(const std::string_view str,
-				   const std::string_view separator,
+void StringUtils::tokenizeBalanced(std::string_view str,
+                                   std::string_view separator,
                                    std::vector<std::string>& args) {
   std::string tmp;
   const unsigned int sepSize = separator.size();
@@ -168,7 +168,7 @@ static std::string removeCR(std::string_view st) {
 
 void StringUtils::replaceInTokenVector(std::vector<std::string>& tokens,
                                        std::vector<std::string> pattern,
-                                       const std::string_view news) {
+                                       std::string_view news) {
   unsigned int patternIndex = 0;
   std::vector<std::string>::iterator itr;
   bool more = true;
@@ -191,8 +191,8 @@ void StringUtils::replaceInTokenVector(std::vector<std::string>& tokens,
 }
 
 void StringUtils::replaceInTokenVector(std::vector<std::string>& tokens,
-                                       const std::string_view pattern,
-				       const std::string_view news) {
+                                       std::string_view pattern,
+                                       std::string_view news) {
   unsigned int tokensSize = tokens.size();
   for (unsigned int i = 0; i < tokensSize; i++) {
     std::string actual(news.begin(), news.end());
@@ -286,8 +286,8 @@ std::string StringUtils::replaceAll(std::string str, const std::string& from,
 
 // TODO: have this return std::string_view to avoid copying the string,
 // but first we need a unit test.
-std::string StringUtils::getLineInString(const std::string_view bulk,
-					 unsigned int line) {
+std::string StringUtils::getLineInString(std::string_view bulk,
+                                         unsigned int line) {
   std::string lineText;
   const unsigned int size = bulk.size();
   unsigned int count = 1;
@@ -302,7 +302,7 @@ std::string StringUtils::getLineInString(const std::string_view bulk,
   return lineText;
 }
 
-std::string StringUtils::removeComments(const std::string_view text) {
+std::string StringUtils::removeComments(std::string_view text) {
   std::string result;
   char c1 = '\0';
   bool inComment = 0;
@@ -360,7 +360,7 @@ void StringUtils::autoExpandEnvironmentVariables(std::string & text)
 }
 
 // Leave input alone and return new string.
-std::string StringUtils::evaluateEnvVars(const std::string_view text) {
+std::string StringUtils::evaluateEnvVars(std::string_view text) {
   std::string input(text.begin(), text.end());
   autoExpandEnvironmentVariables( input );
   return input;

--- a/src/Utils/StringUtils.cpp
+++ b/src/Utils/StringUtils.cpp
@@ -32,12 +32,6 @@ using namespace SURELOG;
 
 std::map<std::string, std::string> StringUtils::envVars;
 
-StringUtils::StringUtils() {}
-
-StringUtils::StringUtils(const StringUtils& orig) {}
-
-StringUtils::~StringUtils() {}
-
 std::string StringUtils::to_string(double a_value, const int n) {
   std::ostringstream out;
   out.precision(n);
@@ -45,11 +39,12 @@ std::string StringUtils::to_string(double a_value, const int n) {
   return out.str();
 }
 
-void StringUtils::tokenizeMulti(std::string str, std::string separator,
+void StringUtils::tokenizeMulti(const std::string_view str,
+				const std::string_view separator,
                                 std::vector<std::string>& args) {
   std::string tmp;
-  unsigned int sepSize = separator.size();
-  unsigned int stringSize = str.size();
+  const unsigned int sepSize = separator.size();
+  const unsigned int stringSize = str.size();
   for (unsigned int i = 0; i < stringSize; i++) {
     bool isSeparator = true;
     for (unsigned int j = 0; j < sepSize; j++) {
@@ -74,11 +69,12 @@ void StringUtils::tokenizeMulti(std::string str, std::string separator,
   }
 }
 
-void StringUtils::tokenize(std::string str, std::string separator,
+void StringUtils::tokenize(const std::string_view str,
+			   const std::string_view separator,
                            std::vector<std::string>& args) {
   std::string tmp;
-  unsigned int sepSize = separator.size();
-  unsigned int stringSize = str.size();
+  const unsigned int sepSize = separator.size();
+  const unsigned int stringSize = str.size();
   for (unsigned int i = 0; i < stringSize; i++) {
     bool isSeparator = false;
     for (unsigned int j = 0; j < sepSize; j++) {
@@ -101,11 +97,12 @@ void StringUtils::tokenize(std::string str, std::string separator,
   }
 }
 
-void StringUtils::tokenizeBalanced(std::string str, std::string separator,
+void StringUtils::tokenizeBalanced(const std::string_view str,
+				   const std::string_view separator,
                                    std::vector<std::string>& args) {
   std::string tmp;
-  unsigned int sepSize = separator.size();
-  unsigned int stringSize = str.size();
+  const unsigned int sepSize = separator.size();
+  const unsigned int stringSize = str.size();
   int level = 0;
   bool inDoubleQuote = false;
   for (unsigned int i = 0; i < stringSize; i++) {
@@ -145,7 +142,7 @@ void StringUtils::tokenizeBalanced(std::string str, std::string separator,
   }
 }
 
-std::string removeCR(std::string st) {
+static std::string removeCR(std::string_view st) {
   std::string result;
   if (st.find('\n') != std::string::npos) {
     std::string temp;
@@ -171,7 +168,7 @@ std::string removeCR(std::string st) {
 
 void StringUtils::replaceInTokenVector(std::vector<std::string>& tokens,
                                        std::vector<std::string> pattern,
-                                       std::string news) {
+                                       const std::string_view news) {
   unsigned int patternIndex = 0;
   std::vector<std::string>::iterator itr;
   bool more = true;
@@ -194,10 +191,11 @@ void StringUtils::replaceInTokenVector(std::vector<std::string>& tokens,
 }
 
 void StringUtils::replaceInTokenVector(std::vector<std::string>& tokens,
-                                       std::string pattern, std::string news) {
+                                       const std::string_view pattern,
+				       const std::string_view news) {
   unsigned int tokensSize = tokens.size();
   for (unsigned int i = 0; i < tokensSize; i++) {
-    std::string actual = news;
+    std::string actual(news.begin(), news.end());
     if (tokens[i] == pattern) {
       if (i > 0 && (tokens[i-1] == "\"")) {
         if ((i < tokensSize-1) && (tokens[i+1] == "\""))
@@ -270,7 +268,7 @@ std::string StringUtils::leaf(std::string str) {
   char c = '.';
   auto it1 = std::find_if(str.rbegin(), str.rend(),
                           [c](char ch) { return (ch == c); });
-  if (it1 != str.rend()) 
+  if (it1 != str.rend())
     str.erase(str.begin(), it1.base());
   return str;
 }
@@ -286,23 +284,25 @@ std::string StringUtils::replaceAll(std::string str, const std::string& from,
   return str;
 }
 
-std::string StringUtils::getLineInString(std::string& bulk, unsigned int line) {
+// TODO: have this return std::string_view to avoid copying the string,
+// but first we need a unit test.
+std::string StringUtils::getLineInString(const std::string_view bulk,
+					 unsigned int line) {
   std::string lineText;
-  unsigned int size = bulk.size();
-  const char* str = bulk.c_str();
+  const unsigned int size = bulk.size();
   unsigned int count = 1;
   for (unsigned int i = 0; i < size; i++) {
     if (line == count) {
-      lineText += str[i];
+      lineText += bulk[i];
     }
-    if (str[i] == '\n') count++;
+    if (bulk[i] == '\n') count++;
     if (count > line) break;
   }
 
   return lineText;
 }
 
-std::string StringUtils::removeComments(std::string text) {
+std::string StringUtils::removeComments(const std::string_view text) {
   std::string result;
   char c1 = '\0';
   bool inComment = 0;
@@ -321,7 +321,7 @@ std::string StringUtils::removeComments(std::string text) {
         result +=c2;
       c1 = c2;
     }
-  
+
   return result;
 }
 
@@ -360,8 +360,8 @@ void StringUtils::autoExpandEnvironmentVariables(std::string & text)
 }
 
 // Leave input alone and return new string.
-std::string StringUtils::evaluateEnvVars(std::string text) {
-    std::string input = text;
-    autoExpandEnvironmentVariables( input );
-    return input;
+std::string StringUtils::evaluateEnvVars(const std::string_view text) {
+  std::string input(text.begin(), text.end());
+  autoExpandEnvironmentVariables( input );
+  return input;
 }

--- a/src/Utils/StringUtils.h
+++ b/src/Utils/StringUtils.h
@@ -33,21 +33,21 @@ namespace SURELOG {
 
 class StringUtils {
  public:
-  static void tokenize(const std::string_view str,
-		       const std::string_view separators,
+  static void tokenize(std::string_view str,
+                       std::string_view separators,
                        std::vector<std::string>& args);
-  static void tokenizeMulti(const std::string_view str,
-			    const std::string_view  multichar_separator,
+  static void tokenizeMulti(std::string_view str,
+                            std::string_view  multichar_separator,
                             std::vector<std::string>& args);
-  static void tokenizeBalanced(const std::string_view str,
-			       const std::string_view separator,
+  static void tokenizeBalanced(std::string_view str,
+                               std::string_view separator,
                                std::vector<std::string>& args);
   static void replaceInTokenVector(std::vector<std::string>& tokens,
                                    std::vector<std::string> pattern,
-                                   const std::string_view news);
+                                   std::string_view news);
   static void replaceInTokenVector(std::vector<std::string>& tokens,
-                                   const std::string_view pattern,
-				   const std::string_view news);
+                                   std::string_view pattern,
+                                   std::string_view news);
   static std::string getFirstNonEmptyToken(std::vector<std::string>& tokens);
 
   // TODO: these should not modify strings, but rather return trimmed
@@ -63,11 +63,11 @@ class StringUtils {
 
   static std::string replaceAll(std::string str, const std::string& from,
                                 const std::string& to);
-  static std::string getLineInString(const std::string_view bulk, unsigned int line);
+  static std::string getLineInString(std::string_view bulk, unsigned int line);
 
   static std::string to_string(double a_value, const int n = 3);
 
-  static std::string removeComments(const std::string_view text);
+  static std::string removeComments(std::string_view text);
 
   static std::string evaluateEnvVars(std::string_view text);
   static void autoExpandEnvironmentVariables( std::string & text );

--- a/src/Utils/StringUtils.h
+++ b/src/Utils/StringUtils.h
@@ -23,26 +23,35 @@
 
 #ifndef STRINGUTILS_H
 #define STRINGUTILS_H
-#include <string>
-#include <vector>
+
 #include <map>
+#include <string>
+#include <string_view>
+#include <vector>
+
 namespace SURELOG {
 
 class StringUtils {
  public:
-  static void tokenize(std::string str, std::string separators,
+  static void tokenize(const std::string_view str,
+		       const std::string_view separators,
                        std::vector<std::string>& args);
-  static void tokenizeMulti(std::string str, std::string multichar_separator,
+  static void tokenizeMulti(const std::string_view str,
+			    const std::string_view  multichar_separator,
                             std::vector<std::string>& args);
-  static void tokenizeBalanced(std::string str, std::string separator,
+  static void tokenizeBalanced(const std::string_view str,
+			       const std::string_view separator,
                                std::vector<std::string>& args);
   static void replaceInTokenVector(std::vector<std::string>& tokens,
                                    std::vector<std::string> pattern,
-                                   std::string news);
+                                   const std::string_view news);
   static void replaceInTokenVector(std::vector<std::string>& tokens,
-                                   std::string pattern, std::string news);
+                                   const std::string_view pattern,
+				   const std::string_view news);
   static std::string getFirstNonEmptyToken(std::vector<std::string>& tokens);
 
+  // TODO: these should not modify strings, but rather return trimmed
+  // std::string_views.
   static std::string& trim(std::string& str);
   static std::string& ltrim(std::string& str);
   static std::string& ltrim(std::string& str, char c);
@@ -54,24 +63,25 @@ class StringUtils {
 
   static std::string replaceAll(std::string str, const std::string& from,
                                 const std::string& to);
-  static std::string getLineInString(std::string& bulk, unsigned int line);
+  static std::string getLineInString(const std::string_view bulk, unsigned int line);
 
   static std::string to_string(double a_value, const int n = 3);
 
-  static std::string removeComments(std::string text);
-  
-  static std::string evaluateEnvVars(std::string text);
+  static std::string removeComments(const std::string_view text);
+
+  static std::string evaluateEnvVars(std::string_view text);
   static void autoExpandEnvironmentVariables( std::string & text );
-  static void registerEnvVar(std::string var, std::string value) { 
+  static void registerEnvVar(std::string var, std::string value) {
       envVars.insert(std::make_pair(var, value));
   }
-  
+
  private:
-  StringUtils();
-  StringUtils(const StringUtils& orig);
-  virtual ~StringUtils();
+  StringUtils() = delete;
+  StringUtils(const StringUtils& orig) = delete;
+  ~StringUtils() = delete;
+
   static std::map<std::string, std::string> envVars;
-  
+
  private:
 };
 


### PR DESCRIPTION
std::string_view has a multitude of advantages; most specifically, it
allows to write code that prevents copies of strings.
Gently transform a first set of functions for that.

There is more opportunity, but I didn't change the functions itself
too much, as there are no unit tests, so this would be dangerous.

Using std::string_view consequently everywhere it is possible (with
proper string ownership known), it is possible to hand around
string slices without ever to copy strings.

string_view appeared in C++17, since we're using this now as minimum
requirement, this was possible (otherwise we could've used
absl::string_view).

Signed-off-by: Henner Zeller <h.zeller@acm.org>