### PR TITLE
Make dependencies work better in Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,46 +9,42 @@ endif
 
 PREFIX ?= /usr/local
 
-release:
-	mkdir -p build/tests;
-	mkdir -p build/dist;
-	mkdir -p dist;
-	cd build; cmake ../ -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(PREFIX)
+release: run-cmake-release
 	$(MAKE) -C build
 
-debug:
-	mkdir -p dbuild/tests;
-	mkdir -p dbuild/dist;
-	mkdir -p dist;
-	cd dbuild; cmake ../ -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$(PREFIX)
+debug: run-cmake-debug
 	$(MAKE) -C dbuild
 
-test/unittest:
-	mkdir -p build
-	cd build && make UnitTests
+run-cmake-release:
+	mkdir -p build/tests build/dist dist
+	cd build; cmake ../ -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(PREFIX)
+
+run-cmake-debug:
+	mkdir -p dbuild/tests dbuild/dist dist
+	cd dbuild; cmake ../ -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$(PREFIX)
+
+test/unittest: run-cmake-release
+	$(MAKE) -C build UnitTests
 	cd build && ctest --output-on-failure
 
-test/regression:
-	mkdir -p build/tests;
+test/regression: run-cmake-release
 	cd build; ../tests/regression.tcl mt=0 show_diff
 
 test: test/unittest test/regression
 
-test-parallel: test/unittest
+test-parallel: release test/unittest
 	mkdir -p build/tests; cd build; rm -rf test; mkdir test; cd test; ../../tests/cmake_gen.tcl; cmake .; time make -j $(CPU_CORES); cd ..; ../tests/regression.tcl diff_mode show_diff;
 
-regression:
+regression: release
 	mkdir -p build/tests; cd build; rm -rf test; mkdir test; cd test; ../../tests/cmake_gen.tcl; cmake .; time make -j $(CPU_CORES); cd ..; ../tests/regression.tcl diff_mode show_diff;
 
 clean:
-	rm -rf dist;
-	if [ -d build ] ; then $(MAKE) -C build clean ; fi
-	rm -rf build
+	rm -rf build dist
 
-install:
-	cd build; make install
+install: release
+	$(MAKE) -C build install
 
-test_install:
+test_install: release
 	cd tests/TestInstall ; rm -rf build; mkdir -p build; cd build; cmake ../ -DINSTALL_DIR=$(PREFIX); make ; ./test_hellosureworld --version
 
 uninstall:


### PR DESCRIPTION
Some targets were only working if other targets had been
called before, e.g. regression required to have run the release
before. These dependencies are now better captured in Makefile
rules.

Also: make clean now just removes the build directory, instead
of first calling make clean and then removing the directory anyway.

Signed-off-by: Henner Zeller <h.zeller@acm.org>