### PR TITLE
For empty string test: don't use string comparison but empty().

### DIFF
--- a/src/API/PythonAPI.cpp
+++ b/src/API/PythonAPI.cpp
@@ -174,7 +174,7 @@ void PythonAPI::loadScriptsInInterp_() {
   }
 
 
-  if (m_listenerScript != "") {
+  if (!m_listenerScript.empty()) {
     if (FileUtils::fileExists(m_listenerScript)) {
       m_listenerLoaded = loadScript_(m_listenerScript);
     }

--- a/src/Cache/Cache.cpp
+++ b/src/Cache/Cache.cpp
@@ -85,7 +85,7 @@ bool Cache::checkIfCacheIsValid(const SURELOG::CACHE::Header* header,
   }
 
   /* Timestamp Cache vs Orig File */
-  if (cacheFileName != "") {
+  if (!cacheFileName.empty()) {
     time_t ct = get_mtime(cacheFileName.c_str());
     std::string fileName = header->m_file()->c_str();
     time_t ft = get_mtime(fileName.c_str());
@@ -206,10 +206,10 @@ void Cache::restoreErrors(
   }
 }
 
-std::vector<CACHE::VObject> 
-        Cache::cacheVObjects(FileContent* fcontent, SymbolTable& canonicalSymbols, 
+std::vector<CACHE::VObject>
+        Cache::cacheVObjects(FileContent* fcontent, SymbolTable& canonicalSymbols,
                SymbolTable& fileTable, SymbolId fileId) {
-  
+
    /* Cache the design objects */
   // std::vector<flatbuffers::Offset<PARSECACHE::VObject>> object_vec;
   std::vector<CACHE::VObject> object_vec;
@@ -254,11 +254,11 @@ std::vector<CACHE::VObject>
 
   return object_vec;
 }
-  
+
 void Cache::restoreVObjects(const flatbuffers::Vector<const SURELOG::CACHE::VObject *> * objects,
-        SymbolTable& canonicalSymbols, 
-        SymbolTable& fileTable, 
-        SymbolId fileId, 
+        SymbolTable& canonicalSymbols,
+        SymbolTable& fileTable,
+        SymbolId fileId,
         FileContent* fileContent) {
    /* Restore design objects */
   for (unsigned int i = 0; i < objects->size(); i++) {
@@ -296,7 +296,7 @@ void Cache::restoreVObjects(const flatbuffers::Vector<const SURELOG::CACHE::VObj
     fileContent->getVObjects().push_back(object);
   }
 }
-  
+
 
 Cache::Cache() {}
 

--- a/src/Cache/PPCache.cpp
+++ b/src/Cache/PPCache.cpp
@@ -53,7 +53,7 @@ std::string PPCache::getCacheFileName_(std::string svFileName) {
   SymbolId cacheDirId =
       m_pp->getCompileSourceFile()->getCommandLineParser()->getCacheDir();
 
-  if (svFileName == "") svFileName = m_pp->getFileName(LINE1);
+  if (svFileName.empty()) svFileName = m_pp->getFileName(LINE1);
   svFileName = FileUtils::fileName(svFileName);
   if (prec->isFilePrecompiled(svFileName)) {
     std::string packageRepDir = m_pp->getSymbol(m_pp->getCompileSourceFile()
@@ -148,7 +148,7 @@ bool PPCache::restore_(std::string cacheFileName) {
         incinfo->m_type());
     m_pp->getIncludeFileInfo().push_back(inf);
   }
-    
+
   auto includes = ppcache->m_includes();
   if (includes)
     for (unsigned int i = 0; i < includes->size(); i++) {
@@ -169,14 +169,14 @@ bool PPCache::restore_(std::string cacheFileName) {
     m_pp->getCompileSourceFile()->getCompiler()->getDesign()->addPPFileContent(
                                               m_pp->getFileId(0), fileContent);
   }
-  
+
   auto objects = ppcache->m_objects();
   restoreVObjects(objects,
-        canonicalSymbols, 
-        *m_pp->getCompileSourceFile()->getSymbolTable(), 
-        m_pp->getFileId(0), 
-        fileContent); 
-  
+        canonicalSymbols,
+        *m_pp->getCompileSourceFile()->getSymbolTable(),
+        m_pp->getFileId(0),
+        fileContent);
+
   delete[] buffer_pointer;
   return true;
 }
@@ -191,11 +191,11 @@ bool PPCache::checkCacheIsValid_(std::string cacheFileName) {
     delete[] buffer_pointer;
     return false;
   }
-  
+
   if (m_pp->getCompileSourceFile()->getCommandLineParser()->parseOnly()) {
     return true;
   }
-  
+
   const MACROCACHE::PPCache* ppcache = MACROCACHE::GetPPCache(buffer_pointer);
   auto header = ppcache->m_header();
 
@@ -234,7 +234,7 @@ bool PPCache::checkCacheIsValid_(std::string cacheFileName) {
           m_pp->getSymbol(definePair.first) + "=" + definePair.second;
       define_vec.push_back(spath);
     }
-    
+
     std::vector<std::string> cache_define_vec;
     for (unsigned int i = 0; i < ppcache->m_cmd_define_options()->size();
          i++) {
@@ -378,10 +378,10 @@ bool PPCache::save() {
     builder,
     builder.CreateString(pretendFileName),
     info.m_originalLine,info.m_pretendLine);
-    linetrans_vec.push_back(lineInfo);   
+    linetrans_vec.push_back(lineInfo);
   }
   auto lineinfoFBList = builder.CreateVector(linetrans_vec);
-  
+
   /* Cache the include info */
   auto includeInfo = m_pp->getIncludeFileInfo();
   std::vector<flatbuffers::Offset<MACROCACHE::IncludeFileInfo>> lineinfo_vec;
@@ -396,17 +396,17 @@ bool PPCache::save() {
     info.m_type,
     info.m_indexOpening,
     info.m_indexClosing);
-    lineinfo_vec.push_back(incInfo);   
+    lineinfo_vec.push_back(incInfo);
   }
   auto incinfoFBList = builder.CreateVector(lineinfo_vec);
-  
+
   /* Cache the design objects */
    FileContent* fcontent = m_pp->getFileContent();
-  std::vector<CACHE::VObject> object_vec = cacheVObjects(fcontent, canonicalSymbols, 
-          *m_pp->getCompileSourceFile()->getSymbolTable(), 
+  std::vector<CACHE::VObject> object_vec = cacheVObjects(fcontent, canonicalSymbols,
+          *m_pp->getCompileSourceFile()->getSymbolTable(),
           m_pp->getFileId(0));
    auto objectList = builder.CreateVectorOfStructs(object_vec);
-  
+
   /* Create Flatbuffers */
   auto ppcache = MACROCACHE::CreatePPCache(
       builder, header, macroList, includeList, body, errorSymbolPair.first,

--- a/src/Cache/ParseCache.cpp
+++ b/src/Cache/ParseCache.cpp
@@ -59,7 +59,7 @@ std::string ParseCache::getCacheFileName_(std::string svFileName) {
   Precompiled* prec = Precompiled::getSingleton();
   SymbolId cacheDirId =
       m_parse->getCompileSourceFile()->getCommandLineParser()->getCacheDir();
-  if (svFileName == "") svFileName = m_parse->getPpFileName();
+  if (svFileName.empty()) svFileName = m_parse->getPpFileName();
   svFileName = FileUtils::fileName(svFileName);
   if (prec->isFilePrecompiled(svFileName)) {
     std::string packageRepDir =
@@ -130,11 +130,11 @@ bool ParseCache::restore_(std::string cacheFileName) {
   /* Restore design objects */
   auto objects = ppcache->m_objects();
   restoreVObjects(objects,
-        canonicalSymbols, 
-        *m_parse->getCompileSourceFile()->getSymbolTable(), 
-        m_parse->getFileId(0), 
+        canonicalSymbols,
+        *m_parse->getCompileSourceFile()->getSymbolTable(),
+        m_parse->getFileId(0),
         fileContent);
-  
+
   delete[] buffer_pointer;
   return true;
 }
@@ -233,8 +233,8 @@ bool ParseCache::save() {
   auto elementList = builder.CreateVector(element_vec);
 
   /* Cache the design objects */
-  std::vector<CACHE::VObject> object_vec = cacheVObjects(fcontent, canonicalSymbols, 
-          *m_parse->getCompileSourceFile()->getSymbolTable(), 
+  std::vector<CACHE::VObject> object_vec = cacheVObjects(fcontent, canonicalSymbols,
+          *m_parse->getCompileSourceFile()->getSymbolTable(),
           m_parse->getFileId(0));
    auto objectList = builder.CreateVectorOfStructs(object_vec);
 

--- a/src/Cache/PythonAPICache.cpp
+++ b/src/Cache/PythonAPICache.cpp
@@ -59,7 +59,7 @@ std::string PythonAPICache::getCacheFileName_(std::string svFileName) {
   SymbolId cacheDirId =
       m_listener->getCompileSourceFile()->getCommandLineParser()->getCacheDir();
   std::string cacheDirName = m_listener->getParseFile()->getSymbol(cacheDirId);
-  if (svFileName == "")
+  if (svFileName.empty())
     svFileName = m_listener->getParseFile()->getFileName(LINE1);
   svFileName = FileUtils::fileName(svFileName);
   Library* lib = m_listener->getCompileSourceFile()->getLibrary();

--- a/src/CommandLine/CommandLineParser.cpp
+++ b/src/CommandLine/CommandLineParser.cpp
@@ -167,7 +167,7 @@ const std::vector<std::string> helpText = {
     "  -nonote               Filters out NOTE messages",
     "  -nowarning            Filters out WARNING messages",
     "  -o <path>             Turns on all compilation stages, produces all ",
-    "  -builtin <path>       Alternative path to builtin.sv, python/ and pkg/ dirs",        
+    "  -builtin <path>       Alternative path to builtin.sv, python/ and pkg/ dirs",
     "outputs under that path",
     "  -cd <dir>             Internally change directory to <dir>",
     "  -exe <command>        Post execute a system call <command>, passes it the ",
@@ -261,7 +261,7 @@ CommandLineParser::CommandLineParser(ErrorContainer* errors,
       m_filterProtectedRegions(false),
       m_filterComments(false),
       m_parse(false),
-      m_parseOnly(false),  
+      m_parseOnly(false),
       m_compile(false),
       m_elaborate(false),
       m_diff_comp_mode(diff_comp_mode),
@@ -497,7 +497,7 @@ int CommandLineParser::parseCommandLine(int argc, const char** argv) {
   }
   processArgs_(cmd_line, all_arguments);
   for (unsigned int i = 0; i < all_arguments.size(); i++) {
-    if (all_arguments[i] == "-help" || all_arguments[i] == "-h" || 
+    if (all_arguments[i] == "-help" || all_arguments[i] == "-h" ||
         all_arguments[i] == "--help") {
       m_help = true;
       std::string help = printStringArray(helpText);
@@ -582,7 +582,7 @@ int CommandLineParser::parseCommandLine(int argc, const char** argv) {
     } else if (strstr(all_arguments[i].c_str(), "-timescale=")) {
       std::string timescale;
       timescale = all_arguments[i].substr(11, std::string::npos);
-      if (timescale == "") {
+      if (timescale.empty()) {
         Location loc(getSymbolTable()->registerSymbol(all_arguments[i]));
         Error err(ErrorDefinition::CMD_TIMESCALE_MISSING_SETTING, loc);
         m_errors->addError(err);
@@ -593,7 +593,7 @@ int CommandLineParser::parseCommandLine(int argc, const char** argv) {
     } else if (strstr(all_arguments[i].c_str(), "-I")) {
       std::string include;
       include = all_arguments[i].substr(2, std::string::npos);
-      if (include == "") {
+      if (include.empty()) {
         Location loc(getSymbolTable()->registerSymbol(all_arguments[i]));
         Error err(ErrorDefinition::CMD_INCLUDE_PATH_DOES_NOT_EXIST, loc);
         m_errors->addError(err);
@@ -614,7 +614,7 @@ int CommandLineParser::parseCommandLine(int argc, const char** argv) {
     } else if (all_arguments[i] == "-exe") {
       i++;
       m_exeCommand = all_arguments[i];
-    } else if (all_arguments[i] == "-mt" || all_arguments[i] == "--threads" || 
+    } else if (all_arguments[i] == "-mt" || all_arguments[i] == "--threads" ||
                all_arguments[i] == "-mp") {
       bool mt = ((all_arguments[i] == "-mt") || (all_arguments[i] == "--threads"));
       if (i == all_arguments.size() - 1) {
@@ -776,7 +776,7 @@ int CommandLineParser::parseCommandLine(int argc, const char** argv) {
     } else if (all_arguments[i] == "-odir") {
       i++;
     } else if (all_arguments[i] == "--Mdir") {
-      i++; 
+      i++;
     } else if (all_arguments[i] == "-o") {
       i++;
       m_writePpOutput = true;
@@ -882,7 +882,7 @@ int CommandLineParser::parseCommandLine(int argc, const char** argv) {
       m_sourceFiles.push_back(id);
       std::string fileName = all_arguments[i];
       fileName = FileUtils::fileName(fileName);
-      m_svSourceFiles.insert(fileName); 
+      m_svSourceFiles.insert(fileName);
     } else if (all_arguments[i].size() && all_arguments[i].at(0) == '+') {
       Location loc(getSymbolTable()->registerSymbol(all_arguments[i]));
       Error err(ErrorDefinition::CMD_PLUS_ARG_IGNORED, loc);
@@ -892,7 +892,7 @@ int CommandLineParser::parseCommandLine(int argc, const char** argv) {
       Error err(ErrorDefinition::CMD_MINUS_ARG_IGNORED, loc);
       m_errors->addError(err);
     } else {
-      if (all_arguments[i] != "") {
+      if (!all_arguments[i].empty()) {
         if (is_number(all_arguments[i]) || is_c_file(all_arguments[i])) {
           Location loc(getSymbolTable()->registerSymbol(all_arguments[i]));
           Error err(ErrorDefinition::CMD_PLUS_ARG_IGNORED, loc);

--- a/src/DesignCompile/CompileClass.cpp
+++ b/src/DesignCompile/CompileClass.cpp
@@ -434,7 +434,7 @@ bool CompileClass::compile_class_method_(FileContent* fC, NodeId id) {
   } else {
     funcName = "UNRECOGNIZED_METHOD_TYPE";
   }
-  if (taskName != "") {
+  if (!taskName.empty()) {
     TaskMethod* method = new TaskMethod(m_class, fC, id, taskName, is_extern);
     method->compile(m_helper);
     TaskMethod* prevDef = m_class->getTask(taskName);

--- a/src/DesignCompile/CompileExpression.cpp
+++ b/src/DesignCompile/CompileExpression.cpp
@@ -63,8 +63,8 @@ static unsigned int get_value(const UHDM::expr* expr) {
 }
 
 any* CompileHelper::compileSelectExpression(DesignComponent* component,
-                                            FileContent* fC, NodeId Bit_select, 
-                                            const std::string& name, 
+                                            FileContent* fC, NodeId Bit_select,
+                                            const std::string& name,
                                             CompileDesign* compileDesign,
                                             UHDM::any* pexpr,
                                             ValuedComponentI* instance) {
@@ -156,17 +156,17 @@ UHDM::any* CompileHelper::compileExpression(DesignComponent* component, FileCont
   if (child) {
     VObjectType childType = fC->Type(child);
     switch (childType) {
-      case VObjectType::slIncDec_PlusPlus: 
-      case VObjectType::slIncDec_MinusMinus: 
-      case VObjectType::slUnary_Minus: 
-      case VObjectType::slUnary_Plus: 
-      case VObjectType::slUnary_Tilda: 
-      case VObjectType::slUnary_Not: 
-      case VObjectType::slUnary_BitwOr: 
+      case VObjectType::slIncDec_PlusPlus:
+      case VObjectType::slIncDec_MinusMinus:
+      case VObjectType::slUnary_Minus:
+      case VObjectType::slUnary_Plus:
+      case VObjectType::slUnary_Tilda:
+      case VObjectType::slUnary_Not:
+      case VObjectType::slUnary_BitwOr:
       case VObjectType::slUnary_BitwAnd:
       case VObjectType::slUnary_BitwXor:
-      case VObjectType::slUnary_ReductNand: 
-      case VObjectType::slUnary_ReductNor: 
+      case VObjectType::slUnary_ReductNand:
+      case VObjectType::slUnary_ReductNor:
       case VObjectType::slUnary_ReductXnor1:
       case VObjectType::slUnary_ReductXnor2: {
         unsigned int vopType = UhdmWriter::getVpiOpType(childType);
@@ -273,7 +273,7 @@ UHDM::any* CompileHelper::compileExpression(DesignComponent* component, FileCont
           result = call;
         }
         break;
-      }  
+      }
       case VObjectType::slEvent_expression: {
         NodeId subExpr = child;
         UHDM::any* opL =
@@ -454,9 +454,9 @@ UHDM::any* CompileHelper::compileExpression(DesignComponent* component, FileCont
         NodeId Expression = fC->Sibling(Casting_type);
         UHDM::any* operand =
             compileExpression(component, fC, Expression, compileDesign, operation, instance, reduce);
-        if (operand)    
-          operands->push_back(operand);    
-        operation->Typespec(tps);  
+        if (operand)
+          operands->push_back(operand);
+        operation->Typespec(tps);
         result = operation;
         break;
       }
@@ -478,7 +478,7 @@ UHDM::any* CompileHelper::compileExpression(DesignComponent* component, FileCont
                 const std::string& param_name = param->Lhs()->VpiName();
                 if (param_name == n) {
                   ElaboratorListener listener(&s);
-                  result = UHDM::clone_tree((any*) param->Rhs(), s, &listener);                  
+                  result = UHDM::clone_tree((any*) param->Rhs(), s, &listener);
                   break;
                 }
               }
@@ -486,7 +486,7 @@ UHDM::any* CompileHelper::compileExpression(DesignComponent* component, FileCont
             if (result == nullptr)
               sval = pack->getValue(n);
           }
-        } else if (childType == VObjectType::slClass_type) { 
+        } else if (childType == VObjectType::slClass_type) {
           const std::string& packageName = fC->SymName(fC->Child(child));
           const std::string& n = fC->SymName(fC->Sibling(parent));
           name = packageName + "::" + n;
@@ -498,7 +498,7 @@ UHDM::any* CompileHelper::compileExpression(DesignComponent* component, FileCont
                 const std::string& param_name = param->Lhs()->VpiName();
                 if (param_name == n) {
                   ElaboratorListener listener(&s);
-                  result = UHDM::clone_tree((any*) param->Rhs(), s, &listener);                  
+                  result = UHDM::clone_tree((any*) param->Rhs(), s, &listener);
                   break;
                 }
               }
@@ -516,8 +516,8 @@ UHDM::any* CompileHelper::compileExpression(DesignComponent* component, FileCont
           }
           if (fC->Name(child))
             name = fC->SymName(child);
-          else 
-            name = fC->SymName(fC->Child(child));  
+          else
+            name = fC->SymName(fC->Child(child));
           while ((rhs = fC->Sibling(rhs))) {
             if (fC->Type(rhs) == VObjectType::slStringConst) {
               name += "." + fC->SymName(rhs);
@@ -529,12 +529,12 @@ UHDM::any* CompileHelper::compileExpression(DesignComponent* component, FileCont
             if (result)
               break;
           }
-          if (instance) 
+          if (instance)
             sval = instance->getValue(name);
         }
         if (result)
           break;
-       
+
         if (sval == NULL) {
           if (component && reduce) {
             UHDM::VectorOfparam_assign* param_assigns= component->getParam_assigns();
@@ -543,7 +543,7 @@ UHDM::any* CompileHelper::compileExpression(DesignComponent* component, FileCont
                 const std::string& param_name = param->Lhs()->VpiName();
                 if (param_name == name) {
                   ElaboratorListener listener(&s);
-                  result = UHDM::clone_tree((any*) param->Rhs(), s, &listener);                  
+                  result = UHDM::clone_tree((any*) param->Rhs(), s, &listener);
                   break;
                 }
               }
@@ -570,19 +570,19 @@ UHDM::any* CompileHelper::compileExpression(DesignComponent* component, FileCont
         c->VpiDecompile(value);
         if (strstr(value.c_str(), "'h")) {
           std::string size = value;
-          StringUtils::rtrim(size, '\''); 
+          StringUtils::rtrim(size, '\'');
           c->VpiSize(atoi(size.c_str()));
           value = "HEX:" + value;
           c->VpiConstType(vpiHexConst);
         } else if (strstr(value.c_str(), "'b")) {
           std::string size = value;
-          StringUtils::rtrim(size, '\''); 
+          StringUtils::rtrim(size, '\'');
           c->VpiSize(atoi(size.c_str()));
           value = "BIN:" + value;
           c->VpiConstType(vpiBinaryConst);
         } else if (strstr(value.c_str(), "'o")) {
           std::string size = value;
-          StringUtils::rtrim(size, '\''); 
+          StringUtils::rtrim(size, '\'');
           c->VpiSize(atoi(size.c_str()));
           value = "OCT:" + value;
           c->VpiConstType(vpiOctConst);
@@ -662,17 +662,17 @@ UHDM::any* CompileHelper::compileExpression(DesignComponent* component, FileCont
         operation->Operands(operands);
         if (fC->Type(Stream_direction) == VObjectType::slBinOp_ShiftRight)
           operation->VpiOpType(vpiStreamLROp);
-        else 
+        else
           operation->VpiOpType(vpiStreamRLOp);
         UHDM::any* exp_slice = compileExpression(component, fC, Constant_expression, compileDesign, pexpr, instance, reduce);
-        if (exp_slice) 
+        if (exp_slice)
           operands->push_back(exp_slice);
         UHDM::any* exp_var = compileExpression(component, fC, Expression, compileDesign, pexpr, instance, reduce);
-        if (exp_var) 
-          operands->push_back(exp_var);  
+        if (exp_var)
+          operands->push_back(exp_var);
         break;
       }
-      case VObjectType::slConstant_concatenation: 
+      case VObjectType::slConstant_concatenation:
       case VObjectType::slConcatenation: {
         UHDM::operation* operation = s.MakeOperation();
         UHDM::VectorOfany* operands = s.MakeAnyVec();
@@ -683,7 +683,7 @@ UHDM::any* CompileHelper::compileExpression(DesignComponent* component, FileCont
         NodeId Expression = fC->Child(child);
         while (Expression) {
           UHDM::any* exp = compileExpression(component, fC, Expression, compileDesign, pexpr, instance, reduce);
-          if (exp) 
+          if (exp)
             operands->push_back(exp);
           Expression = fC->Sibling(Expression);
         }
@@ -700,7 +700,7 @@ UHDM::any* CompileHelper::compileExpression(DesignComponent* component, FileCont
         NodeId Expression = fC->Child(child);
         while (Expression) {
           UHDM::any* exp = compileExpression(component, fC, Expression, compileDesign, pexpr, instance, reduce);
-          if (exp) 
+          if (exp)
             operands->push_back(exp);
           Expression = fC->Sibling(Expression);
         }
@@ -776,14 +776,14 @@ UHDM::any* CompileHelper::compileExpression(DesignComponent* component, FileCont
         break;
     }
   }
-  
+
   if (result == nullptr) {
-    NodeId the_node; 
+    NodeId the_node;
     if (child) {
       the_node = child;
     } else {
       the_node = parent;
-    } 
+    }
     VObjectType exprtype = fC->Type(the_node);
     if ((exprtype != VObjectType::slEnd)) {
       unsupported_expr* exp = s.MakeUnsupported_expr();
@@ -798,10 +798,10 @@ UHDM::any* CompileHelper::compileExpression(DesignComponent* component, FileCont
       //std::cout << " -> " << fC->printObject(the_node) << std::endl;
     }
   }
-  
+
   if ((result != nullptr) && reduce) {
-  
-    // Reduce 
+
+    // Reduce
     if (result->UhdmType() == uhdmoperation) {
       operation* op = (operation*) result;
       VectorOfany* operands = op->Operands();
@@ -910,7 +910,7 @@ UHDM::any* CompileHelper::compileExpression(DesignComponent* component, FileCont
       }
     }
   }
-  
+
   if (result) {
     if (child) {
       result->VpiFile(fC->getFileName(child));
@@ -924,7 +924,7 @@ UHDM::any* CompileHelper::compileExpression(DesignComponent* component, FileCont
   return result;
 }
 
-UHDM::any* CompileHelper::compileAssignmentPattern(DesignComponent* component, FileContent* fC, NodeId Assignment_pattern, 
+UHDM::any* CompileHelper::compileAssignmentPattern(DesignComponent* component, FileContent* fC, NodeId Assignment_pattern,
                                        CompileDesign* compileDesign,
                                        UHDM::any* pexpr,
                                        ValuedComponentI* instance) {
@@ -960,25 +960,25 @@ UHDM::any* CompileHelper::compileAssignmentPattern(DesignComponent* component, F
   return result;
 }
 
-std::vector<UHDM::range*>* CompileHelper::compileRanges(DesignComponent* component, FileContent* fC, NodeId Packed_dimension, 
+std::vector<UHDM::range*>* CompileHelper::compileRanges(DesignComponent* component, FileContent* fC, NodeId Packed_dimension,
                                        CompileDesign* compileDesign,
                                        UHDM::any* pexpr,
                                        ValuedComponentI* instance, bool reduce, int& size) {
   UHDM::Serializer& s = compileDesign->getSerializer();
   VectorOfrange* ranges = nullptr;
   size = 0;
-  if (Packed_dimension && ((fC->Type(Packed_dimension) == VObjectType::slPacked_dimension) || 
-                           (fC->Type(Packed_dimension) == VObjectType::slUnpacked_dimension) || 
+  if (Packed_dimension && ((fC->Type(Packed_dimension) == VObjectType::slPacked_dimension) ||
+                           (fC->Type(Packed_dimension) == VObjectType::slUnpacked_dimension) ||
                            (fC->Type(Packed_dimension) == VObjectType::slVariable_dimension))) {
     ranges = s.MakeRangeVec();
     size = 1;
     while (Packed_dimension) {
       NodeId Constant_range = fC->Child(Packed_dimension);
-      if (fC->Type(Constant_range) == VObjectType::slUnpacked_dimension || 
+      if (fC->Type(Constant_range) == VObjectType::slUnpacked_dimension ||
           fC->Type(Constant_range) == VObjectType::slPacked_dimension) {
         Constant_range = fC->Child(Constant_range);
       }
-      if (fC->Type(Constant_range) == VObjectType::slConstant_range) { 
+      if (fC->Type(Constant_range) == VObjectType::slConstant_range) {
         // Specified by range
         NodeId lexpr = fC->Child(Constant_range);
         NodeId rexpr = fC->Sibling(lexpr);
@@ -1020,7 +1020,7 @@ std::vector<UHDM::range*>* CompileHelper::compileRanges(DesignComponent* compone
         range->Left_expr(lexp);
         if (lexp)
           lexp->VpiParent(range);
-        if (rexp == nullptr)  
+        if (rexp == nullptr)
           rexp = dynamic_cast<expr*> (compileExpression(component, fC, rexpr, compileDesign, pexpr, instance, reduce));
         if (rexp)
           rexp->VpiParent(range);
@@ -1030,7 +1030,7 @@ std::vector<UHDM::range*>* CompileHelper::compileRanges(DesignComponent* compone
         ranges->push_back(range);
         range->VpiParent(pexpr);
       } else if (fC->Type(Constant_range) == VObjectType::slConstant_expression) {
-        // Specified by size  
+        // Specified by size
         NodeId rexpr = Constant_range;
         range* range = s.MakeRange();
         expr* lexp = nullptr;
@@ -1061,7 +1061,7 @@ std::vector<UHDM::range*>* CompileHelper::compileRanges(DesignComponent* compone
         }
         range->Left_expr(lexp);
         lexp->VpiParent(range);
-        if (rexp == nullptr)  
+        if (rexp == nullptr)
           rexp = dynamic_cast<expr*> (compileExpression(component, fC, rexpr, compileDesign, pexpr, instance, reduce));
         if (rexp)
           rexp->VpiParent(range);
@@ -1077,7 +1077,7 @@ std::vector<UHDM::range*>* CompileHelper::compileRanges(DesignComponent* compone
   return ranges;
 }
 
-UHDM::any* CompileHelper::compilePartSelectRange(DesignComponent* component, FileContent* fC, NodeId Constant_range, 
+UHDM::any* CompileHelper::compilePartSelectRange(DesignComponent* component, FileContent* fC, NodeId Constant_range,
                                        const std::string& name,
                                        CompileDesign* compileDesign,
                                        UHDM::any* pexpr,
@@ -1093,7 +1093,7 @@ UHDM::any* CompileHelper::compilePartSelectRange(DesignComponent* component, Fil
     UHDM::part_select* part_select = s.MakePart_select();
     part_select->Left_range(lexp);
     part_select->Right_range(rexp);
-    if (name != "") {
+    if (!name.empty()) {
       UHDM::ref_obj* ref = s.MakeRef_obj();
       ref->VpiName(name);
       part_select->VpiParent(ref);
@@ -1115,7 +1115,7 @@ UHDM::any* CompileHelper::compilePartSelectRange(DesignComponent* component, Fil
       part_select->VpiIndexedPartSelectType(vpiPosIndexed);
     else
       part_select->VpiIndexedPartSelectType(vpiNegIndexed);
-    if (name != "") {  
+    if (!name.empty()) {
       UHDM::ref_obj* ref = s.MakeRef_obj();
       ref->VpiName(name);
       part_select->VpiParent(ref);
@@ -1179,11 +1179,11 @@ static unsigned int Bits(const UHDM::typespec* typespec) {
             bits += Bits(member->Typespec());
           }
         }
-        break;  
+        break;
       }
       case UHDM::uhdmenum_typespec: {
         UHDM::enum_typespec* sts = (UHDM::enum_typespec*) typespec;
-        bits = Bits(sts->Base_typespec());   
+        bits = Bits(sts->Base_typespec());
         break;
       }
       case UHDM::uhdmunion_typespec: {
@@ -1322,7 +1322,7 @@ const typespec* CompileHelper::getTypespec(DesignComponent* component, FileConte
       Struct* st = dynamic_cast<Struct*>(dt);
       if (st) {
         result = st->getTypespec();
-        if (suffixname != "") {
+        if (!suffixname.empty()) {
           struct_typespec* tpss = (struct_typespec*) result;
           for (typespec_member* memb : *tpss->Members()) {
             if (memb->VpiName() == suffixname) {
@@ -1384,7 +1384,7 @@ UHDM::any* CompileHelper::compileBits(DesignComponent* component, FileContent* f
   UHDM::any* result = nullptr;
   NodeId typeSpecId = 0;
   switch (fC->Type(Expression)) {
-    case slIntegerAtomType_Byte: 
+    case slIntegerAtomType_Byte:
     case slIntegerAtomType_Int:
     case slIntegerAtomType_LongInt:
     case slIntegerAtomType_Shortint:
@@ -1401,7 +1401,7 @@ UHDM::any* CompileHelper::compileBits(DesignComponent* component, FileContent* f
 
   unsigned int bits = 0;
 
-  const typespec* tps = getTypespec(component, fC, typeSpecId, compileDesign, instance, reduce); 
+  const typespec* tps = getTypespec(component, fC, typeSpecId, compileDesign, instance, reduce);
   if (tps)
     bits = Bits(tps);
 

--- a/src/DesignCompile/CompileType.cpp
+++ b/src/DesignCompile/CompileType.cpp
@@ -63,9 +63,9 @@ UHDM::any* CompileHelper::compileVariable(DesignComponent* component, FileConten
   if (Packed_dimension && (fC->Type(Packed_dimension) == VObjectType::slPacked_dimension)) {
     Constant_range = fC->Child(Packed_dimension);
   }
-  if (fC->Type(Constant_range) == VObjectType::slConstant_range) { 
+  if (fC->Type(Constant_range) == VObjectType::slConstant_range) {
     ranges = s.MakeRangeVec();
-    while (Constant_range) {     
+    while (Constant_range) {
       NodeId lexpr = fC->Child(Constant_range);
       NodeId rexpr = fC->Sibling(lexpr);
       range* range = s.MakeRange();
@@ -156,7 +156,7 @@ UHDM::any* CompileHelper::compileVariable(DesignComponent* component, FileConten
 }
 
 
-UHDM::typespec* CompileHelper::compileTypespec(DesignComponent* component, FileContent* fC, NodeId type, 
+UHDM::typespec* CompileHelper::compileTypespec(DesignComponent* component, FileContent* fC, NodeId type,
         CompileDesign* compileDesign, UHDM::any* pstmt, SURELOG::ValuedComponentI* instance, bool reduce, const std::string& suffixname) {
   UHDM::Serializer& s = compileDesign->getSerializer();
   UHDM::typespec* result = nullptr;
@@ -164,7 +164,7 @@ UHDM::typespec* CompileHelper::compileTypespec(DesignComponent* component, FileC
   if (the_type == VObjectType::slData_type) {
     type = fC->Child(type);
     the_type = fC->Type(type);
-  } 
+  }
   NodeId Packed_dimension = fC->Sibling(type);
   int size;
   VectorOfrange* ranges = compileRanges(component, fC, Packed_dimension, compileDesign, pstmt, instance, reduce, size);
@@ -223,14 +223,14 @@ UHDM::typespec* CompileHelper::compileTypespec(DesignComponent* component, FileC
       result = var;
       break;
     }
-    case VObjectType::slIntVec_TypeBit: { 
-      bit_typespec* var = s.MakeBit_typespec(); 
+    case VObjectType::slIntVec_TypeBit: {
+      bit_typespec* var = s.MakeBit_typespec();
       var->Ranges(ranges);
       var->VpiFile(fC->getFileName());
       var->VpiLineNo(fC->Line(type));
       result = var;
-      break; 
-    } 
+      break;
+    }
     case VObjectType::slNonIntType_ShortReal: {
       short_real_typespec* var = s.MakeShort_real_typespec();
       var->VpiFile(fC->getFileName());
@@ -300,7 +300,7 @@ UHDM::typespec* CompileHelper::compileTypespec(DesignComponent* component, FileC
 
       bool packed = false;
       NodeId struct_or_union_member = fC->Sibling(type);
-      if (fC->Type(struct_or_union_member) == VObjectType::slPacked_keyword) {        
+      if (fC->Type(struct_or_union_member) == VObjectType::slPacked_keyword) {
         struct_or_union_member = fC->Sibling(struct_or_union_member);
         packed = true;
       }
@@ -320,7 +320,7 @@ UHDM::typespec* CompileHelper::compileTypespec(DesignComponent* component, FileC
         ts->VpiFile(fC->getFileName());
         ts->VpiLineNo(fC->Line(type));
       }
-     
+
       while (struct_or_union_member) {
         NodeId Data_type_or_void = fC->Child(struct_or_union_member);
         NodeId Data_type = fC->Child(Data_type_or_void);
@@ -354,7 +354,7 @@ UHDM::typespec* CompileHelper::compileTypespec(DesignComponent* component, FileC
           Struct* st = dynamic_cast<Struct*>(dt);
           if (st) {
             result = st->getTypespec();
-            if (suffixname != "") {
+            if (!suffixname.empty()) {
               struct_typespec* tpss = (struct_typespec*)result;
               for (typespec_member* memb : *tpss->Members()) {
                 if (memb->VpiName() == suffixname) {

--- a/src/DesignCompile/ElaborationStep.cpp
+++ b/src/DesignCompile/ElaborationStep.cpp
@@ -247,7 +247,7 @@ DataType* ElaborationStep::bindDataType_(std::string type_name, FileContent* fC,
             if (dtype) {
               result = dtype;
               found = true;
-            }            
+            }
           }
         }
       }
@@ -604,7 +604,7 @@ bool ElaborationStep::bindPortType_(Signal* signal,
       StringUtils::ltrim(modPort,'.');
       StringUtils::rtrim(baseName,'.');
     }
-      
+
     DesignComponent* def = NULL;
     DataType* type = NULL;
 
@@ -615,7 +615,7 @@ bool ElaborationStep::bindPortType_(Signal* signal,
     } else {
       std::string name = parentComponent->getName() + "::" + interfName;
       def = design->getClassDefinition(name);
-    } 
+    }
     if (def == NULL) {
       def = design->getComponentDefinition(libName + "@" + baseName);
       if (def) {
@@ -625,9 +625,9 @@ bool ElaborationStep::bindPortType_(Signal* signal,
         } else {
           def = NULL;
         }
-        if (modPort != "") {
+        if (!modPort.empty()) {
           if (module) {
-            if (ModPort* modport = module->getModPort(modPort)) {    
+            if (ModPort* modport = module->getModPort(modPort)) {
               signal->setModPort(modport);
             } else {
               def = NULL;
@@ -646,7 +646,7 @@ bool ElaborationStep::bindPortType_(Signal* signal,
       } else {
         def = NULL;
       }
-    }   
+    }
     if (def == NULL) {
       type = parentComponent->getDataType(interfName);
       signal->setDataType(type);

--- a/src/DesignCompile/NetlistElaboration.cpp
+++ b/src/DesignCompile/NetlistElaboration.cpp
@@ -62,9 +62,9 @@ NetlistElaboration::NetlistElaboration(CompileDesign* compileDesign)
   m_exprBuilder.seterrorReporting(
       m_compileDesign->getCompiler()->getErrorContainer(),
       m_compileDesign->getCompiler()->getSymbolTable());
-  m_exprBuilder.setDesign(m_compileDesign->getCompiler()->getDesign()); 
+  m_exprBuilder.setDesign(m_compileDesign->getCompiler()->getDesign());
   m_helper.seterrorReporting(m_compileDesign->getCompiler()->getErrorContainer(),
-      m_compileDesign->getCompiler()->getSymbolTable());       
+      m_compileDesign->getCompiler()->getSymbolTable());
   m_symbols = m_compileDesign->getCompiler()->getSymbolTable();
   m_errors = m_compileDesign->getCompiler()->getErrorContainer();
 }
@@ -77,7 +77,7 @@ bool NetlistElaboration::elaborate() {
   Design* design = m_compileDesign->getCompiler()->getDesign();
   std::vector<ModuleInstance*>& topModules = design->getTopLevelModuleInstances();
   for (ModuleInstance* inst : topModules) {
-    if (!elaborate_(inst)) 
+    if (!elaborate_(inst))
       return false;
   }
   return true;
@@ -91,9 +91,9 @@ bool NetlistElaboration::elaborate_(ModuleInstance* instance) {
   }
   elab_interfaces_(instance);
   elab_generates_(instance);
-  
+
   VObjectType insttype = instance->getType();
-  if ((insttype != VObjectType::slInterface_instantiation) && 
+  if ((insttype != VObjectType::slInterface_instantiation) &&
       (insttype != VObjectType::slConditional_generate_construct) &&
       (insttype != VObjectType::slLoop_generate_construct) &&
       (insttype != VObjectType::slGenerate_item) &&
@@ -107,7 +107,7 @@ bool NetlistElaboration::elaborate_(ModuleInstance* instance) {
   }
 
   high_conn_(instance);
-  
+
   for (unsigned int i = 0; i < instance->getNbChildren(); i++) {
      elaborate_(instance->getChildren(i));
   }
@@ -134,7 +134,7 @@ bool NetlistElaboration::high_conn_(ModuleInstance* instance) {
     signals = &((ModuleDefinition*) comp)->getPorts();
   } else if (compType == VObjectType::slProgram_declaration) {
     signals = &((Program*) comp)->getPorts();
-  } 
+  }
 
   if ((inst_type == VObjectType::slUdp_instantiation) ||
      (inst_type == VObjectType::slModule_instantiation) ||
@@ -167,7 +167,7 @@ bool NetlistElaboration::high_conn_(ModuleInstance* instance) {
     const std::string& instName = fC->SymName(instId);
     NodeId Net_lvalue = fC->Sibling(Name_of_instance);
     if (fC->Type(Net_lvalue) == VObjectType::slNet_lvalue) {
-      unsigned int index = 0; 
+      unsigned int index = 0;
       while (Net_lvalue) {
         std::string sigName;
         if (fC->Type(Net_lvalue) == VObjectType::slNet_lvalue) {
@@ -198,7 +198,7 @@ bool NetlistElaboration::high_conn_(ModuleInstance* instance) {
   /*
   n<TESTBENCH> u<195> t<StringConst> p<212> s<211> l<21>
   n<tb> u<196> t<StringConst> p<197> l<21>
-  n<> u<197> t<Name_of_instance> p<211> c<196> s<210> l<21> 
+  n<> u<197> t<Name_of_instance> p<211> c<196> s<210> l<21>
   n<observe> u<198> t<StringConst> p<203> s<202> l<21>
   n<o> u<199> t<StringConst> p<200> l<21>
   n<> u<200> t<Primary_literal> p<201> c<199> l<21>
@@ -223,7 +223,7 @@ bool NetlistElaboration::high_conn_(ModuleInstance* instance) {
       }
       while (Named_port_connection) {
         NodeId formalId = fC->Child(Named_port_connection);
-        if (formalId == 0) 
+        if (formalId == 0)
           break;
         if (fC->Type(formalId) == VObjectType::slExpression) {
           NodeId Expression = formalId;
@@ -242,12 +242,12 @@ bool NetlistElaboration::high_conn_(ModuleInstance* instance) {
           sigId = fC->Child(Primary_literal);
         }
         std::string sigName;
-        if (fC->Name(sigId)) 
+        if (fC->Name(sigId))
           sigName = fC->SymName(sigId);
         std::string baseName = sigName;
         std::string selectName;
         if (NodeId subId = fC->Sibling(sigId)) {
-          if (fC->Name(subId)) { 
+          if (fC->Name(subId)) {
             selectName = fC->SymName(subId);
             sigName += std::string(".") + selectName;
           }
@@ -261,16 +261,16 @@ bool NetlistElaboration::high_conn_(ModuleInstance* instance) {
             p = (*ports)[index];
           } else {
             p = s.MakePort();
-            ports->push_back(p); 
+            ports->push_back(p);
           }
         } else {
           ports = s.MakePortVec();
           netlist->ports(ports);
           p = s.MakePort();
-          ports->push_back(p);         
+          ports->push_back(p);
         }
         any* net = nullptr;
-        if (sigName != "") {
+        if (!sigName.empty()) {
           ref_obj* ref = s.MakeRef_obj();
           ref->VpiFile(fC->getFileName());
           ref->VpiLineNo(fC->Line(sigId));
@@ -348,11 +348,11 @@ bool NetlistElaboration::high_conn_(ModuleInstance* instance) {
         index++;
       }
     }
-  } 
+  }
   return true;
 }
 
-interface* NetlistElaboration::elab_interface_(ModuleInstance* instance, ModuleInstance* interf_instance, const std::string& instName,  
+interface* NetlistElaboration::elab_interface_(ModuleInstance* instance, ModuleInstance* interf_instance, const std::string& instName,
                        const std::string& defName, ModuleDefinition* mod,
                        const std::string& fileName, int lineNb) {
   Netlist* netlist = instance->getNetlist();
@@ -403,7 +403,7 @@ interface* NetlistElaboration::elab_interface_(ModuleInstance* instance, ModuleI
 }
 
 
-modport* NetlistElaboration::elab_modport_(ModuleInstance* instance, const std::string& instName,  
+modport* NetlistElaboration::elab_modport_(ModuleInstance* instance, const std::string& instName,
                        const std::string& defName, ModuleDefinition* mod,
                        const std::string& fileName, int lineNb, const std::string& modPortName) {
   Netlist* netlist = instance->getNetlist();
@@ -455,13 +455,13 @@ bool NetlistElaboration::elab_generates_(ModuleInstance* instance) {
 
       if (mm->getContAssigns())
         gen_scope->Cont_assigns(mm->getContAssigns());
-      if (mm->getProcesses())  
+      if (mm->getProcesses())
         gen_scope->Process(mm->getProcesses());
       if (mm->getParameters())
         gen_scope->Parameters(mm->getParameters());
-      if (mm->getParam_assigns())  
+      if (mm->getParam_assigns())
         gen_scope->Param_assigns(mm->getParam_assigns());
-      
+
       elab_ports_nets_(instance);
 
       gen_scope->Nets(netlist->nets());
@@ -489,7 +489,7 @@ bool NetlistElaboration::elab_interfaces_(ModuleInstance* instance) {
       }
     }
   }
- 
+
   return true;
 }
 
@@ -530,12 +530,12 @@ bool NetlistElaboration::elab_ports_nets_(ModuleInstance* instance, ModuleInstan
       if (pass == 1)
         signals = &((ModuleDefinition*) comp)->getSignals();
       else
-        signals = &((ModuleDefinition*) comp)->getPorts();  
+        signals = &((ModuleDefinition*) comp)->getPorts();
     } else if (compType == VObjectType::slProgram_declaration) {
       if (pass == 1)
         signals = &((Program*) comp)->getSignals();
-      else 
-        signals = &((Program*) comp)->getPorts(); 
+      else
+        signals = &((Program*) comp)->getPorts();
     } else {
       continue;
     }
@@ -548,7 +548,7 @@ bool NetlistElaboration::elab_ports_nets_(ModuleInstance* instance, ModuleInstan
       if (pass == 0) {
         // Ports pass
         port* dest_port = s.MakePort();
-        dest_port->VpiDirection(UhdmWriter::getVpiDirection(sig->getDirection())); 
+        dest_port->VpiDirection(UhdmWriter::getVpiDirection(sig->getDirection()));
         std::string signame = sig->getName();
         dest_port->VpiName(signame);
         dest_port->VpiLineNo(fC->Line(id));
@@ -556,7 +556,7 @@ bool NetlistElaboration::elab_ports_nets_(ModuleInstance* instance, ModuleInstan
         if (ports == nullptr) {
           ports = s.MakePortVec();
           netlist->ports(ports);
-        } 
+        }
         ports->push_back(dest_port);
 
         NodeId typeSpecId = sig->getTypeSpecId();
@@ -572,11 +572,11 @@ bool NetlistElaboration::elab_ports_nets_(ModuleInstance* instance, ModuleInstan
           Netlist::ModPortMap::iterator itr = netlist->getModPortMap().find(signame);
           if (itr == netlist->getModPortMap().end()) {
             ModuleDefinition* orig_interf = orig_modport->getParent();
-            modport* mp =  elab_modport_(instance, signame, orig_interf->getName(), orig_interf, 
+            modport* mp =  elab_modport_(instance, signame, orig_interf->getName(), orig_interf,
                         instance->getFileName(),instance->getLineNb(), orig_modport->getName());
-            ref->Actual_group(mp);            
+            ref->Actual_group(mp);
           } else {
-           ref->Actual_group((*itr).second.second); 
+           ref->Actual_group((*itr).second.second);
           }
         } else if (ModuleDefinition* orig_interf = sig->getInterfaceDef()) {
           ref_obj* ref = s.MakeRef_obj();
@@ -587,7 +587,7 @@ bool NetlistElaboration::elab_ports_nets_(ModuleInstance* instance, ModuleInstan
                  sig->getNodeId(), instance, signame, orig_interf->getName());
             Netlist* netlist = new Netlist(interfaceInstance);
             interfaceInstance->setNetlist(netlist);
-            interface* sm =  elab_interface_(instance, interfaceInstance, signame, orig_interf->getName(), orig_interf, 
+            interface* sm =  elab_interface_(instance, interfaceInstance, signame, orig_interf->getName(), orig_interf,
                         instance->getFileName(),instance->getLineNb());
             ref->Actual_group(sm);
           } else {
@@ -607,7 +607,7 @@ bool NetlistElaboration::elab_ports_nets_(ModuleInstance* instance, ModuleInstan
             netlist->variables(vars);
           }
         }
-      
+
         std::string signame = sig->getName();
         std::string parentSymbol = prefix + signame;
         int packedSize;
@@ -643,7 +643,7 @@ bool NetlistElaboration::elab_ports_nets_(ModuleInstance* instance, ModuleInstan
               if (array_nets == nullptr) {
                 array_nets = s.MakeArray_netVec();
                 netlist->array_nets(array_nets);
-              } 
+              }
 
               array_nets->push_back(array_net);
               obj->VpiParent(array_net);
@@ -654,7 +654,7 @@ bool NetlistElaboration::elab_ports_nets_(ModuleInstance* instance, ModuleInstan
               if (nets == nullptr) {
                 nets = s.MakeNetVec();
                 netlist->nets(nets);
-              } 
+              }
               if (obj->UhdmType() == uhdmenum_net) {
                 ((enum_net*)obj)->VpiName(signame);
               } else {
@@ -676,7 +676,7 @@ bool NetlistElaboration::elab_ports_nets_(ModuleInstance* instance, ModuleInstan
               if (array_nets == nullptr) {
                 array_nets = s.MakeArray_netVec();
                 netlist->array_nets(array_nets);
-              } 
+              }
               array_nets->push_back(array_net);
               logicn->VpiParent(array_net);
               UHDM::VectorOfnet* array_n = array_net->Nets();
@@ -688,16 +688,16 @@ bool NetlistElaboration::elab_ports_nets_(ModuleInstance* instance, ModuleInstan
               if (nets == nullptr) {
                 nets = s.MakeNetVec();
                 netlist->nets(nets);
-              } 
+              }
               nets->push_back(logicn);
             }
 
           }
           parentNetlist->getSymbolTable().insert(std::make_pair(parentSymbol, obj));
           netlist->getSymbolTable().insert(std::make_pair(signame, obj));
-          
+
         } else {
-          // Vars 
+          // Vars
           NodeId assignment = 0;
           if (unpackedDimension) {
             NodeId tmp = unpackedDimension;
@@ -738,10 +738,10 @@ bool NetlistElaboration::elab_ports_nets_(ModuleInstance* instance, ModuleInstan
                 enum_var* stv = s.MakeEnum_var();
                 stv->Typespec(en->getTypespec());
                 obj = stv;
-              } else if (Struct* st = dynamic_cast<Struct*>(dtype)) {              
+              } else if (Struct* st = dynamic_cast<Struct*>(dtype)) {
                 struct_var* stv = s.MakeStruct_var();
                 stv->Typespec(st->getTypespec());
-                obj = stv;              
+                obj = stv;
               } else if (Union* un = dynamic_cast<Union*>(dtype)) {
                 union_var* stv = s.MakeUnion_var();
                 stv->Typespec(un->getTypespec());
@@ -775,7 +775,7 @@ bool NetlistElaboration::elab_ports_nets_(ModuleInstance* instance, ModuleInstan
                   ((struct_var*)obj)->VpiName(signame);
                 } else if (obj->UhdmType() == uhdmunion_var) {
                   ((union_var*)obj)->VpiName(signame);
-                } 
+                }
                 vars->push_back((variables*) obj);
               }
 
@@ -798,7 +798,7 @@ bool NetlistElaboration::elab_ports_nets_(ModuleInstance* instance, ModuleInstan
         // Port low conn pass
         std::string signame = sig->getName();
         port* dest_port = (*netlist->ports())[portIndex];
- 
+
         if (any* n = bind_net_(netlist->getParent(), signame)) {
           ref_obj* ref = s.MakeRef_obj();
           ref->Actual_group(n);
@@ -811,11 +811,11 @@ bool NetlistElaboration::elab_ports_nets_(ModuleInstance* instance, ModuleInstan
           Netlist::ModPortMap::iterator itr = netlist->getModPortMap().find(signame);
           if (itr == netlist->getModPortMap().end()) {
             ModuleDefinition* orig_interf = orig_modport->getParent();
-            modport* mp =  elab_modport_(instance, signame, orig_interf->getName(), orig_interf, 
+            modport* mp =  elab_modport_(instance, signame, orig_interf->getName(), orig_interf,
                         instance->getFileName(),instance->getLineNb(), orig_modport->getName());
-            ref->Actual_group(mp);            
+            ref->Actual_group(mp);
           } else {
-           ref->Actual_group((*itr).second.second); 
+           ref->Actual_group((*itr).second.second);
           }
         } else if (ModuleDefinition* orig_interf = sig->getInterfaceDef()) {
           ref_obj* ref = s.MakeRef_obj();
@@ -826,7 +826,7 @@ bool NetlistElaboration::elab_ports_nets_(ModuleInstance* instance, ModuleInstan
                  sig->getNodeId(), instance, signame, orig_interf->getName());
             Netlist* netlist = new Netlist(interfaceInstance);
             interfaceInstance->setNetlist(netlist);
-            interface* sm =  elab_interface_(instance, interfaceInstance, signame, orig_interf->getName(), orig_interf, 
+            interface* sm =  elab_interface_(instance, interfaceInstance, signame, orig_interf->getName(), orig_interf,
                         instance->getFileName(),instance->getLineNb());
             ref->Actual_group(sm);
           } else {
@@ -887,7 +887,7 @@ any* NetlistElaboration::bind_net_(ModuleInstance* instance, const std::string& 
                return p;
               }
             }
-          }   
+          }
         } else {
           modport* mport = dynamic_cast<modport*> (baseclass);
           if (mport) {

--- a/src/DesignCompile/TestbenchElaboration.cpp
+++ b/src/DesignCompile/TestbenchElaboration.cpp
@@ -563,11 +563,11 @@ bool TestbenchElaboration::bindSubRoutineCall_(ClassDefinition* classDefinition,
     while (dtype && dtype->getDefinition()) {
       dtype = dtype->getDefinition();
     }
-    if (name == "") {
+    if (name.empty()) {
       name = "this";
     }
     std::string typeName = dtype->getName();
-    if (datatypeName != "") typeName = datatypeName;
+    if (!datatypeName.empty()) typeName = datatypeName;
     NodeId p = st->getNodeId();
     FileContent* fC = st->getFileContent();
     std::string fileName = fC->getFileName(p);

--- a/src/DesignCompile/UhdmChecker.cpp
+++ b/src/DesignCompile/UhdmChecker.cpp
@@ -14,10 +14,10 @@
  limitations under the License.
  */
 
-/* 
+/*
  * File:   UhdmChecker.cpp
  * Author: alain
- * 
+ *
  * Created on January 17, 2020, 9:13 PM
  */
 #include <map>
@@ -49,7 +49,7 @@
 #include "DesignCompile/CompileClass.h"
 #include "DesignCompile/Builtin.h"
 #include "DesignCompile/PackageAndRootElaboration.h"
-#include "Design/ModuleInstance.h" 
+#include "Design/ModuleInstance.h"
 #include "Design/Netlist.h"
 #include "Utils/FileUtils.h"
 #include "surelog.h"
@@ -83,8 +83,8 @@ bool registerFile(FileContent* fC) {
     std::map<unsigned int, int> uhdmCover;
     fileNodeCoverMap.insert(std::make_pair(fC, uhdmCover));
     fileItr = fileNodeCoverMap.find(fC);
-  } 
-  std::map<unsigned int, int>& uhdmCover = (*fileItr).second; 
+  }
+  std::map<unsigned int, int>& uhdmCover = (*fileItr).second;
 
   while (stack.size()) {
     id = stack.top();
@@ -93,9 +93,9 @@ bool registerFile(FileContent* fC) {
     bool skip = false;
     if (current.m_type == VObjectType::slEnd ||
         current.m_type == VObjectType::slEndcase ||
-        current.m_type == VObjectType::slEndtask || 
-        current.m_type == VObjectType::slEndfunction|| 
-        current.m_type == VObjectType::slEndmodule || 
+        current.m_type == VObjectType::slEndtask ||
+        current.m_type == VObjectType::slEndfunction||
+        current.m_type == VObjectType::slEndmodule ||
         current.m_type == VObjectType::slEndinterface ||
         current.m_type == VObjectType::slEndpackage ||
         current.m_type == VObjectType::slEndclocking ||
@@ -131,9 +131,9 @@ bool registerFile(FileContent* fC) {
         continue;
     }
 
-    if (current.m_sibling) 
+    if (current.m_sibling)
       stack.push(current.m_sibling);
-    if (current.m_child) 
+    if (current.m_child)
        stack.push(current.m_child);
     if (skip == false)
       uhdmCover.insert(std::make_pair(current.m_line, 0));
@@ -170,16 +170,16 @@ bool reportHtml(std::string reportFile, int overallCoverage) {
       if (str[i] == '\n') count++;
     }
 
-    std::map<unsigned int, int>& uhdmCover = (*fileItr).second;  
+    std::map<unsigned int, int>& uhdmCover = (*fileItr).second;
     int cov = 0;
     std::map<std::string, int>::iterator itr = fileCoverageMap.find(fC->getFileName());
     cov = (*itr).second;
-    std::string coverage = std::string(" Cov: ") + std::to_string(cov) + "% ";    
+    std::string coverage = std::string(" Cov: ") + std::to_string(cov) + "% ";
     std::string fileStatGreen = "<div style=\"overflow: hidden;\"> <h3 style=\"background-color: #82E0AA; margin:0; min-width: 90px; padding:10; float: left; \">" + coverage + "</h3> <h3 style=\"margin:0; padding:10; float: left; \"> <a href=" + fname + "> " + fC->getFileName() + "</a></h3></div>\n";
     std::string fileStatPink = "<div style=\"overflow: hidden;\"> <h3 style=\"background-color: #FFB6C1; margin:0; min-width: 90px; padding:10; float: left; \">" + coverage + "</h3> <h3 style=\"margin:0; padding:10; float: left; \"> <a href=" + fname + "> " + fC->getFileName() + "</a></h3></div>\n";
     std::string fileStatRed = "<div style=\"overflow: hidden;\"> <h3 style=\"background-color: #FF0000; margin:0; min-width: 90px; padding:10; float: left; \">" + coverage + "</h3> <h3 style=\"margin:0; padding:10; float: left; \"> <a href=" + fname + "> " + fC->getFileName() + "</a></h3></div>\n";
     std::string fileStatWhite = "<h3 style=\"margin:0; padding:0 \"> <a href=" + fname + ">" + fC->getFileName() + "</a> " + coverage + "</h3>\n";
-    
+
     reportF << "<h3>" << fC->getFileName() << coverage << "</h3>\n";
     bool uncovered = false;
     std::string pinkCoverage;
@@ -188,11 +188,11 @@ bool reportHtml(std::string reportFile, int overallCoverage) {
       std::string lineText = StringUtils::getLineInString(fileContent, line);
       lineText = StringUtils::replaceAll(lineText, "\n", "");
       std::map<unsigned int, int>::iterator cItr = uhdmCover.find(line);
-    
+
       if (cItr == uhdmCover.end()) {
           reportF << "<pre style=\"margin:0; padding:0 \">" << lineText << "</pre>\n";  // white
       } else {
-        if ((*cItr).second == 0) { 
+        if ((*cItr).second == 0) {
           reportF << "<pre id=\"id" << line << "\" style=\"background-color: #FFB6C1; margin:0; padding:0 \">" << lineText << "</pre>\n"; // pink
           if (uncovered == false) {
             allUncovered += "<pre></pre>\n";
@@ -202,7 +202,7 @@ bool reportHtml(std::string reportFile, int overallCoverage) {
           }
           pinkCoverage = fileStatPink;
           allUncovered +=  "<pre style=\"background-color: #FFB6C1; margin:0; padding:0 \"> <a href=" + fname + "#id" + std::to_string(line) + ">" + lineText + "</a></pre>\n";
-        } else if ((*cItr).second == -1) { 
+        } else if ((*cItr).second == -1) {
           reportF << "<pre id=\"id" << line << "\" style=\"background-color: #FF0000; margin:0; padding:0 \">" << lineText << "</pre>\n"; // red
           if (uncovered == false) {
             allUncovered += "<pre></pre>\n";
@@ -217,10 +217,10 @@ bool reportHtml(std::string reportFile, int overallCoverage) {
         }
       }
     }
-    if (redCoverage != "") {
+    if (!redCoverage.empty()) {
       orderedCoverageMap.insert(std::make_pair(cov, redCoverage));
     } else {
-      if (pinkCoverage != "") {
+      if (!pinkCoverage.empty()) {
         orderedCoverageMap.insert(std::make_pair(cov, pinkCoverage));
       }
     }
@@ -230,7 +230,7 @@ bool reportHtml(std::string reportFile, int overallCoverage) {
     reportF << "</body>\n</html>\n";
     reportF.close();
     fileIndex++;
-  }   
+  }
   for (auto covFile : orderedCoverageMap) {
     report <<  covFile.second << "\n";
   }
@@ -251,15 +251,15 @@ int reportCoverage(std::string reportFile) {
   int overallLineNb = 0;
   for (FileNodeCoverMap::iterator fileItr = fileNodeCoverMap.begin(); fileItr != fileNodeCoverMap.end(); fileItr++) {
     FileContent* fC = (*fileItr).first;
-    std::map<unsigned int, int>& uhdmCover = (*fileItr).second; 
+    std::map<unsigned int, int>& uhdmCover = (*fileItr).second;
     bool fileNamePrinted = false;
     int lineNb = 0;
-    int uncovered = 0;    
+    int uncovered = 0;
     int firstUncoveredLine = 0;
     for (std::map<unsigned int, int>::iterator cItr = uhdmCover.begin(); cItr != uhdmCover.end(); cItr++) {
       lineNb++;
       overallLineNb++;
-      if ((*cItr).second <= 0) { 
+      if ((*cItr).second <= 0) {
         if (fileNamePrinted == false) {
           firstUncoveredLine = (*cItr).first;
           report << "\n\n" << fC->getFileName() << ":" << (*cItr).first << ": " << " Missing models\n";
@@ -267,7 +267,7 @@ int reportCoverage(std::string reportFile) {
         }
         report << "Line: " <<(*cItr).first << "\n";
         uncovered++;
-        overallUncovered++; 
+        overallUncovered++;
       }
     }
     int coverage = (lineNb - uncovered) * 100 / lineNb;
@@ -296,7 +296,7 @@ void annotate(CompileDesign* m_compileDesign) {
     if (!bc)
       continue;
     bool unsupported = false;
-    if (bc->UhdmType() == uhdmunsupported_expr || bc->UhdmType() == uhdmunsupported_stmt) 
+    if (bc->UhdmType() == uhdmunsupported_expr || bc->UhdmType() == uhdmunsupported_stmt)
       unsupported  = true;
     const std::string& fn = bc->VpiFile();
     std::map<std::string, FileContent*>::iterator fItr =  fileMap.find(fn);

--- a/src/ErrorReporting/ErrorContainer.cpp
+++ b/src/ErrorReporting/ErrorContainer.cpp
@@ -84,12 +84,12 @@ Error& ErrorContainer::addError(Error& error, bool showDuplicates,
   for (std::multimap<ErrorDefinition::ErrorType, Waiver::WaiverData>::iterator
            it = ret.first;
        it != ret.second; ++it) {
-    if ((((*it).second.m_fileName == "") ||
+    if ((((*it).second.m_fileName.empty()) ||
          (m_symbolTable->getSymbol(error.m_locations[0].m_fileId) ==
           (*it).second.m_fileName)) &&
         (((*it).second.m_line == 0) ||
          (error.m_locations[0].m_line == (*it).second.m_line)) &&
-        (((*it).second.m_objectId == "") ||
+        (((*it).second.m_objectId.empty()) ||
          (m_symbolTable->getSymbol(error.m_locations[0].m_object) ==
           (*it).second.m_objectId))) {
       error.m_waived = true;
@@ -211,7 +211,7 @@ std::tuple<std::string, bool, bool> ErrorContainer::createErrorMessage(
           size_t objectOffset = text.find("%exloc");
           if (objectOffset != std::string::npos) {
             text = text.replace(objectOffset, 6, extraLocation);
-          } else if (info.m_extraText != "") {
+          } else if (!info.m_extraText.empty()) {
             text += ",\n             " + info.m_extraText;
             // text += ",\n" + info.m_extraText;
             size_t objectOffset = text.find("%exloc");
@@ -220,7 +220,7 @@ std::tuple<std::string, bool, bool> ErrorContainer::createErrorMessage(
             }
           }
         } else {
-          if (info.m_extraText != "") {
+          if (!info.m_extraText.empty()) {
             if ((nbExtraLoc == 2) && (extraLoc.m_fileId == 0))
               text += ",\n" + info.m_extraText;
             else

--- a/src/Library/ParseLibraryDef.cpp
+++ b/src/Library/ParseLibraryDef.cpp
@@ -138,9 +138,9 @@ bool ParseLibraryDef::parseLibraryDefinition(SymbolId fileId, Library* lib) {
   SVLibShapeListener* m_listener =
       new SVLibShapeListener(this, m_tokens, relativePath);
   m_fileContent = m_listener->getFileContent();
-  
+
   tree::ParseTreeWalker::DEFAULT.walk(m_listener, m_tree);
- 
+
   if (m_fileContent->getLibrary() == NULL) {
     if (lib) {
       m_fileContent->setLibrary(lib);
@@ -222,7 +222,7 @@ bool ParseLibraryDef::parseConfigDefinition() {
       if (type == slInst_clause) instName = fC->Child(instName);
       std::string instNameS;
       while (instName) {
-        if (instNameS == "")
+        if (instNameS.empty())
           instNameS = fC->SymName(instName);
         else
           instNameS += "." + fC->SymName(instName);
@@ -252,7 +252,7 @@ bool ParseLibraryDef::parseConfigDefinition() {
         } else {
           NodeId mem = use;
           while (use) {
-            if (useName == "")
+            if (useName.empty())
               useName = fC->SymName(use);
             else
               useName += "." + fC->SymName(use);
@@ -270,7 +270,7 @@ bool ParseLibraryDef::parseConfigDefinition() {
         std::string useName;
         NodeId mem = use;
         while (use) {
-          if (useName == "")
+          if (useName.empty())
             useName = fC->SymName(use);
           else
             useName += "@" + fC->SymName(use);

--- a/src/SourceCompile/AnalyzeFile.cpp
+++ b/src/SourceCompile/AnalyzeFile.cpp
@@ -375,8 +375,8 @@ void AnalyzeFile::analyze() {
             }
             inPrimitive = false;
           }
-          if (keyword != "") {
-            if (prev_keyword != "") {
+          if (!keyword.empty()) {
+            if (!prev_keyword.empty()) {
               prev_prev_keyword = prev_keyword;
             }
             prev_keyword = keyword;

--- a/src/SourceCompile/AntlrParserErrorListener.cpp
+++ b/src/SourceCompile/AntlrParserErrorListener.cpp
@@ -46,14 +46,14 @@ void AntlrParserErrorListener::syntaxError(Recognizer *recognizer,
     m_barked = true;
     return;
   }
-  if (m_fileContent == "") {
+  if (m_fileContent.empty()) {
     m_fileContent = FileUtils::getFileContent(m_fileName);
   }
 
   std::string lineText;
-  if (m_fileContent != "") {
+  if (!m_fileContent.empty()) {
     lineText = StringUtils::getLineInString(m_fileContent, line);
-    if (lineText != "") {
+    if (!lineText.empty()) {
       if (!strstr(lineText.c_str(), "\n")) {
         lineText += "\n";
       }

--- a/src/SourceCompile/CheckCompile.cpp
+++ b/src/SourceCompile/CheckCompile.cpp
@@ -72,7 +72,7 @@ bool CheckCompile::mergeSymbolTables_() {
 bool CheckCompile::checkTimescale_() {
   std::string globaltimescale =
       m_compiler->getCommandLineParser()->getTimeScale();
-  if (globaltimescale != "") {
+  if (!globaltimescale.empty()) {
     Location loc(0, 0, 0,
                  m_compiler->getSymbolTable()->registerSymbol(globaltimescale));
     Error err(ErrorDefinition::CMD_USING_GLOBAL_TIMESCALE, loc);

--- a/src/SourceCompile/Compiler.cpp
+++ b/src/SourceCompile/Compiler.cpp
@@ -262,7 +262,7 @@ bool Compiler::createFileList_()
   }
   return true;
 }
- 
+
 bool Compiler::createMultiProcess_() {
   unsigned int nbProcesses = m_commandLineParser->getNbMaxProcesses();
   if (nbProcesses == 0)
@@ -319,20 +319,20 @@ bool Compiler::createMultiProcess_() {
         jobSize[newJobIndex] += size;
         jobArray[newJobIndex].push_back(m_compilers[i]);
       }
-      
+
       std::string full_exe_path = m_commandLineParser->getExePath();
       full_exe_path = FileUtils::getFullPath(full_exe_path);
       if (m_commandLineParser->profile()) {
         full_exe_path += " -profile";
       }
-        
+
       std::string fileUnit = "";
       if (m_commandLineParser->fileunit())
         fileUnit = " -fileunit ";
-     
+
       std::vector<std::string > targets;
       int absoluteIndex = 0;
-      
+
       // Big jobs
       for (CompileSourceFile* compiler : bigJobs) {
         absoluteIndex++;
@@ -344,12 +344,12 @@ bool Compiler::createMultiProcess_() {
         ofs <<"  COMMAND " << full_exe_path << fileUnit <<
                             " -parseonly -mt 0 -mp 0 -nostdout -nobuiltin -l "
                            <<  directory + FileUtils::fileName(targetname) + ".log" << " " << fileName << std::endl;
-        ofs << ")" << std::endl;  
+        ofs << ")" << std::endl;
       }
-        
+
       // Small jobs batch in clump processes
-      for (unsigned short i = 0; i < nbProcesses; i++) {  
-        std::string fileList; 
+      for (unsigned short i = 0; i < nbProcesses; i++) {
+        std::string fileList;
         std::string lastFile;
         absoluteIndex++;
         for (unsigned int j = 0; j < jobArray[i].size(); j++) {
@@ -358,24 +358,24 @@ bool Compiler::createMultiProcess_() {
                                         compiler->getPpOutputFileId());
           fileList += " " + fileName;
           lastFile = fileName;
-        } 
-        if (fileList != "") {
+        }
+        if (!fileList.empty()) {
           std::string targetname = std::to_string(absoluteIndex) + "_" + FileUtils::fileName(lastFile);
           targets.push_back(targetname);
           ofs << "add_custom_command(OUTPUT " << targetname << std::endl;
           ofs << "  COMMAND " << full_exe_path << fileUnit <<
                   " -parseonly -mt 0 -mp 0 -nostdout -nobuiltin -l "
                   << directory + FileUtils::fileName(targetname) + ".log" << " " << fileList << std::endl;
-          ofs << ")" << std::endl; 
+          ofs << ")" << std::endl;
         }
       }
-            
-      ofs << "add_custom_target(Parse ALL DEPENDS" << std::endl; 
+
+      ofs << "add_custom_target(Parse ALL DEPENDS" << std::endl;
       for (auto target : targets) {
-        ofs << target << std::endl;  
+        ofs << target << std::endl;
       }
-      ofs << ")" << std::endl; 
-      ofs << std::flush;      
+      ofs << ")" << std::endl;
+      ofs << std::flush;
       ofs.close();
       std::string command = "cd " + directory + ";" + "cmake .; make -j " + std::to_string(nbProcesses);
       std::cout << "Running: " << command << std::endl << std::flush;
@@ -385,17 +385,17 @@ bool Compiler::createMultiProcess_() {
       std::cout << "Could not create CMakeLists.txt: " << fileList << std::endl;
     }
   }
-  
-  
+
+
   return true;
 }
-  
+
 bool Compiler::parseinit_() {
   Precompiled* prec = Precompiled::getSingleton();
   // Single out the large files.
   // Small files are going to be scheduled in multiple threads based on size.
   // Large files are going to be compiled in a different batch in multithread
-  
+
   if (!m_commandLineParser->fileunit()) {
     unsigned int size = m_symbolTables.size();
     for (unsigned int i = 0; i < size; i++) {
@@ -427,7 +427,7 @@ bool Compiler::parseinit_() {
       effectiveNbThreads = (int) (log(((float) nbThreads + 1.0) / 4.0) * 10.0);
     else
       effectiveNbThreads = nbThreads;
-    
+
     AnalyzeFile* fileAnalyzer = new AnalyzeFile(
         m_commandLineParser, m_design, fileName, origFile, effectiveNbThreads);
     fileAnalyzer->analyze();

--- a/src/SourceCompile/PreprocessFile.cpp
+++ b/src/SourceCompile/PreprocessFile.cpp
@@ -63,7 +63,7 @@ void PreprocessFile::setDebug(int level) {
       m_debugPPTokens = false;
       m_debugPPTree = false;
       m_debugMacro = false;
-      m_debugAstModel = false;   
+      m_debugAstModel = false;
       break;
     case 1:
       m_debugPP = false;
@@ -71,8 +71,8 @@ void PreprocessFile::setDebug(int level) {
       m_debugPPTokens = false;
       m_debugPPTree = false;
       m_debugMacro = false;
-      m_debugAstModel = true;   
-      break;  
+      m_debugAstModel = true;
+      break;
     case 2:
       m_debugPP = true;
       m_debugPPResult = false;
@@ -152,14 +152,14 @@ void PreprocessFile::DescriptiveErrorListener::syntaxError(
     Error err(ErrorDefinition::PP_MACRO_SYNTAX_ERROR, loc, extraLoc);
     m_pp->addError(err);
   } else {
-    if (m_fileContent == "") {
+    if (m_fileContent.empty()) {
       m_fileContent = FileUtils::getFileContent(m_fileName);
     }
 
     std::string lineText;
-    if (m_fileContent != "") {
+    if (!m_fileContent.empty()) {
       lineText = StringUtils::getLineInString(m_fileContent, line);
-      if (lineText != "") {
+      if (!lineText.empty()) {
         if (!strstr(lineText.c_str(), "\n")) {
           lineText += "\n";
         }
@@ -214,7 +214,7 @@ PreprocessFile::PreprocessFile(SymbolId fileId, CompileSourceFile* csf,
       m_fileContent(NULL),
       m_verilogVersion(VerilogVersion::NoVersion) {
   setDebug(m_compileSourceFile->m_commandLineParser->getDebugLevel());
-  IncludeFileInfo info(0, m_fileId, 0, 2); 
+  IncludeFileInfo info(0, m_fileId, 0, 2);
   info.m_indexClosing = 0;
   info.m_indexOpening = 0;
   getIncludeFileInfo().push_back(info);
@@ -299,7 +299,7 @@ bool PreprocessFile::preprocess() {
   std::string root = FileUtils::fileName(fileName);
   bool precompiled = false;
   if (prec->isFilePrecompiled(root)) precompiled = true;
-  
+
   Timer tmr;
   PPCache cache(this);
   if (cache.restore()) {
@@ -314,11 +314,11 @@ bool PreprocessFile::preprocess() {
     return true;
 
   m_antlrParserHandler = getCompileSourceFile()->getAntlrPpHandlerForId(
-      (m_macroBody == "") ? m_fileId : getMacroSignature());
+    (m_macroBody.empty()) ? m_fileId : getMacroSignature());
 
   if (m_antlrParserHandler == NULL) {
     m_antlrParserHandler = new AntlrParserHandler();
-    if (m_macroBody != "") {
+    if (!m_macroBody.empty()) {
       if (m_debugPP) {
         std::cout << "PP PREPROCESS MACRO: " << m_macroBody << endl;
       }
@@ -369,7 +369,7 @@ bool PreprocessFile::preprocess() {
     }
     m_antlrParserHandler->m_errorListener =
         new PreprocessFile::DescriptiveErrorListener(
-            this, (m_macroBody == "") ? fileName : "in macro " + fileName);
+          this, (m_macroBody.empty()) ? fileName : "in macro " + fileName);
     m_antlrParserHandler->m_pplexer =
         new SV3_1aPpLexer(m_antlrParserHandler->m_inputStream);
     m_antlrParserHandler->m_pplexer->removeErrorListeners();
@@ -384,7 +384,7 @@ bool PreprocessFile::preprocess() {
       // + " " + fileName + "\n";
       tmr.reset();
     }
-    
+
     if (m_debugPPTokens) {
       std::cout << "PP TOKENS: " << std::endl;
       for (auto token : m_antlrParserHandler->m_pptokens->getTokens()) {
@@ -409,7 +409,7 @@ bool PreprocessFile::preprocess() {
                 " " + fileName + "\n";
         tmr.reset();
       }
-      
+
     } catch (ParseCancellationException& pex) {
       m_antlrParserHandler->m_pptokens->reset();
       m_antlrParserHandler->m_ppparser->reset();
@@ -439,20 +439,20 @@ bool PreprocessFile::preprocess() {
                 << std::endl;
 
     getCompileSourceFile()->registerAntlrPpHandlerForId(
-        (m_macroBody == "") ? m_fileId : getMacroSignature(),
-        m_antlrParserHandler);
+      (m_macroBody.empty()) ? m_fileId : getMacroSignature(),
+      m_antlrParserHandler);
   }
   m_result = "";
   if (m_listener != NULL)
     delete m_listener;
-  m_listener = new SV3_1aPpTreeShapeListener(this, 
+  m_listener = new SV3_1aPpTreeShapeListener(this,
             m_antlrParserHandler->m_pptokens,
             m_instructions);
   tree::ParseTreeWalker::DEFAULT.walk(m_listener,
                                       m_antlrParserHandler->m_pptree);
   if (m_debugAstModel && !precompiled)
      std::cout << m_fileContent->printObjects();
-     
+
   return true;
 }
 
@@ -1087,7 +1087,7 @@ std::string PreprocessFile::getPreProcessedFileContent() {
   if (m_debugPPResult) {
     const std::string fileName = getSymbol(m_fileId);
     std::string objName =
-        (m_macroBody != "") ? "macro " + m_macroBody : "file " + fileName;
+      (!m_macroBody.empty()) ? "macro " + m_macroBody : "file " + fileName;
     std::cout << "PP RESULT for " << objName
               << " : \nvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv\n"
               << m_result << "\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n"
@@ -1118,14 +1118,14 @@ void PreprocessFile::collectIncludedFiles(std::set<PreprocessFile*>& included) {
 void PreprocessFile::saveCache() {
    if (getCompileSourceFile()->getCommandLineParser()->parseOnly())
     return;
-  if (m_macroBody == "") {
-    if (!m_usingCachedVersion) {
-      PPCache cache(this);
-      cache.save();
-    }
-  }
-  for (std::vector<PreprocessFile*>::iterator itr = m_includes.begin();
-       itr != m_includes.end(); itr++) {
-    (*itr)->saveCache();
-  }
+   if (m_macroBody.empty()) {
+     if (!m_usingCachedVersion) {
+       PPCache cache(this);
+       cache.save();
+     }
+   }
+   for (std::vector<PreprocessFile*>::iterator itr = m_includes.begin();
+        itr != m_includes.end(); itr++) {
+     (*itr)->saveCache();
+   }
 }

--- a/src/SourceCompile/PreprocessFile.h
+++ b/src/SourceCompile/PreprocessFile.h
@@ -59,7 +59,7 @@ class PreprocessFile {
  public:
   class SpecialInstructions;
   class DescriptiveErrorListener;
-  
+
   /* Constructors */
   PreprocessFile(SymbolId fileId, CompileSourceFile* csf,
                  SpecialInstructions& instructions,
@@ -96,7 +96,7 @@ class PreprocessFile {
                        SymbolId embeddedMacroCallFile = 0);
   bool deleteMacro(const std::string name, std::set<PreprocessFile*>& visited);
   void undefineAllMacros(std::set<PreprocessFile*>& visited);
-  bool isMacroBody() { return (m_macroBody != ""); }
+  bool isMacroBody() { return !m_macroBody.empty(); }
   std::string getMacroBody() { return m_macroBody; }
   MacroInfo* getMacroInfo() { return m_macroInfo; }
   SymbolId getMacroSignature();
@@ -296,11 +296,11 @@ class PreprocessFile {
   LoopCheck m_loopChecker;
 
   void setFileContent(FileContent* content) { m_fileContent = content; }
-  FileContent* getFileContent() { return m_fileContent; } 
-  
+  FileContent* getFileContent() { return m_fileContent; }
+
   void setVerilogVersion(VerilogVersion version) { m_verilogVersion = version; }
-  VerilogVersion getVerilogVersion() { return m_verilogVersion; } 
-  
+  VerilogVersion getVerilogVersion() { return m_verilogVersion; }
+
   // For cache processing
   void saveCache();
   void collectIncludedFiles(std::set<PreprocessFile*>& included);

--- a/src/SourceCompile/SV3_1aPpTreeShapeListener.cpp
+++ b/src/SourceCompile/SV3_1aPpTreeShapeListener.cpp
@@ -41,7 +41,7 @@ using namespace antlr4;
 
 #include "SourceCompile/SV3_1aPpTreeShapeListener.h"
 
-SV3_1aPpTreeShapeListener::SV3_1aPpTreeShapeListener(PreprocessFile* pp, 
+SV3_1aPpTreeShapeListener::SV3_1aPpTreeShapeListener(PreprocessFile* pp,
         antlr4::CommonTokenStream* tokens,
         PreprocessFile::SpecialInstructions& instructions) :
 	SV3_1aPpTreeListenerHelper::SV3_1aPpTreeListenerHelper(pp, instructions) {
@@ -107,13 +107,13 @@ void SV3_1aPpTreeShapeListener::enterNumber(
   }
 }
 
-void SV3_1aPpTreeShapeListener::exitDescription(SV3_1aPpParser::DescriptionContext * ctx) { 
+void SV3_1aPpTreeShapeListener::exitDescription(SV3_1aPpParser::DescriptionContext * ctx) {
   if (ctx->text_blob()) {
     if (ctx->text_blob()->CR())
       addVObject (ctx, VObjectType::slText_blob);
     else if (ctx->text_blob()->Spaces())
       addVObject (ctx, VObjectType::slText_blob);
-    else 
+    else
       addVObject (ctx, ctx->getText(), VObjectType::slText_blob);
   } else {
     addVObject (ctx, ctx->getText(), VObjectType::slDescription);
@@ -127,48 +127,48 @@ void SV3_1aPpTreeShapeListener::exitComments(SV3_1aPpParser::CommentsContext * c
             (!(m_filterProtectedRegions && m_inProtectedRegion)) &&
             (!m_inMacroDefinitionParsing)) {
       if (ctx->Block_comment()) {
-        addVObject (ctx, ctx->Block_comment()->getText(), VObjectType::slComments);  
+        addVObject (ctx, ctx->Block_comment()->getText(), VObjectType::slComments);
       } else if (ctx->One_line_comment()) {
-        addVObject (ctx, ctx->One_line_comment()->getText(), VObjectType::slComments); 
+        addVObject (ctx, ctx->One_line_comment()->getText(), VObjectType::slComments);
       }
     }
   }
 }
-  
-void SV3_1aPpTreeShapeListener::exitNumber(SV3_1aPpParser::NumberContext * ctx) {  
+
+void SV3_1aPpTreeShapeListener::exitNumber(SV3_1aPpParser::NumberContext * ctx) {
  if (m_inActiveBranch &&
           (!(m_filterProtectedRegions && m_inProtectedRegion))) {
     if (!m_inMacroDefinitionParsing) {
       std::string text = ctx->Number()->getText();
-      addVObject (ctx, text, VObjectType::slNumber);       
+      addVObject (ctx, text, VObjectType::slNumber);
     }
  }
 }
 
-void SV3_1aPpTreeShapeListener::exitEscaped_macro_definition_body(SV3_1aPpParser::Escaped_macro_definition_bodyContext * ctx) { 
-  addVObject (ctx, ctx->getText(), VObjectType::slText_blob); 
+void SV3_1aPpTreeShapeListener::exitEscaped_macro_definition_body(SV3_1aPpParser::Escaped_macro_definition_bodyContext * ctx) {
+  addVObject (ctx, ctx->getText(), VObjectType::slText_blob);
 }
 
 void SV3_1aPpTreeShapeListener::exitSimple_macro_definition_body(SV3_1aPpParser::Simple_macro_definition_bodyContext * ctx) {
-  addVObject (ctx, ctx->getText(), VObjectType::slText_blob); 
+  addVObject (ctx, ctx->getText(), VObjectType::slText_blob);
 }
 
-void SV3_1aPpTreeShapeListener::exitPragma_expression(SV3_1aPpParser::Pragma_expressionContext * ctx) { 
-  addVObject (ctx, ctx->getText(), VObjectType::slPragma_expression); 
+void SV3_1aPpTreeShapeListener::exitPragma_expression(SV3_1aPpParser::Pragma_expressionContext * ctx) {
+  addVObject (ctx, ctx->getText(), VObjectType::slPragma_expression);
 }
 
-void SV3_1aPpTreeShapeListener::exitMacro_arg(SV3_1aPpParser::Macro_argContext * ctx) { 
-  addVObject (ctx, ctx->getText(), VObjectType::slText_blob); 
+void SV3_1aPpTreeShapeListener::exitMacro_arg(SV3_1aPpParser::Macro_argContext * ctx) {
+  addVObject (ctx, ctx->getText(), VObjectType::slText_blob);
 }
 
-void SV3_1aPpTreeShapeListener::exitString_blob(SV3_1aPpParser::String_blobContext * ctx) { 
-  addVObject (ctx, ctx->getText(), VObjectType::slString); 
+void SV3_1aPpTreeShapeListener::exitString_blob(SV3_1aPpParser::String_blobContext * ctx) {
+  addVObject (ctx, ctx->getText(), VObjectType::slString);
 }
 
-void SV3_1aPpTreeShapeListener::exitDefault_value(SV3_1aPpParser::Default_valueContext * ctx) { 
-  addVObject (ctx, ctx->getText(), VObjectType::slText_blob); 
+void SV3_1aPpTreeShapeListener::exitDefault_value(SV3_1aPpParser::Default_valueContext * ctx) {
+  addVObject (ctx, ctx->getText(), VObjectType::slText_blob);
 }
- 
+
 
 void SV3_1aPpTreeShapeListener::enterUnterminated_string(
         SV3_1aPpParser::Unterminated_stringContext *ctx)
@@ -282,7 +282,7 @@ void SV3_1aPpTreeShapeListener::enterInclude_directive(
       }
     }
     std::string pp_result = pp->getPreProcessedFileContent();
-    if (pp_result != "") m_pp->append(pre + pp_result + post);
+    if (!pp_result.empty()) m_pp->append(pre + pp_result + post);
     if (ctx->macro_instance()) {
       m_append_paused_context = ctx;
       m_pp->pauseAppend();
@@ -317,7 +317,7 @@ void SV3_1aPpTreeShapeListener::exitInclude_directive(
     addVObject((ParserRuleContext*) ctx->String(), text, VObjectType::slString);
   }
   addVObject(ctx, VObjectType::slInclude_statement);
-  
+
 }
 
 void SV3_1aPpTreeShapeListener::enterSimple_no_args_macro_definition(
@@ -518,7 +518,7 @@ void SV3_1aPpTreeShapeListener::enterMacroInstanceNoArgs(
     if (m_pp->m_debugMacro)
       std::cout << "FIND MACRO: " << macroName << ", BODY: |" << macroBody
             << "|" << std::endl;
-    if ((macroBody == "") && m_instructions.m_mark_empty_macro) {
+    if (macroBody.empty() && m_instructions.m_mark_empty_macro) {
       macroBody = SymbolTable::getEmptyMacroMarker();
     }
     if (macroBody == PreprocessFile::MacroNotDefined) {

--- a/src/Utils/StringUtils.cpp
+++ b/src/Utils/StringUtils.cpp
@@ -341,7 +341,7 @@ void StringUtils::autoExpandEnvironmentVariables(std::string & text)
       if (itr != envVars.end())
         var = (*itr).second;
     }
-    if ((var == "") && s)
+    if (var.empty() && s)
       var = s;
     text.replace( match.position(0), match.length(0), var );
   }
@@ -354,7 +354,7 @@ void StringUtils::autoExpandEnvironmentVariables(std::string & text)
       if (itr != envVars.end())
         var = (*itr).second;
     }
-    if ((var == "") && s)
+    if (var.empty() && s)
       var = s;
     text.replace( match.position(0), match.length(0), var );
   }

--- a/src/hellouhdm.cpp
+++ b/src/hellouhdm.cpp
@@ -35,7 +35,7 @@ int main(int argc, const char** argv) {
   SURELOG::SymbolTable* symbolTable = new SURELOG::SymbolTable();
   SURELOG::ErrorContainer* errors = new SURELOG::ErrorContainer(symbolTable);
   SURELOG::CommandLineParser* clp =
-      new SURELOG::CommandLineParser(errors, symbolTable, false, false);  
+      new SURELOG::CommandLineParser(errors, symbolTable, false, false);
   clp->noPython();
   clp->setParse(true);
   clp->setwritePpOutput(true);
@@ -59,10 +59,10 @@ int main(int argc, const char** argv) {
 
   // Browse the UHDM Data Model using the IEEE VPI API.
   // See third_party/Verilog_Object_Model.pdf
-  
+
   // Either use the
   // - C IEEE API, (See third_party/UHDM/tests/test_helper.h)
-  // - or C++ UHDM API (See third_party/UHDM/headers/*.h) 
+  // - or C++ UHDM API (See third_party/UHDM/headers/*.h)
   // - Listener design pattern (See third_party/UHDM/tests/test_listener.cpp)
   // - Walker design pattern (See third_party/UHDM/src/vpi_visitor.cpp)
 
@@ -78,7 +78,7 @@ int main(int argc, const char** argv) {
     result +=
         "Design name (VPI): " + std::string(vpi_get_str(vpiName, the_design)) + "\n";
     // Flat Module list:
-    result += "Module List:\n";    
+    result += "Module List:\n";
     vpiHandle modItr = vpi_iterate(UHDM::uhdmallModules, the_design);
     while (vpiHandle obj_h = vpi_scan(modItr)) {
       if (vpi_get(vpiType, obj_h) != vpiModule) {
@@ -90,7 +90,7 @@ int main(int argc, const char** argv) {
         defName = s;
       }
       if (const char* s = vpi_get_str(vpiName, obj_h)) {
-        if (defName != "") {
+        if (!defName.empty()) {
           defName += " ";
         }
         objectName = std::string("(") + s + std::string(")");
@@ -112,7 +112,7 @@ int main(int argc, const char** argv) {
       vpiHandle assignItr = vpi_iterate(vpiContAssign, obj_h);
       while (vpiHandle sub_h = vpi_scan(assignItr)) {
         result += "\n    \\_ assign stmt, file:" + std::string(vpi_get_str(vpiFile, sub_h)) +
-            ", line:" + std::to_string(vpi_get(vpiLineNo, sub_h));    
+            ", line:" + std::to_string(vpi_get(vpiLineNo, sub_h));
       }
       vpi_release_handle(assignItr);
       // ...
@@ -125,7 +125,7 @@ int main(int argc, const char** argv) {
 
     // Instance tree:
     // Instance tree (all sizes evaluated) contains instances, elaborated nets (with ranges)
-    result += "Instance Tree:\n";    
+    result += "Instance Tree:\n";
     vpiHandle instItr = vpi_iterate(UHDM::uhdmtopModules, the_design);
     while (vpiHandle obj_h = vpi_scan(instItr)) {
       std::function<std::string(vpiHandle,  std::string)> inst_visit =
@@ -137,7 +137,7 @@ int main(int argc, const char** argv) {
           defName = s;
         }
         if (const char* s = vpi_get_str(vpiName, obj_h)) {
-          if (defName != "") {
+          if (!defName.empty()) {
             defName += " ";
           }
           objectName = std::string("(") + s + std::string(")");
@@ -147,7 +147,7 @@ int main(int argc, const char** argv) {
           ", file:" + std::string(vpi_get_str(vpiFile, obj_h)) +
           ", line:" + std::to_string(vpi_get(vpiLineNo, obj_h)) + "\n";
         // ...
-        // Iterate thru ports/nets/low conn/high conn  
+        // Iterate thru ports/nets/low conn/high conn
         // ...
 
         // Recursive tree traversal

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,12 +1,12 @@
 /*
  Copyright 2019 Alain Dargelas
- 
+
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
- 
+
  http://www.apache.org/licenses/LICENSE-2.0
- 
+
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,7 +14,7 @@
  limitations under the License.
  */
 
-/* 
+/*
  * File:   main.cpp
  * Author: alain
  *
@@ -40,7 +40,7 @@
 #include "API/PythonAPI.h"
 #include "Utils/StringUtils.h"
 
-unsigned int executeCompilation(int argc, const char ** argv, bool diff_comp_mode, 
+unsigned int executeCompilation(int argc, const char ** argv, bool diff_comp_mode,
                                 bool fileunit, SURELOG::ErrorContainer::Stats* overallStats = NULL)
 {
   bool success = true;
@@ -67,7 +67,7 @@ unsigned int executeCompilation(int argc, const char ** argv, bool diff_comp_mod
           }
         }
 
-      SURELOG::scompiler* compiler = SURELOG::start_compiler(clp);  
+      SURELOG::scompiler* compiler = SURELOG::start_compiler(clp);
       if (!compiler)
         codedReturn |= 1;
       SURELOG::shutdown_compiler(compiler);
@@ -91,9 +91,9 @@ unsigned int executeCompilation(int argc, const char ** argv, bool diff_comp_mod
   if (noFErrors == false) {
      noFatalErrors = false;
   }
-  
+
   std::string ext_command = clp->getExeCommand();
-  if (ext_command != "") {
+  if (!ext_command.empty()) {
     std::string directory = symbolTable->getSymbol(clp->getFullCompileDir());
     std::string fileList = directory + "/file.lst";
     std::string command = ext_command + " " + fileList;
@@ -102,12 +102,12 @@ unsigned int executeCompilation(int argc, const char ** argv, bool diff_comp_mod
     std::cout << "Command result: " << result << std::endl;
   }
   clp->logFooter();
-  if (diff_comp_mode && fileunit) 
+  if (diff_comp_mode && fileunit)
     {
        SURELOG::Report* report = new SURELOG::Report();
        std::pair<bool, bool> results = report->makeDiffCompUnitReport(clp, symbolTable );
        success = results.first;
-       noFatalErrors = results.second; 
+       noFatalErrors = results.second;
        delete report;
     }
   delete clp;
@@ -117,8 +117,8 @@ unsigned int executeCompilation(int argc, const char ** argv, bool diff_comp_mod
     codedReturn |= 1;
   if (parseOnly)
     return 0;
-  else 
-    return codedReturn;  
+  else
+    return codedReturn;
 }
 enum COMP_MODE {
     NORMAL,
@@ -164,7 +164,7 @@ int batchCompilation(const char* argv0, std::string batchFile)
     if (ret < 0) {
       std::cout << "Could not change directory to " << path << "\n" << std::endl;
       returnCode |= 1;
-    }    
+    }
   }
   std::cout << "Processed " << count << " tests." << std::endl << std::flush;
   SURELOG::SymbolTable* symbolTable = new SURELOG::SymbolTable ();
@@ -182,7 +182,7 @@ int main(int argc, const char ** argv) {
   unsigned int codedReturn = 0;
   COMP_MODE mode = NORMAL;
   bool python_mode = true;
-  
+
   std::string batchFile;
   std::string diff_unit_opt = "-diffcompunit";
   std::string nopython_opt  = "-nopython";
@@ -246,5 +246,3 @@ int main(int argc, const char ** argv) {
     SURELOG::PythonAPI::shutdown();
   return codedReturn;
 }
-
-


### PR DESCRIPTION
String comparison against "" (foo == "" or foo != "") is expensive
and can lead to subtle bugs (if foo is a const char* instead of
std::string). Let's be explicit (and slightly faster) by using
.empty() instead.

Signed-off-by: Henner Zeller <h.zeller@acm.org>