### PR TITLE
Change a few places that can use const references.

### DIFF
--- a/src/Design/Enum.cpp
+++ b/src/Design/Enum.cpp
@@ -26,12 +26,12 @@
 using namespace SURELOG;
 
 Enum::Enum(FileContent* fC, NodeId nameId, NodeId baseTypeId)
-    : DataType(fC, baseTypeId, fC->SymName(nameId), fC->Type(baseTypeId)), m_nameId(nameId), 
+    : DataType(fC, baseTypeId, fC->SymName(nameId), fC->Type(baseTypeId)), m_nameId(nameId),
     m_typespec(nullptr), m_baseTypespec(nullptr) {}
 
 Enum::~Enum() {}
 
-Value* Enum::getValue(std::string& name) {
+Value* Enum::getValue(const std::string& name) {
   NameValueMap::iterator itr = m_values.find(name);
   if (itr == m_values.end()) {
     return NULL;

--- a/src/Design/Enum.h
+++ b/src/Design/Enum.h
@@ -44,11 +44,11 @@ class Enum : public DataType {
 
   typedef std::map<std::string, std::pair<unsigned int, Value*>> NameValueMap;
 
-  void addValue(std::string& name, unsigned int lineNb, Value* value) {
+  void addValue(const std::string& name, unsigned int lineNb, Value* value) {
     m_values.insert(std::make_pair(name, std::make_pair(lineNb, value)));
   }
-  Value* getValue(std::string& name);
-  NodeId getDefinitionId() { return m_nameId;}
+  Value* getValue(const std::string& name);
+  NodeId getDefinitionId() const { return m_nameId;}
   NameValueMap& getValues() { return  m_values;}
 
   UHDM::typespec* getTypespec() { return m_typespec; }
@@ -58,8 +58,8 @@ class Enum : public DataType {
   void setBaseTypespec(UHDM::typespec* typespec) { m_baseTypespec = typespec; }
 
  private:
+  const NodeId m_nameId;
   NameValueMap m_values;
-  NodeId m_nameId;
   UHDM::typespec* m_typespec;
   UHDM::typespec* m_baseTypespec;
 };

--- a/src/Design/ModPort.cpp
+++ b/src/Design/ModPort.cpp
@@ -30,8 +30,8 @@ ModPort::~ModPort()
 {
 }
 
-Signal* ModPort::getPort(std::string& name) {
-  for (Signal& sig : m_ports) {
+const Signal* ModPort::getPort(const std::string& name) const {
+  for (const Signal& sig : m_ports) {
     if (sig.getName() == name) {
       return &sig;
     }

--- a/src/Design/ModPort.h
+++ b/src/Design/ModPort.h
@@ -33,16 +33,19 @@ class ModuleDefinition;
 
 class ModPort {
 public:
-  ModPort(ModuleDefinition* parent, const std::string& name) : m_parent(parent), m_name(name) {}
+  ModPort(ModuleDefinition* parent, const std::string_view name)
+    : m_parent(parent), m_name(name) {}
   virtual ~ModPort();
-  const std::string& getName() { return m_name; }
-  void addSignal(Signal& sig) { m_ports.push_back(sig); }
-  std::vector<Signal>& getPorts() { return m_ports; }
-  Signal* getPort(std::string& name);
+  const std::string& getName() const { return m_name; }
+  void addSignal(const Signal& sig) { m_ports.push_back(sig); }
+  const std::vector<Signal>& getPorts() const { return m_ports; }
+  const Signal* getPort(const std::string& name) const;
   ModuleDefinition* getParent () { return m_parent; }
+
 private:
-  ModuleDefinition* m_parent;
-  std::string m_name;
+  ModuleDefinition* const m_parent;
+  const std::string m_name;
+
   std::vector<Signal> m_ports;
 };
 };

--- a/src/Design/ModuleDefinition.cpp
+++ b/src/Design/ModuleDefinition.cpp
@@ -29,7 +29,7 @@
 using namespace SURELOG;
 
 ModuleDefinition::ModuleDefinition(FileContent* fileContent, NodeId nodeId,
-                                   std::string& name)
+                                   const std::string_view name)
     : DesignComponent(fileContent, NULL), m_name(name), m_gen_block_id(0) {
   if (fileContent) {
     addFileContent(fileContent, nodeId);
@@ -76,8 +76,8 @@ void ModuleDefinition::insertModPort(const std::string& modport, Signal& signal)
   }
 }
 
-Signal* ModuleDefinition::getModPortSignal(const std::string& modport, NodeId port) {
-  ModPortSignalMap::iterator itr = m_modportSignalMap.find(modport);
+const Signal* ModuleDefinition::getModPortSignal(const std::string& modport, NodeId port) const {
+  ModPortSignalMap::const_iterator itr = m_modportSignalMap.find(modport);
   if (itr == m_modportSignalMap.end()) {
     return NULL;
   } else {

--- a/src/Design/ModuleDefinition.h
+++ b/src/Design/ModuleDefinition.h
@@ -23,7 +23,10 @@
 
 #ifndef MODULEDEFINITION_H
 #define MODULEDEFINITION_H
+
+#include <string_view>
 #include <vector>
+
 #include "Design/DesignComponent.h"
 #include "Design/ValuedComponentI.h"
 #include "Design/Signal.h"
@@ -39,7 +42,8 @@ class ModuleDefinition : public DesignComponent, public ClockingBlockHolder {
   friend CompileModule;
 
  public:
-  ModuleDefinition(FileContent* fileContent, NodeId nodeId, std::string& name);
+  ModuleDefinition(FileContent* fileContent, NodeId nodeId,
+		   const std::string_view name);
 
   ~ModuleDefinition() override;
 
@@ -62,24 +66,24 @@ class ModuleDefinition : public DesignComponent, public ClockingBlockHolder {
   }
   void insertModPort(const std::string& modport, Signal& signal);
   void insertModPort(const std::string& modport, ClockingBlock& block);
-  Signal* getModPortSignal(const std::string& modport, NodeId port);
+  const Signal* getModPortSignal(const std::string& modport, NodeId port) const;
   ModPort* getModPort(const std::string& modport);
-  
+
   ClockingBlock* getModPortClockingBlock(const std::string& modport, NodeId port);
 
   ClassNameClassDefinitionMultiMap& getClassDefinitions() {
     return m_classDefinitions;
   }
-  void addClassDefinition(std::string className, ClassDefinition* classDef) {
+  void addClassDefinition(const std::string &className, ClassDefinition* classDef) {
     m_classDefinitions.insert(std::make_pair(className, classDef));
   }
   ClassDefinition* getClassDefinition(const std::string& name);
 
   void setGenBlockId(NodeId id) { m_gen_block_id = id; }
-  NodeId getGenBlockId() { return m_gen_block_id; }
+  NodeId getGenBlockId() const { return m_gen_block_id; }
 
  private:
-  std::string m_name;
+  const std::string m_name;
   ModPortSignalMap m_modportSignalMap;
   ModPortClockingBlockMap m_modportClockingBlockMap;
   ClassNameClassDefinitionMultiMap m_classDefinitions;

--- a/src/Design/Signal.h
+++ b/src/Design/Signal.h
@@ -33,15 +33,15 @@ class ModuleDefinition;
 class Signal {
  public:
   Signal(FileContent* fileContent, NodeId node, VObjectType type, VObjectType direction, NodeId range);
-  Signal(FileContent* fileContent, NodeId node, VObjectType type, VObjectType direction, NodeId typeSpecId, NodeId range);       
+  Signal(FileContent* fileContent, NodeId node, VObjectType type, VObjectType direction, NodeId typeSpecId, NodeId range);
   Signal(FileContent* fileContent, NodeId node, NodeId interfaceTypeName, VObjectType subnettype, NodeId range);
   virtual ~Signal();
 
-  VObjectType getType() { return m_type; }
-  VObjectType getDirection() { return m_direction; }
+  VObjectType getType() const { return m_type; }
+  VObjectType getDirection() const { return m_direction; }
   FileContent* getFileContent() { return m_fileContent; }
-  NodeId getNodeId() { return m_nodeId; }
-  std::string getName() { return m_fileContent->SymName(m_nodeId); }
+  NodeId getNodeId() const { return m_nodeId; }
+  std::string getName() const { return m_fileContent->SymName(m_nodeId); }
 
   std::string getInterfaceTypeName() {
     std::string type_name = m_fileContent->SymName(m_interfaceTypeNameId);
@@ -57,7 +57,7 @@ class Signal {
     }
     return type_name;
   }
- 
+
   ModuleDefinition* getInterfaceDef() { return m_interfaceDef; }
   void setInterfaceDef(ModuleDefinition* interfaceDef) {
     m_interfaceDef = interfaceDef;
@@ -66,7 +66,7 @@ class Signal {
   void setModPort(ModPort* modport) { m_modPort = modport; }
   void setDirection(VObjectType direction) { m_direction = direction; }
   void setType(VObjectType type) { m_type = type; }
-  void setDataType(DataType* dtype) { m_dataType = dtype; } 
+  void setDataType(DataType* dtype) { m_dataType = dtype; }
   bool isInterface() { return (m_interfaceTypeNameId != 0); }
   void setLowConn(Signal* sig) { m_lowConn = sig; }
   Signal* getLowConn() { return m_lowConn; }
@@ -75,6 +75,7 @@ class Signal {
   NodeId getInterfaceTypeNameId() { return m_interfaceTypeNameId; }
   NodeId getTypeSpecId() { return m_typeSpecId; }
   DataType* getDataType() { return m_dataType; }
+
  private:
   FileContent* m_fileContent;
   NodeId m_nodeId;

--- a/src/SourceCompile/AnalyzeFile.cpp
+++ b/src/SourceCompile/AnalyzeFile.cpp
@@ -46,7 +46,8 @@
 #include <regex>
 using namespace SURELOG;
 
-void saveContent(std::string fileName, std::string& content) {
+static void saveContent(const std::string& fileName,
+			const std::string& content) {
   std::ifstream ifs;
   ifs.open(fileName);
   bool save = true;
@@ -403,7 +404,7 @@ void AnalyzeFile::analyze() {
     m_lineOffsets.push_back(0);
     return;
   }
-  
+
   if (lineSize < minNbLineForPartitioning) {
     m_splitFiles.push_back(m_ppFileName);
     m_lineOffsets.push_back(0);

--- a/src/SourceCompile/SV3_1aPpTreeListenerHelper.cpp
+++ b/src/SourceCompile/SV3_1aPpTreeListenerHelper.cpp
@@ -181,13 +181,13 @@ void SV3_1aPpTreeListenerHelper::addLineFiller(ParserRuleContext* ctx) {
     return;
   const std::string& text = ctx->getText();
   for (unsigned int i = 0; i < text.size(); i++) {
-    if (text[i] == '\n') 
+    if (text[i] == '\n')
       m_pp->append("\n");
   }
 }
 
 void SV3_1aPpTreeListenerHelper::checkMultiplyDefinedMacro(
-    std::string& macroName, ParserRuleContext* ctx) {
+    const std::string &macroName, ParserRuleContext* ctx) {
   std::set<PreprocessFile*> visited;
   MacroInfo* macroInf = m_pp->getMacro(macroName);
   if (macroInf) {

--- a/src/SourceCompile/SV3_1aPpTreeListenerHelper.h
+++ b/src/SourceCompile/SV3_1aPpTreeListenerHelper.h
@@ -66,7 +66,7 @@ public:
     void logError(ErrorDefinition::ErrorType error, ParserRuleContext* ctx, std::string object, bool printColumn = false);
     void logError(ErrorDefinition::ErrorType, Location& loc, bool showDuplicates = false);
     void logError(ErrorDefinition::ErrorType, Location& loc, Location& extraLoc, bool showDuplicates = false);
-    void checkMultiplyDefinedMacro(std::string& macroName, ParserRuleContext* ctx);
+    void checkMultiplyDefinedMacro(const std::string &macroName, ParserRuleContext* ctx);
     void forwardToParser(ParserRuleContext* ctx);
     void init();
     void addLineFiller(ParserRuleContext* ctx);


### PR DESCRIPTION
Using const references improves readability as it is easier for
a developer to see that nothing is modified.
(It also opens of course optimization opportunities, but well
 self-documenting code is the main motivation).

Also in this change a few places that
  - use std::string_view where safe to do
  - make some member variables 'const' where they are only
    set in the constructor and never modified.
  - make methods that don't modify internals 'const'.
-
Signed-off-by: Henner Zeller <h.zeller@acm.org>