### PR TITLE
Add an editorconfig file so all contributors are on one page.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# Editor config file, see http://editorconfig.org/
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.tcl]
+indent_size = 4
+
+[*.{h,cpp}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/.editorconfig
+++ b/.editorconfig
@@ -8,11 +8,11 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.tcl]
-indent_size = 4
-
 [*.{h,cpp}]
 indent_size = 2
+
+[*.tcl]
+indent_size = 4
 
 [Makefile]
 indent_style = tab


### PR DESCRIPTION
Editorconfig is a universal description for various editors
to apply the right indentation rules.

https://editorconfig.org/

Signed-off-by: Henner Zeller <h.zeller@acm.org>