### PR TITLE
SymbolTable: use const references and const methods where possible.

### DIFF
--- a/src/Library/Library.h
+++ b/src/Library/Library.h
@@ -23,9 +23,12 @@
 
 #ifndef LIBRARY_H
 #define LIBRARY_H
+
+#include <map>
+#include <set>
 #include <string>
 #include <vector>
-#include <set>
+
 namespace SURELOG {
 
 class ModuleDefinition;

--- a/src/SourceCompile/LoopCheck.cpp
+++ b/src/SourceCompile/LoopCheck.cpp
@@ -20,17 +20,13 @@
  *
  * Created on May 2, 2017, 8:14 PM
  */
+#include "SourceCompile/LoopCheck.h"
 
 #include <queue>
-#include <set>
-#include "SourceCompile/SymbolTable.h"
-#include "SourceCompile/LoopCheck.h"
 
 using namespace SURELOG;
 
 LoopCheck::LoopCheck() {}
-
-LoopCheck::LoopCheck(const LoopCheck& orig) {}
 
 LoopCheck::~LoopCheck() {
   for (auto itr : m_nodes) {
@@ -65,7 +61,7 @@ bool LoopCheck::addEdge(SymbolId from, SymbolId to) {
   }
   nodeFrom->m_toList.insert(nodeTo);
 
-  for (auto itr : m_nodes) {
+  for (auto &itr : m_nodes) {
     itr.second->m_visited = false;
   }
 
@@ -89,9 +85,9 @@ bool LoopCheck::addEdge(SymbolId from, SymbolId to) {
   return false;
 }
 
-std::vector<SymbolId> LoopCheck::reportLoop() {
+std::vector<SymbolId> LoopCheck::reportLoop() const {
   std::vector<SymbolId> loop;
-  for (auto itr : m_nodes) {
+  for (const auto &itr : m_nodes) {
     if (itr.second->m_visited) {
       loop.push_back(itr.first);
     }

--- a/src/SourceCompile/LoopCheck.h
+++ b/src/SourceCompile/LoopCheck.h
@@ -20,37 +20,41 @@
  *
  * Created on May 2, 2017, 8:14 PM
  */
-
 #ifndef LOOPCHECK_H
 #define LOOPCHECK_H
 
-namespace SURELOG {
+#include <set>
+#include <map>
+#include <vector>
 
+#include "SourceCompile/SymbolTable.h"
+
+namespace SURELOG {
 class LoopCheck {
- public:
+public:
   LoopCheck();
-  LoopCheck(const LoopCheck& orig);
-  virtual ~LoopCheck();
+  ~LoopCheck();
 
   void clear();
 
   // return true if new edge creates a loop
   bool addEdge(SymbolId from, SymbolId to);
 
-  std::vector<SymbolId> reportLoop();
+  std::vector<SymbolId> reportLoop() const;
 
- private:
+private:
+  LoopCheck(const LoopCheck& orig) = delete;
+
   class Node {
-   public:
+  public:
     Node(SymbolId objId) : m_objId(objId), m_visited(false) {}
-    SymbolId m_objId;
+    const SymbolId m_objId;
     std::set<Node*> m_toList;
     bool m_visited;
   };
 
   std::map<SymbolId, Node*> m_nodes;
 };
-
-};  // namespace SURELOG
+}  // namespace SURELOG
 
 #endif /* LOOPCHECK_H */

--- a/src/SourceCompile/SymbolTable.cpp
+++ b/src/SourceCompile/SymbolTable.cpp
@@ -20,16 +20,13 @@
  *
  * Created on March 6, 2017, 11:10 PM
  */
-#include <iostream>
 #include "SourceCompile/SymbolTable.h"
-#include <mutex>
-#include <vector>
 
 using namespace SURELOG;
 
-std::string SymbolTable::m_badSymbol("@@BAD_SYMBOL@@");
-std::string SymbolTable::m_emptyMacroMarker("@@EMPTY_MACRO@@");
-SymbolId SymbolTable::m_badId = 0;
+const std::string SymbolTable::m_badSymbol("@@BAD_SYMBOL@@");
+const std::string SymbolTable::m_emptyMacroMarker("@@EMPTY_MACRO@@");
+const SymbolId SymbolTable::m_badId = 0;
 
 SymbolTable::SymbolTable() : m_idCounter(1) {
   m_id2SymbolMap.push_back(m_badSymbol);
@@ -38,12 +35,13 @@ SymbolTable::SymbolTable() : m_idCounter(1) {
 
 SymbolTable::~SymbolTable() {}
 
-SymbolId SymbolTable::registerSymbol(const std::string symbol) {
-  std::unordered_map<std::string, SymbolId>::iterator itr =
+SymbolId SymbolTable::registerSymbol(const std::string& symbol) {
+  // TODO: use std::string_view and heterogeneous lookup
+  std::unordered_map<std::string, SymbolId>::const_iterator itr =
       m_symbol2IdMap.find(symbol);
   if (itr == m_symbol2IdMap.end()) {
     m_symbol2IdMap.insert(std::make_pair(symbol, m_idCounter));
-    m_id2SymbolMap.push_back(symbol);
+    m_id2SymbolMap.emplace_back(symbol);
     m_idCounter++;
     SymbolId tmp = m_idCounter - 1;
     return (tmp);
@@ -53,8 +51,9 @@ SymbolId SymbolTable::registerSymbol(const std::string symbol) {
   }
 }
 
-SymbolId SymbolTable::getId(const std::string symbol) {
-  std::unordered_map<std::string, SymbolId>::iterator itr =
+SymbolId SymbolTable::getId(const std::string& symbol) const {
+  // TODO: use std::string_view and heterogeneous lookup
+  std::unordered_map<std::string, SymbolId>::const_iterator itr =
       m_symbol2IdMap.find(symbol);
   if (itr == m_symbol2IdMap.end()) {
     return 0;
@@ -64,8 +63,8 @@ SymbolId SymbolTable::getId(const std::string symbol) {
   }
 }
 
-const std::string SymbolTable::getSymbol(SymbolId id) {
+const std::string& SymbolTable::getSymbol(SymbolId id) const {
   if (id >= m_id2SymbolMap.size())
-    return "@@BAD_SYMBOL@@";
+    return m_badSymbol;
   return m_id2SymbolMap[id];
 }

--- a/src/SourceCompile/SymbolTable.h
+++ b/src/SourceCompile/SymbolTable.h
@@ -26,8 +26,8 @@
 
 #include <stdint.h>
 
-#include <map>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 
@@ -42,25 +42,26 @@ static constexpr NodeId InvalidNodeId = 969696;
 class SymbolTable {
  public:
   SymbolTable();
-  // SymbolTable(const SymbolTable& orig);
+  ~SymbolTable();
 
-  SymbolId registerSymbol(const std::string symbol);
-  SymbolId getId(const std::string symbol);
-  const std::string getSymbol(SymbolId id);
-  const std::string getBadSymbol() { return m_badSymbol; }
+  SymbolId registerSymbol(const std::string& symbol);
+  SymbolId getId(const std::string& symbol) const;
+  const std::string& getSymbol(SymbolId id) const;
+
+  const std::string& getBadSymbol() const { return m_badSymbol; }
   SymbolId getBadId() const { return m_badId; }
-  virtual ~SymbolTable();
 
-  static const std::string getEmptyMacroMarker() { return m_emptyMacroMarker; }
-  std::vector<std::string>& getSymbols() { return m_id2SymbolMap; }
+  const std::vector<std::string>& getSymbols() const { return m_id2SymbolMap; }
+  static const std::string& getEmptyMacroMarker() { return m_emptyMacroMarker; }
 
  private:
   SymbolId m_idCounter;
   std::vector<std::string> m_id2SymbolMap;
   std::unordered_map<std::string, SymbolId> m_symbol2IdMap;
-  static std::string m_badSymbol;
-  static SymbolId m_badId;
-  static std::string m_emptyMacroMarker;
+
+  static const std::string m_badSymbol;
+  static const SymbolId m_badId;
+  static const std::string m_emptyMacroMarker;
 };
 
 };  // namespace SURELOG


### PR DESCRIPTION
Also IWYU: remove some unnecessary includes in SymbolTable, which then
uncovered some other places which relied on that. Fixed them.
    
In the touched files: always include the header of the implementation
(so foo.h included in foo.cpp) at the very first: this should always
work cleanly and will find accidental dependencies on other headers.
