### PR TITLE
Document SymbolTable class. Add unit test. Make static what should.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -374,6 +374,7 @@ endfunction()
 register_gtests(
   src/Utils/StringUtils_test.cpp
   src/DesignCompile/CompileHelper_test.cpp
+  src/SourceCompile/SymbolTable_test.cpp
 )
 
 target_link_libraries(hellosureworld surelog)

--- a/src/SourceCompile/SymbolTable.cpp
+++ b/src/SourceCompile/SymbolTable.cpp
@@ -24,13 +24,13 @@
 
 using namespace SURELOG;
 
-const std::string SymbolTable::m_badSymbol("@@BAD_SYMBOL@@");
-const std::string SymbolTable::m_emptyMacroMarker("@@EMPTY_MACRO@@");
-const SymbolId SymbolTable::m_badId = 0;
+const std::string SymbolTable::s_badSymbol("@@BAD_SYMBOL@@");
+const std::string SymbolTable::s_emptyMacroMarker("@@EMPTY_MACRO@@");
+const SymbolId SymbolTable::s_badId = 0;
 
 SymbolTable::SymbolTable() : m_idCounter(1) {
-  m_id2SymbolMap.push_back(m_badSymbol);
-  m_symbol2IdMap.insert(std::make_pair(m_badSymbol, 0));
+  m_id2SymbolMap.push_back(s_badSymbol);
+  m_symbol2IdMap.insert(std::make_pair(s_badSymbol, 0));
 }
 
 SymbolTable::~SymbolTable() {}
@@ -56,7 +56,7 @@ SymbolId SymbolTable::getId(const std::string& symbol) const {
   std::unordered_map<std::string, SymbolId>::const_iterator itr =
       m_symbol2IdMap.find(symbol);
   if (itr == m_symbol2IdMap.end()) {
-    return 0;
+    return s_badId;
   } else {
     SymbolId tmp = (*itr).second;
     return tmp;
@@ -65,6 +65,6 @@ SymbolId SymbolTable::getId(const std::string& symbol) const {
 
 const std::string& SymbolTable::getSymbol(SymbolId id) const {
   if (id >= m_id2SymbolMap.size())
-    return m_badSymbol;
+    return s_badSymbol;
   return m_id2SymbolMap[id];
 }

--- a/src/SourceCompile/SymbolTable.h
+++ b/src/SourceCompile/SymbolTable.h
@@ -44,24 +44,35 @@ class SymbolTable {
   SymbolTable();
   ~SymbolTable();
 
+  // Register given "symbol" string as a symbol and return its id.
+  // If this is an existing symbol, its ID is returned, otherwise a new one
+  // is created.
   SymbolId registerSymbol(const std::string& symbol);
+
+  // Find id of given "symbol" or return bad-ID (see #getBad()) if it doesn't
+  // exist.
   SymbolId getId(const std::string& symbol) const;
+
+  // Get symbol string identified by given ID or BadSymbol if it doesn't exist
+  // (see #getBadSymbol()).
   const std::string& getSymbol(SymbolId id) const;
 
-  const std::string& getBadSymbol() const { return m_badSymbol; }
-  SymbolId getBadId() const { return m_badId; }
-
+  // Get a vector of all symbols. As a special property, the SymbolID can be
+  // used as an index into this  vector to get the corresponding text-symbol.
   const std::vector<std::string>& getSymbols() const { return m_id2SymbolMap; }
-  static const std::string& getEmptyMacroMarker() { return m_emptyMacroMarker; }
+
+  static const std::string& getBadSymbol() { return s_badSymbol; }
+  static SymbolId getBadId() { return s_badId; }
+  static const std::string& getEmptyMacroMarker() { return s_emptyMacroMarker; }
 
  private:
   SymbolId m_idCounter;
   std::vector<std::string> m_id2SymbolMap;
   std::unordered_map<std::string, SymbolId> m_symbol2IdMap;
 
-  static const std::string m_badSymbol;
-  static const SymbolId m_badId;
-  static const std::string m_emptyMacroMarker;
+  static const std::string s_badSymbol;
+  static const SymbolId s_badId;
+  static const std::string s_emptyMacroMarker;
 };
 
 };  // namespace SURELOG

--- a/src/SourceCompile/SymbolTable_test.cpp
+++ b/src/SourceCompile/SymbolTable_test.cpp
@@ -1,0 +1,60 @@
+/*
+ Copyright 2020 The Surelog Team.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+#include "SourceCompile/SymbolTable.h"
+
+#include <vector>
+#include <string>
+#include <string_view>
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+using testing::ElementsAre;
+
+namespace SURELOG {
+namespace {
+TEST(SymbolTableTest, SymbolTableAccess) {
+  SymbolTable table;
+
+  const SymbolId foo_id = table.registerSymbol("foo");
+  EXPECT_NE(foo_id, SymbolTable::getBadId());
+
+  const SymbolId bar_id = table.registerSymbol("bar");
+  EXPECT_NE(foo_id, bar_id);
+
+  // Attempting to register the same symbol will result in original ID.
+  EXPECT_EQ(table.registerSymbol("foo"), foo_id);
+  EXPECT_EQ(table.registerSymbol("bar"), bar_id);
+
+  // Retrieve symbol-ID by text string
+  EXPECT_EQ(table.getId("foo"), foo_id);
+  EXPECT_EQ(table.getId("bar"), bar_id);
+  EXPECT_EQ(table.getId("baz"), SymbolTable::getBadId());  // no-exist
+
+  // Retrieve text symbol by ID
+  EXPECT_EQ(table.getSymbol(foo_id), "foo");
+  EXPECT_EQ(table.getSymbol(bar_id), "bar");
+  EXPECT_EQ(table.getSymbol(42), SymbolTable::getBadSymbol());  // no-exist
+
+  // For now, symbols returned in getSymbols() always contain bad symbol as
+  // first element (though this is an implementation detail and might change).
+  EXPECT_THAT(table.getSymbols(),
+              ElementsAre(SymbolTable::getBadSymbol(), "foo", "bar"));
+}
+
+}  // namespace
+}  // namespace SURELOG


### PR DESCRIPTION
 * Added a unit test for SymbolTable that verifies the basic guarantees
   of the class. This allows the implementation later to be modified
   and test if the behavior still holds.
 * Also good example how to add such a test now: it is as simple as
   adding the *.cpp file in the register_gtests() call in cmake.
 * While at it: document the methods in SymbolTable.
 * Renamed the static members to s_ (vs. m_) to make them stand out
   a bit more visually.
 * make members that only return a static value also static.

Signed-off-by: Henner Zeller <h.zeller@acm.org>