### PR TITLE
Cache: remove unnecessary virtual. Typedef a particular long type.

### DIFF
--- a/src/Cache/Cache.h
+++ b/src/Cache/Cache.h
@@ -1,18 +1,18 @@
 /*
- Copyright 2019 Alain Dargelas
+  Copyright 2019 Alain Dargelas
 
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
 
- http://www.apache.org/licenses/LICENSE-2.0
+  http://www.apache.org/licenses/LICENSE-2.0
 
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
- */
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 
 /*
  * File:   Cache.h
@@ -30,14 +30,17 @@
 
 namespace SURELOG {
 
+// A cache class used as a base for various other cashes persisting
+// things in flatbuffers.
+// All methods are protected as they are ment for derived classes to use.
 class Cache {
- public:
+protected:
+  using VectorOffsetError = flatbuffers::Vector<
+    flatbuffers::Offset<SURELOG::CACHE::Error>>;
+  using VectorOffsetString = flatbuffers::Vector<
+    flatbuffers::Offset<flatbuffers::String>>;
 
-  Cache();
-
-  Cache(const Cache& orig);
-
-  virtual ~Cache();
+  Cache() = default;
 
   time_t get_mtime(const char* path);
 
@@ -53,38 +56,36 @@ class Cache {
                            std::string cacheFileName);
 
   const flatbuffers::Offset<SURELOG::CACHE::Header> createHeader(
-      flatbuffers::FlatBufferBuilder& builder, std::string schemaVersion,
-      std::string origFileName);
-  
-  std::pair<flatbuffers::Offset<flatbuffers::Vector<
-            flatbuffers::Offset<SURELOG::CACHE::Error>>>,
-            flatbuffers::Offset<
-            flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>>>
+    flatbuffers::FlatBufferBuilder& builder, std::string schemaVersion,
+    std::string origFileName);
+
+  std::pair<flatbuffers::Offset<VectorOffsetError>,
+            flatbuffers::Offset<VectorOffsetString>>
   cacheErrors(flatbuffers::FlatBufferBuilder& builder,
               SymbolTable& canonicalSymbols, ErrorContainer* errorContainer,
               SymbolTable* symbols, SymbolId subjectId);
 
   void restoreErrors(
-      const flatbuffers::Vector<flatbuffers::Offset<SURELOG::CACHE::Error>>*
-          errorsBuf,
-      const flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>*
-          symbolBuf,
-      SymbolTable& canonicalSymbols, ErrorContainer* errorContainer,
-      SymbolTable* symbols);
-  
-  std::vector<CACHE::VObject> 
-        cacheVObjects(FileContent* fcontent, SymbolTable& canonicalSymbols, 
-               SymbolTable& fileTable, SymbolId fileId);
-  
- void restoreVObjects(const flatbuffers::Vector<const SURELOG::CACHE::VObject*>* 
-        objects,
-        SymbolTable& canonicalSymbols, 
-        SymbolTable& fileTable, 
-        SymbolId fileId, 
-        FileContent* fileContent);
-  
+    const VectorOffsetError* errorsBuf,
+    const VectorOffsetString* symbolBuf,
+    SymbolTable& canonicalSymbols, ErrorContainer* errorContainer,
+    SymbolTable* symbols);
+
+  std::vector<CACHE::VObject>
+  cacheVObjects(FileContent* fcontent, SymbolTable& canonicalSymbols,
+                SymbolTable& fileTable, SymbolId fileId);
+
+  void restoreVObjects(
+    const flatbuffers::Vector<const SURELOG::CACHE::VObject*>* objects,
+    SymbolTable& canonicalSymbols,
+    SymbolTable& fileTable,
+    SymbolId fileId,
+    FileContent* fileContent);
+
+private:
+  Cache(const Cache& orig) = delete;
 };
 
-};  // namespace SURELOG
+}  // namespace SURELOG
 
 #endif /* CACHE_H */

--- a/src/Cache/PPCache.cpp
+++ b/src/Cache/PPCache.cpp
@@ -42,10 +42,6 @@ using namespace SURELOG;
 
 PPCache::PPCache(PreprocessFile* pp) : m_pp(pp), m_isPrecompiled(false) {}
 
