### PR TITLE
Make it simpler adding more tests; start StringUtils tests.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -344,20 +344,36 @@ endif()
 
 # Unit tests
 enable_testing()
+include(GoogleTest)
+# All unit-tests are registered with this custom target as dependency, so
+# just `make UnitTests` will build them all.
+add_custom_target(UnitTests)
 
-add_executable(CompileHelper-Test EXCLUDE_FROM_ALL
-  ${PROJECT_SOURCE_DIR}/src/DesignCompile/CompileHelper_test.cpp
-)
-target_link_libraries(CompileHelper-Test
-  PRIVATE surelog
-  PRIVATE gtest
-  PRIVATE gmock
-  PRIVATE gtest_main)
-#add_test(NAME test_CompileHelper COMMAND CompileHelper-Test WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} )
+# Concise way to register a new google test
+# call with register_gtest(path/to/UnitTestFile.cpp)
+function(register_gtests)
+  foreach(gtest_cc_file IN LISTS ARGN)
+    # We create the binary name and test prefix from the cpp-filepath
+    get_filename_component(test_bin ${gtest_cc_file} NAME_WE)
+    get_filename_component(test_prefix ${gtest_cc_file} DIRECTORY)
 
-add_custom_target(UnitTests
-  DEPENDS CompileHelper-Test
-  # Add further test binaries above
+    # Build binary, link all relevant libs and extract tests
+    add_executable(${test_bin} EXCLUDE_FROM_ALL ${gtest_cc_file})
+
+    # For simplicity, we link the test with libsurelog, but there is of
+    # course a lot unnecessary churn if headers are modified.
+    # Often it is sufficient to just have a few depeendencies.
+    target_link_libraries(${test_bin} surelog gtest gmock gtest_main)
+    gtest_discover_tests(${test_bin} TEST_PREFIX "${test_prefix}/")
+
+    # Now, add this binary to our UnitTests target that it builds this
+    add_dependencies(UnitTests ${test_bin})
+  endforeach()
+endfunction()
+
+register_gtests(
+  src/Utils/StringUtils_test.cpp
+  src/DesignCompile/CompileHelper_test.cpp
 )
 
 target_link_libraries(hellosureworld surelog)

--- a/src/DesignCompile/CompileHelper_test.cpp
+++ b/src/DesignCompile/CompileHelper_test.cpp
@@ -73,7 +73,6 @@ MockCompileDesign cd;
 
 using SURELOG::VObject;
 
-
 struct CompileHelperTestStruct {
   std::vector<VObject> objects;
   UHDM::tf_call* expected;
@@ -366,7 +365,8 @@ UHDM::design* addCallToDesign(UHDM::tf_call* call) {
   return d;
 }
 
-TEST(TestCompileTfCall, FirstTest) {
+// Currently segfaults. Disbled.
+TEST(DISABLED_CompileHelperTest, TestCompileTfCall) {
   SURELOG::CompileHelper dut;
   MockFileContent fc;
   UHDM::Serializer& s = cd.getSerializer();

--- a/src/Utils/StringUtils.cpp
+++ b/src/Utils/StringUtils.cpp
@@ -41,7 +41,7 @@ std::string StringUtils::to_string(double a_value, const int n) {
 
 void StringUtils::tokenizeMulti(std::string_view str,
                                 std::string_view separator,
-                                std::vector<std::string>& args) {
+                                std::vector<std::string>& result) {
   std::string tmp;
   const unsigned int sepSize = separator.size();
   const unsigned int stringSize = str.size();
@@ -56,12 +56,12 @@ void StringUtils::tokenizeMulti(std::string_view str,
     }
     if (isSeparator) {
       i = i + sepSize - 1;
-      args.push_back(tmp);
+      result.push_back(tmp);
       tmp = "";
-      if (i == (str.size() - 1)) args.push_back(tmp);
+      if (i == (str.size() - 1)) result.push_back(tmp);
     } else if (i == (str.size() - 1)) {
       tmp += str[i];
-      args.push_back(tmp);
+      result.push_back(tmp);
       tmp = "";
     } else {
       tmp += str[i];
@@ -71,7 +71,7 @@ void StringUtils::tokenizeMulti(std::string_view str,
 
 void StringUtils::tokenize(std::string_view str,
                            std::string_view separator,
-                           std::vector<std::string>& args) {
+                           std::vector<std::string>& result) {
   std::string tmp;
   const unsigned int sepSize = separator.size();
   const unsigned int stringSize = str.size();
@@ -84,12 +84,12 @@ void StringUtils::tokenize(std::string_view str,
       }
     }
     if (isSeparator) {
-      args.push_back(tmp);
+      result.push_back(tmp);
       tmp = "";
-      if (i == (str.size() - 1)) args.push_back(tmp);
+      if (i == (str.size() - 1)) result.push_back(tmp);
     } else if (i == (str.size() - 1)) {
       tmp += str[i];
-      args.push_back(tmp);
+      result.push_back(tmp);
       tmp = "";
     } else {
       tmp += str[i];
@@ -99,7 +99,7 @@ void StringUtils::tokenize(std::string_view str,
 
 void StringUtils::tokenizeBalanced(std::string_view str,
                                    std::string_view separator,
-                                   std::vector<std::string>& args) {
+                                   std::vector<std::string>& result) {
   std::string tmp;
   const unsigned int sepSize = separator.size();
   const unsigned int stringSize = str.size();
@@ -129,12 +129,12 @@ void StringUtils::tokenizeBalanced(std::string_view str,
       }
     }
     if (isSeparator) {
-      args.push_back(tmp);
+      result.push_back(tmp);
       tmp = "";
-      if (i == (str.size() - 1)) args.push_back(tmp);
+      if (i == (str.size() - 1)) result.push_back(tmp);
     } else if (i == (str.size() - 1)) {
       tmp += str[i];
-      args.push_back(tmp);
+      result.push_back(tmp);
       tmp = "";
     } else {
       tmp += str[i];
@@ -207,7 +207,7 @@ void StringUtils::replaceInTokenVector(std::vector<std::string>& tokens,
 }
 
 std::string StringUtils::getFirstNonEmptyToken(
-    std::vector<std::string>& tokens) {
+    const std::vector<std::string>& tokens) {
   unsigned int tokensSize = tokens.size();
   for (unsigned int i = 0; i < tokensSize; i++) {
     if (tokens[i] != " ") return tokens[i];
@@ -273,15 +273,16 @@ std::string StringUtils::leaf(std::string str) {
   return str;
 }
 
-std::string StringUtils::replaceAll(std::string str, const std::string& from,
-                                    const std::string& to) {
+std::string StringUtils::replaceAll(std::string_view str,
+                                    std::string_view from,
+                                    std::string_view to) {
   size_t start_pos = 0;
-  while ((start_pos = str.find(from, start_pos)) != std::string::npos) {
-    str.replace(start_pos, from.length(), to);
-    start_pos +=
-        to.length();  // Handles case where 'to' is a substring of 'from'
+  std::string result(str);
+  while ((start_pos = result.find(from, start_pos)) != std::string::npos) {
+    result.replace(start_pos, from.length(), to);
+    start_pos += to.length();  // Handles case where 'to' is a substr of 'from'
   }
-  return str;
+  return result;
 }
 
 // TODO: have this return std::string_view to avoid copying the string,

--- a/src/Utils/StringUtils.h
+++ b/src/Utils/StringUtils.h
@@ -33,22 +33,33 @@ namespace SURELOG {
 
 class StringUtils {
  public:
+  // Tokenize "str" at "any_of_separator", store in "result" array.
   static void tokenize(std::string_view str,
-                       std::string_view separators,
-                       std::vector<std::string>& args);
+                       std::string_view any_of_separator,
+                       std::vector<std::string>& result);
+
+  // Tokenize "str" at "multichar_separator"; store in "result" array.
   static void tokenizeMulti(std::string_view str,
-                            std::string_view  multichar_separator,
-                            std::vector<std::string>& args);
+                            std::string_view multichar_separator,
+                            std::vector<std::string>& result);
+
+  // Tokenizes "str" at "separator", but leaves 'bracketed' areas
+  // intact: "double quoted" (parenthesized) [foo] {bar}
   static void tokenizeBalanced(std::string_view str,
                                std::string_view separator,
-                               std::vector<std::string>& args);
+                               std::vector<std::string>& result);
   static void replaceInTokenVector(std::vector<std::string>& tokens,
                                    std::vector<std::string> pattern,
                                    std::string_view news);
   static void replaceInTokenVector(std::vector<std::string>& tokens,
                                    std::string_view pattern,
                                    std::string_view news);
-  static std::string getFirstNonEmptyToken(std::vector<std::string>& tokens);
+
+  // Given a list of tokens, return the first that is not a single space.
+  // (unlike the name implies, it does not look for empty but space. TODO
+  //  rename)
+  static std::string getFirstNonEmptyToken(
+    const std::vector<std::string>& tokens);
 
   // TODO: these should not modify strings, but rather return trimmed
   // std::string_views.
@@ -61,10 +72,16 @@ class StringUtils {
   static std::string& rtrim(std::string& str, char c);
   static std::string leaf(std::string str);
 
-  static std::string replaceAll(std::string str, const std::string& from,
-                                const std::string& to);
+  // In given string "str", replace all occurences of "from" with "to"
+  static std::string replaceAll(std::string_view str,
+                                std::string_view from,
+                                std::string_view to);
+
+  // Given a large input, return the content of line number "line". Lines
+  // are 1 indexed.
   static std::string getLineInString(std::string_view bulk, unsigned int line);
 
+  // Convert double number with given amount of precision.
   static std::string to_string(double a_value, const int n = 3);
 
   static std::string removeComments(std::string_view text);

--- a/src/Utils/StringUtils_test.cpp
+++ b/src/Utils/StringUtils_test.cpp
@@ -1,0 +1,106 @@
+/*
+ Copyright 2020 The Surelog Team.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+#include "Utils/StringUtils.h"
+
+#include <vector>
+#include <string>
+#include <string_view>
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+using ::testing::ElementsAre;
+
+namespace SURELOG {
+namespace {
+TEST(StringUtilsTest, Tokenize) {
+  std::vector<std::string> tok_result;
+  StringUtils::tokenize("A;tokenized. string,List", ",.;", tok_result);
+  EXPECT_EQ(tok_result.size(), size_t(4));
+  EXPECT_THAT(tok_result, ElementsAre("A", "tokenized", " string", "List"));
+}
+
+TEST(StringUtilsTest, TokenizeMulti) {
+  std::vector<std::string> tok_result;
+  StringUtils::tokenizeMulti("Mary_¯Had_¯a_¯little_¯lamb", "_¯", tok_result);
+  EXPECT_EQ(tok_result.size(), size_t(5));
+  EXPECT_THAT(tok_result, ElementsAre("Mary", "Had", "a", "little", "lamb"));
+}
+
+TEST(StringUtilsTest, TokenizeBalanced) {
+  std::vector<std::string> tok_result;
+  StringUtils::tokenizeBalanced("\"some text\" (that has) {multiple clusters} "
+                                "[that shall not break]", " ", tok_result);
+  EXPECT_EQ(tok_result.size(), size_t(4));
+  EXPECT_THAT(tok_result, ElementsAre("\"some text\"",
+                                      "(that has)",
+                                      "{multiple clusters}",
+                                      "[that shall not break]"));
+}
+
+// TODO: tests needed for replaceInTokenVector()
+
+TEST(StringUtilsTest, GetFirstNonEmptyToken) {
+  EXPECT_EQ("hello", StringUtils::getFirstNonEmptyToken({" ", " ", "hello"}));
+
+  // Unlike the name implies, 'empty' actually doesn't mean empty, but
+  // one space. The function needs to be renamed, here just documenting.
+  EXPECT_NE("hello", StringUtils::getFirstNonEmptyToken({"", " ", "hello"}));
+}
+
+// TODO: tests for various trim functions.
+
+TEST(StringUtilsTest, ReplaceAll) {
+  EXPECT_EQ("The String With Space",
+            StringUtils::replaceAll("TheFOOStringFOOWithFOOSpace",
+                                    "FOO", " "));
+
+  // Various substring situations.
+  EXPECT_EQ("xABCyABCzABC", StringUtils::replaceAll("xAyAzA", "A", "ABC"));
+  EXPECT_EQ("xAyAzA", StringUtils::replaceAll("xABCyABCzABC", "ABC", "A"));
+
+  // Empty string corner-case testing.
+  EXPECT_EQ("", StringUtils::replaceAll("", "A", "B"));
+  EXPECT_EQ("", StringUtils::replaceAll("A", "A", ""));
+}
+
+TEST(StringUtilsTest, GetLineInString) {
+  constexpr std::string_view input_text = "one\ntwo\nthree\nno-newline";
+  // Lines are one-indexed
+  EXPECT_EQ("one\n", StringUtils::getLineInString(input_text, 1));
+  EXPECT_EQ("two\n", StringUtils::getLineInString(input_text, 2));
+  EXPECT_EQ("three\n", StringUtils::getLineInString(input_text, 3));
+  // If bulk ends without newline, the line is still valid.
+  EXPECT_EQ("no-newline", StringUtils::getLineInString(input_text, 4));
+
+  // Out-of-range accesses.
+  EXPECT_EQ("", StringUtils::getLineInString(input_text, 0));
+  EXPECT_EQ("", StringUtils::getLineInString(input_text, 5));
+}
+
+TEST(StringUtilsTest, DoubleStringConversion) {
+  EXPECT_EQ("3", StringUtils::to_string(3.1415926, 0));
+  EXPECT_EQ("3.1", StringUtils::to_string(3.1415926, 1));
+
+  // Proper rounding.
+  EXPECT_EQ("2", StringUtils::to_string(1.99, 0));
+  EXPECT_EQ("2.0", StringUtils::to_string(1.96, 1));
+  EXPECT_EQ("1.9", StringUtils::to_string(1.94, 1));
+}
+
+}  // namespace
+}  // namespace SURELOG


### PR DESCRIPTION
o Combine the several things needed to add a gtest into
  a function, so that we now can just add a new test file
  by adding the corresponding *.cpp file.
o use gtest_discover_tests() to output each test within
  test files.
o Start testing StringUtils. While writing the tests,
  discovered what they were doing and started documenting
  them.

Signed-off-by: Henner Zeller <h.zeller@acm.org>