-PPCache::PPCache(const PPCache& orig) {}
-
-PPCache::~PPCache() {}
-
 static std::string FlbSchemaVersion = "1.0";
 
 std::string PPCache::getCacheFileName_(std::string svFileName) {

--- a/src/Cache/PPCache.h
+++ b/src/Cache/PPCache.h
@@ -34,19 +34,21 @@ namespace SURELOG {
 class PPCache : Cache {
  public:
   PPCache(PreprocessFile* pp);
-  PPCache(const PPCache& orig);
+
   bool restore();
   bool save();
-  ~PPCache() override;
 
  private:
-  PreprocessFile* m_pp;
+  PPCache(const PPCache& orig) = delete;
+
   std::string getCacheFileName_(std::string fileName = "");
   bool restore_(std::string cacheFileName);
   bool checkCacheIsValid_(std::string cacheFileName);
+
+  PreprocessFile* m_pp;
   bool m_isPrecompiled;
 };
 
-};  // namespace SURELOG
+}  // namespace SURELOG
 
 #endif /* PPCACHE_H */

--- a/src/Cache/ParseCache.cpp
+++ b/src/Cache/ParseCache.cpp
@@ -49,10 +49,6 @@ using namespace SURELOG;
 ParseCache::ParseCache(ParseFile* parser)
     : m_parse(parser), m_isPrecompiled(false) {}
 
-ParseCache::ParseCache(const ParseCache& orig) {}
-
-ParseCache::~ParseCache() {}
-
 static std::string FlbSchemaVersion = "1.0";
 
 std::string ParseCache::getCacheFileName_(std::string svFileName) {

--- a/src/Cache/ParseCache.h
+++ b/src/Cache/ParseCache.h
@@ -34,20 +34,22 @@ namespace SURELOG {
 class ParseCache : Cache {
  public:
   ParseCache(ParseFile* pp);
-  ParseCache(const ParseCache& orig);
+
   bool restore();
   bool save();
   bool isValid();
-  ~ParseCache() override;
 
  private:
-  ParseFile* m_parse;
+  ParseCache(const ParseCache& orig) = delete;
+
   std::string getCacheFileName_(std::string fileName = "");
   bool restore_(std::string cacheFileName);
   bool checkCacheIsValid_(std::string cacheFileName);
+
+  ParseFile* m_parse;
   bool m_isPrecompiled;
 };
 
-};  // namespace SURELOG
+}  // namespace SURELOG
 
 #endif /* PARSECACHE_H */

--- a/src/Cache/PythonAPICache.cpp
+++ b/src/Cache/PythonAPICache.cpp
@@ -51,10 +51,6 @@ static std::string FlbSchemaVersion = "1.0";
 
 PythonAPICache::PythonAPICache(PythonListen* listener) : m_listener(listener) {}
 
-PythonAPICache::PythonAPICache(const PythonAPICache& orig) {}
-
-PythonAPICache::~PythonAPICache() {}
-
 std::string PythonAPICache::getCacheFileName_(std::string svFileName) {
   SymbolId cacheDirId =
       m_listener->getCompileSourceFile()->getCommandLineParser()->getCacheDir();

--- a/src/Cache/PythonAPICache.h
+++ b/src/Cache/PythonAPICache.h
@@ -34,17 +34,19 @@ namespace SURELOG {
 class PythonAPICache : Cache {
  public:
   PythonAPICache(PythonListen* listener);
-  PythonAPICache(const PythonAPICache& orig);
+
   bool restore();
   bool save();
   bool isValid();
-  ~PythonAPICache() override;
 
  private:
-  PythonListen* m_listener;
+  PythonAPICache(const PythonAPICache& orig) = delete;
+
   std::string getCacheFileName_(std::string fileName = "");
   bool restore_(std::string cacheFileName);
   bool checkCacheIsValid_(std::string cacheFileName);
+
+  PythonListen* m_listener;
 };
 
 };  // namespace SURELOG


### PR DESCRIPTION
 * SURELOG::Cache is extended, but does not have a virtual method.
   Change the virtual destructor to plain.
 * Make all methods in Cache protected, as they just serve as
   utilities in derived classes without being publically accessed.
 * use a using-clauses for a particular long flatbuffer vector of
   offsets of things.
 * Fix some indentation; remove unnecessary semicolon at end of
   namespace.

Signed-off-by: Henner Zeller <h.zeller@acm.org>