### PR TITLE
Use Range-loops in Compiler.cpp; some more const changes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,35 +1,7 @@
-# Prerequisites
-*.d
-
-# Compiled Object files
-*.slo
-*.lo
-*.o
-*.obj
-
-# Precompiled Headers
-*.gch
-*.pch
-
-# Compiled Dynamic libraries
-*.so
-*.dylib
-*.dll
-
-# Fortran module files
-*.mod
-*.smod
-
-# Compiled Static libraries
-*.lai
-*.la
-*.a
-*.lib
-
-# Executables
-*.exe
-*.out
-*.app
+*~
+*.v.log
+*.sv.log
+slpp_all/
 
 # Development environment cache folders
 /.vs

--- a/src/API/Surelog.cpp
+++ b/src/API/Surelog.cpp
@@ -28,7 +28,7 @@
 
 SURELOG::scompiler* SURELOG::start_compiler (SURELOG::CommandLineParser* clp) {
   Compiler* the_compiler = new SURELOG::Compiler(clp, clp->getErrorContainer(),
-						 clp->getSymbolTable());
+						 clp->mutableSymbolTable());
   bool status = the_compiler->compile();
   if (!status)
     return nullptr;

--- a/src/Cache/PPCache.cpp
+++ b/src/Cache/PPCache.cpp
@@ -50,14 +50,14 @@ std::string PPCache::getCacheFileName_(std::string svFileName) {
       m_pp->getCompileSourceFile()->getCommandLineParser()->getCacheDir();
 
   if (svFileName.empty()) svFileName = m_pp->getFileName(LINE1);
-  svFileName = FileUtils::fileName(svFileName);
+  svFileName = FileUtils::basename(svFileName);
   if (prec->isFilePrecompiled(svFileName)) {
     std::string packageRepDir = m_pp->getSymbol(m_pp->getCompileSourceFile()
                                                     ->getCommandLineParser()
                                                     ->getPrecompiledDir());
     cacheDirId = m_pp->getCompileSourceFile()
                      ->getCommandLineParser()
-                     ->getSymbolTable()
+                     ->mutableSymbolTable()
                      ->registerSymbol(packageRepDir);
     m_isPrecompiled = true;
   }

--- a/src/Cache/ParseCache.cpp
+++ b/src/Cache/ParseCache.cpp
@@ -56,7 +56,7 @@ std::string ParseCache::getCacheFileName_(std::string svFileName) {
   SymbolId cacheDirId =
       m_parse->getCompileSourceFile()->getCommandLineParser()->getCacheDir();
   if (svFileName.empty()) svFileName = m_parse->getPpFileName();
-  svFileName = FileUtils::fileName(svFileName);
+  svFileName = FileUtils::basename(svFileName);
   if (prec->isFilePrecompiled(svFileName)) {
     std::string packageRepDir =
         m_parse->getSymbol(m_parse->getCompileSourceFile()
@@ -64,7 +64,7 @@ std::string ParseCache::getCacheFileName_(std::string svFileName) {
                                ->getPrecompiledDir());
     cacheDirId = m_parse->getCompileSourceFile()
                      ->getCommandLineParser()
-                     ->getSymbolTable()
+                     ->mutableSymbolTable()
                      ->registerSymbol(packageRepDir);
     m_isPrecompiled = true;
   }

--- a/src/Cache/PythonAPICache.cpp
+++ b/src/Cache/PythonAPICache.cpp
@@ -57,7 +57,7 @@ std::string PythonAPICache::getCacheFileName_(std::string svFileName) {
   std::string cacheDirName = m_listener->getParseFile()->getSymbol(cacheDirId);
   if (svFileName.empty())
     svFileName = m_listener->getParseFile()->getFileName(LINE1);
-  svFileName = FileUtils::fileName(svFileName);
+  svFileName = FileUtils::basename(svFileName);
   Library* lib = m_listener->getCompileSourceFile()->getLibrary();
   std::string libName = lib->getName() + "/";
   std::string cacheFileName = cacheDirName + libName + svFileName + ".slpy";

--- a/src/CommandLine/CommandLineParser.cpp
+++ b/src/CommandLine/CommandLineParser.cpp
@@ -531,7 +531,7 @@ bool CommandLineParser::parseCommandLine(int argc, const char** argv) {
     if (all_arguments[i] == "-odir" || all_arguments[i] == "-o"
     || all_arguments[i] == "--Mdir"){
       if (i == all_arguments.size() - 1) {
-        Location loc(getSymbolTable()->registerSymbol(all_arguments[i]));
+        Location loc(mutableSymbolTable()->registerSymbol(all_arguments[i]));
         Error err(ErrorDefinition::CMD_PP_FILE_MISSING_ODIR, loc);
         m_errors->addError(err);
         break;
@@ -547,7 +547,7 @@ bool CommandLineParser::parseCommandLine(int argc, const char** argv) {
     if (plus_arguments_(all_arguments[i])) {
     } else if (all_arguments[i] == "-d") {
       if (i == all_arguments.size() - 1) {
-        Location loc(getSymbolTable()->registerSymbol(all_arguments[i]));
+        Location loc(mutableSymbolTable()->registerSymbol(all_arguments[i]));
         Error err(ErrorDefinition::CMD_DEBUG_MISSING_LEVEL, loc);
         m_errors->addError(err);
         break;
@@ -568,7 +568,7 @@ bool CommandLineParser::parseCommandLine(int argc, const char** argv) {
       } else {
         int debugLevel = atoi(all_arguments[i].c_str());
         if (debugLevel < 0 || debugLevel > 4) {
-          Location loc(getSymbolTable()->registerSymbol(all_arguments[i]));
+          Location loc(mutableSymbolTable()->registerSymbol(all_arguments[i]));
           Error err(ErrorDefinition::CMD_DEBUG_INCORRECT_LEVEL, loc);
           m_errors->addError(err);
         } else {
@@ -579,7 +579,7 @@ bool CommandLineParser::parseCommandLine(int argc, const char** argv) {
       std::string timescale;
       timescale = all_arguments[i].substr(11, std::string::npos);
       if (timescale.empty()) {
-        Location loc(getSymbolTable()->registerSymbol(all_arguments[i]));
+        Location loc(mutableSymbolTable()->registerSymbol(all_arguments[i]));
         Error err(ErrorDefinition::CMD_TIMESCALE_MISSING_SETTING, loc);
         m_errors->addError(err);
         break;
@@ -590,15 +590,15 @@ bool CommandLineParser::parseCommandLine(int argc, const char** argv) {
       std::string include;
       include = all_arguments[i].substr(2, std::string::npos);
       if (include.empty()) {
-        Location loc(getSymbolTable()->registerSymbol(all_arguments[i]));
+        Location loc(mutableSymbolTable()->registerSymbol(all_arguments[i]));
         Error err(ErrorDefinition::CMD_INCLUDE_PATH_DOES_NOT_EXIST, loc);
         m_errors->addError(err);
         break;
       }
-      m_includePaths.push_back(getSymbolTable()->registerSymbol(include));
+      m_includePaths.push_back(mutableSymbolTable()->registerSymbol(include));
     } else if (all_arguments[i] == "-split") {
       if (i == all_arguments.size() - 1) {
-        Location loc(getSymbolTable()->registerSymbol(all_arguments[i]));
+        Location loc(mutableSymbolTable()->registerSymbol(all_arguments[i]));
         Error err(ErrorDefinition::CMD_SPLIT_FILE_MISSING_SIZE, loc);
         m_errors->addError(err);
         break;
@@ -614,7 +614,7 @@ bool CommandLineParser::parseCommandLine(int argc, const char** argv) {
                all_arguments[i] == "-mp") {
       bool mt = ((all_arguments[i] == "-mt") || (all_arguments[i] == "--threads"));
       if (i == all_arguments.size() - 1) {
-        Location loc(getSymbolTable()->registerSymbol(all_arguments[i]));
+        Location loc(mutableSymbolTable()->registerSymbol(all_arguments[i]));
         Error err(ErrorDefinition::CMD_MT_MISSING_LEVEL, loc);
         m_errors->addError(err);
         break;
@@ -630,7 +630,7 @@ bool CommandLineParser::parseCommandLine(int argc, const char** argv) {
         maxMT = atoi(all_arguments[i].c_str());
       }
       if (maxMT < 0 || maxMT > 512) {
-        Location loc(getSymbolTable()->registerSymbol(all_arguments[i]));
+        Location loc(mutableSymbolTable()->registerSymbol(all_arguments[i]));
         Error err(ErrorDefinition::CMD_MT_INCORRECT_LEVEL, loc);
         m_errors->addError(err);
       } else {
@@ -659,7 +659,7 @@ bool CommandLineParser::parseCommandLine(int argc, const char** argv) {
             if (m_nbMaxProcesses < 2) m_nbMaxProcesses = 2;
           }
           Location loc(
-              getSymbolTable()->registerSymbol(std::to_string(maxMT)));
+              mutableSymbolTable()->registerSymbol(std::to_string(maxMT)));
           Error err(ErrorDefinition::CMD_NUMBER_THREADS, loc);
           m_errors->addError(err);
         }
@@ -677,7 +677,7 @@ bool CommandLineParser::parseCommandLine(int argc, const char** argv) {
       m_lineOffsetsAsComments = true;
     } else if (all_arguments[i] == "-v") {
       if (i == all_arguments.size() - 1) {
-        Location loc(getSymbolTable()->registerSymbol(all_arguments[i]));
+        Location loc(mutableSymbolTable()->registerSymbol(all_arguments[i]));
         Error err(ErrorDefinition::CMD_LIBRARY_FILE_MISSING_FILE, loc);
         m_errors->addError(err);
         break;
@@ -686,7 +686,7 @@ bool CommandLineParser::parseCommandLine(int argc, const char** argv) {
       m_libraryFiles.push_back(m_symbolTable->registerSymbol(all_arguments[i]));
     } else if (all_arguments[i] == "-y") {
       if (i == all_arguments.size() - 1) {
-        Location loc(getSymbolTable()->registerSymbol(all_arguments[i]));
+        Location loc(mutableSymbolTable()->registerSymbol(all_arguments[i]));
         Error err(ErrorDefinition::CMD_LIBRARY_PATH_MISSING_PATH, loc);
         m_errors->addError(err);
         break;
@@ -695,7 +695,7 @@ bool CommandLineParser::parseCommandLine(int argc, const char** argv) {
       m_libraryPaths.push_back(m_symbolTable->registerSymbol(all_arguments[i]));
     } else if (all_arguments[i] == "-l") {
       if (i == all_arguments.size() - 1) {
-        Location loc(getSymbolTable()->registerSymbol(all_arguments[i]));
+        Location loc(mutableSymbolTable()->registerSymbol(all_arguments[i]));
         Error err(ErrorDefinition::CMD_LOG_FILE_MISSING_FILE, loc);
         m_errors->addError(err);
         break;
@@ -719,7 +719,7 @@ bool CommandLineParser::parseCommandLine(int argc, const char** argv) {
       m_useConfigs.push_back(m_symbolTable->registerSymbol(all_arguments[i]));
     } else if (all_arguments[i] == "-writeppfile") {
       if (i == all_arguments.size() - 1) {
-        Location loc(getSymbolTable()->registerSymbol(all_arguments[i]));
+        Location loc(mutableSymbolTable()->registerSymbol(all_arguments[i]));
         Error err(ErrorDefinition::CMD_PP_FILE_MISSING_FILE, loc);
         m_errors->addError(err);
         break;
@@ -728,7 +728,7 @@ bool CommandLineParser::parseCommandLine(int argc, const char** argv) {
       m_writePpOutputFileId = m_symbolTable->registerSymbol(all_arguments[i]);
     } else if (all_arguments[i] == "-cache") {
       if (i == all_arguments.size() - 1) {
-        Location loc(getSymbolTable()->registerSymbol(all_arguments[i]));
+        Location loc(mutableSymbolTable()->registerSymbol(all_arguments[i]));
         Error err(ErrorDefinition::CMD_PP_FILE_MISSING_FILE, loc);
         m_errors->addError(err);
         break;
@@ -760,12 +760,12 @@ bool CommandLineParser::parseCommandLine(int argc, const char** argv) {
     } else if (all_arguments[i] == "-sverilog") {
       m_sverilog = true;
     } else if (all_arguments[i] == "-fileunit") {
-      Location loc(getSymbolTable()->registerSymbol(all_arguments[i]));
+      Location loc(mutableSymbolTable()->registerSymbol(all_arguments[i]));
       Error err(ErrorDefinition::CMD_SEPARATE_COMPILATION_UNIT_ON, loc);
       m_errors->addError(err);
     } else if (all_arguments[i] == "-diffcompunit") {
       if (m_fileunit) {
-        Location loc(getSymbolTable()->registerSymbol(all_arguments[i]));
+        Location loc(mutableSymbolTable()->registerSymbol(all_arguments[i]));
         Error err(ErrorDefinition::CMD_SEPARATE_COMPILATION_UNIT_ON, loc);
         m_errors->addError(err);
       }
@@ -820,7 +820,7 @@ bool CommandLineParser::parseCommandLine(int argc, const char** argv) {
       m_pythonAllowed = false;
     } else if (all_arguments[i] == "-pythonevalscriptperfile") {
       if (i == all_arguments.size() - 1) {
-        Location loc(getSymbolTable()->registerSymbol(all_arguments[i]));
+        Location loc(mutableSymbolTable()->registerSymbol(all_arguments[i]));
         Error err(ErrorDefinition::CMD_PP_FILE_MISSING_FILE, loc);
         m_errors->addError(err);
         break;
@@ -839,7 +839,7 @@ bool CommandLineParser::parseCommandLine(int argc, const char** argv) {
         std::cout << "ERROR: No Python allowed, check your arguments!\n";
     } else if (all_arguments[i] == "-pythonlistenerfile") {
       if (i == all_arguments.size() - 1) {
-        Location loc(getSymbolTable()->registerSymbol(all_arguments[i]));
+        Location loc(mutableSymbolTable()->registerSymbol(all_arguments[i]));
         Error err(ErrorDefinition::CMD_PP_FILE_MISSING_FILE, loc);
         m_errors->addError(err);
         break;
@@ -854,7 +854,7 @@ bool CommandLineParser::parseCommandLine(int argc, const char** argv) {
       PythonAPI::setListenerScript(all_arguments[i]);
     } else if (all_arguments[i] == "-pythonevalscript") {
       if (i == all_arguments.size() - 1) {
-        Location loc(getSymbolTable()->registerSymbol(all_arguments[i]));
+        Location loc(mutableSymbolTable()->registerSymbol(all_arguments[i]));
         Error err(ErrorDefinition::CMD_PP_FILE_MISSING_FILE, loc);
         m_errors->addError(err);
         break;
@@ -877,20 +877,20 @@ bool CommandLineParser::parseCommandLine(int argc, const char** argv) {
       SymbolId id = m_symbolTable->registerSymbol(all_arguments[i]);
       m_sourceFiles.push_back(id);
       std::string fileName = all_arguments[i];
-      fileName = FileUtils::fileName(fileName);
+      fileName = FileUtils::basename(fileName);
       m_svSourceFiles.insert(fileName);
     } else if (all_arguments[i].size() && all_arguments[i].at(0) == '+') {
-      Location loc(getSymbolTable()->registerSymbol(all_arguments[i]));
+      Location loc(mutableSymbolTable()->registerSymbol(all_arguments[i]));
       Error err(ErrorDefinition::CMD_PLUS_ARG_IGNORED, loc);
       m_errors->addError(err);
     } else if (all_arguments[i].size() && all_arguments[i].at(0) == '-') {
-      Location loc(getSymbolTable()->registerSymbol(all_arguments[i]));
+      Location loc(mutableSymbolTable()->registerSymbol(all_arguments[i]));
       Error err(ErrorDefinition::CMD_MINUS_ARG_IGNORED, loc);
       m_errors->addError(err);
     } else {
       if (!all_arguments[i].empty()) {
         if (is_number(all_arguments[i]) || is_c_file(all_arguments[i])) {
-          Location loc(getSymbolTable()->registerSymbol(all_arguments[i]));
+          Location loc(mutableSymbolTable()->registerSymbol(all_arguments[i]));
           Error err(ErrorDefinition::CMD_PLUS_ARG_IGNORED, loc);
           m_errors->addError(err);
         } else {

--- a/src/CommandLine/CommandLineParser.h
+++ b/src/CommandLine/CommandLineParser.h
@@ -125,9 +125,13 @@ class CommandLineParser final {
   SymbolId pythonEvalScriptPerFileId() { return m_pythonEvalScriptPerFileId; }
   SymbolId pythonEvalScriptId() { return m_pythonEvalScriptId; }
   SymbolId pythonListenerId() { return m_pythonListenerFileId; }
+  const SymbolTable& getSymbolTable() const { return *m_symbolTable; }
+
+  // There are some places that modify the command-line symbol table.
+  SymbolTable* mutableSymbolTable() { return m_symbolTable; }
+
   /* Internal */
   ErrorContainer* getErrorContainer() { return m_errors; }
-  SymbolTable* getSymbolTable() { return m_symbolTable; }
   unsigned short int getNbMaxTreads() { return m_nbMaxTreads; }
   unsigned short int getNbMaxProcesses() { return m_nbMaxProcesses; }
   void setNbMaxTreads(unsigned short int max) { m_nbMaxTreads = max; }

--- a/src/Config/Config.h
+++ b/src/Config/Config.h
@@ -29,6 +29,9 @@
 #include <string_view>
 #include <vector>
 
+#include "SourceCompile/SymbolTable.h"
+#include "Design/FileContent.h"
+
 namespace SURELOG {
 
 class UseClause {

--- a/src/DesignCompile/CompileDesign.cpp
+++ b/src/DesignCompile/CompileDesign.cpp
@@ -261,7 +261,7 @@ bool CompileDesign::compilation_() {
   int index = 0;
   do {
     SymbolTable* symbols = new SymbolTable(
-            *m_compiler->getCommandLineParser()->getSymbolTable());
+            m_compiler->getCommandLineParser()->getSymbolTable());
     m_symbolTables.push_back(symbols);
     ErrorContainer* errors = new ErrorContainer(symbols);
     errors->regiterCmdLine(m_compiler->getCommandLineParser());

--- a/src/DesignCompile/DesignElaboration.cpp
+++ b/src/DesignCompile/DesignElaboration.cpp
@@ -78,7 +78,7 @@ bool DesignElaboration::setupConfigurations_() {
   ConfigSet* configSet =
       m_compileDesign->getCompiler()->getDesign()->getConfigSet();
   SymbolTable* st =
-      m_compileDesign->getCompiler()->getCommandLineParser()->getSymbolTable();
+      m_compileDesign->getCompiler()->getCommandLineParser()->mutableSymbolTable();
   std::vector<Config>& allConfigs = configSet->getAllConfigs();
   std::vector<SymbolId> selectedConfigIds =
       m_compileDesign->getCompiler()->getCommandLineParser()->getUseConfigs();

--- a/src/ErrorReporting/ErrorContainer.cpp
+++ b/src/ErrorReporting/ErrorContainer.cpp
@@ -52,7 +52,7 @@ ErrorContainer::ErrorContainer(SymbolTable* symbolTable)
 void ErrorContainer::init() {
   if (ErrorDefinition::init()) {
     const std::string& logFileName =
-        m_clp->getSymbolTable()->getSymbol(m_clp->getLogFileId());
+        m_clp->getSymbolTable().getSymbol(m_clp->getLogFileId());
     std::ofstream ofs;
     ofs.open(logFileName, std::fstream::out);
     if (!ofs.good()) {
@@ -374,7 +374,7 @@ bool ErrorContainer::printToLogFile(std::string report) {
   if (!m_clp)
     return false;
   const std::string& logFileName =
-      m_clp->getSymbolTable()->getSymbol(m_clp->getLogFileId());
+      m_clp->getSymbolTable().getSymbol(m_clp->getLogFileId());
   std::ofstream ofs;
   ofs.open(logFileName, std::fstream::app);
   if (!ofs.good()) {

--- a/src/ErrorReporting/ErrorContainer.h
+++ b/src/ErrorReporting/ErrorContainer.h
@@ -32,13 +32,12 @@
 namespace SURELOG {
 
 class CommandLineParser;
- 
+
 class ErrorContainer {
  public:
   class Stats {
-   public:
-    Stats() : nbFatal(0), nbSyntax(0), nbError(0), nbWarning(0), nbNote(0), nbInfo(0){};
-    Stats& operator+=(Stats& r) {
+  public:
+    Stats& operator+=(const Stats& r) {
       nbFatal += r.nbFatal;
       nbSyntax += r.nbSyntax;
       nbError += r.nbError;
@@ -47,12 +46,13 @@ class ErrorContainer {
       nbInfo += r.nbInfo;
       return *this;
     }
-    int nbFatal;
-    int nbSyntax;
-    int nbError;
-    int nbWarning;
-    int nbNote;
-    int nbInfo;
+
+    int nbFatal = 0;
+    int nbSyntax = 0;
+    int nbError = 0;
+    int nbWarning = 0;
+    int nbNote = 0;
+    int nbInfo = 0;
   };
 
   ErrorContainer(SymbolTable* symbolTable);

--- a/src/SourceCompile/AnalyzeFile.cpp
+++ b/src/SourceCompile/AnalyzeFile.cpp
@@ -82,7 +82,7 @@ void AnalyzeFile::checkSLlineDirective_(std::string line, unsigned int lineNb) {
     std::stringstream(tmp) >> file;
     StringUtils::ltrim(file, '\"');
     StringUtils::rtrim(file, '\"');
-    info.m_sectionFile = m_clp->getSymbolTable()->registerSymbol(file);
+    info.m_sectionFile = m_clp->mutableSymbolTable()->registerSymbol(file);
     ss >> tmp;
     std::stringstream(tmp) >> type;
 
@@ -111,7 +111,7 @@ std::string AnalyzeFile::setSLlineDirective_(unsigned int lineNb,
   std::string result;
   if (m_includeFileInfo.size()) {
     result = "SLline ";
-    origFile = m_clp->getSymbolTable()->getSymbol(
+    origFile = m_clp->mutableSymbolTable()->getSymbol(
         m_includeFileInfo.top().m_sectionFile);
     unsigned int origLine = m_includeFileInfo.top().m_originalLine;
     unsigned int sectionStartLine = m_includeFileInfo.top().m_sectionStartLine;
@@ -419,7 +419,7 @@ void AnalyzeFile::analyze() {
   if (inComment || inString) {
     m_splitFiles.clear();
     m_lineOffsets.clear();
-    Location loc(0, 0, 0, m_clp->getSymbolTable()->registerSymbol(m_fileName));
+    Location loc(0, 0, 0, m_clp->mutableSymbolTable()->registerSymbol(m_fileName));
     Error err(ErrorDefinition::PA_CANNOT_SPLIT_FILE, loc);
     m_clp->getErrorContainer()->addError(err);
     m_clp->getErrorContainer()->printMessages();
@@ -433,7 +433,7 @@ void AnalyzeFile::analyze() {
 
   unsigned int fromLine = 1;
   unsigned int toIndex = 0;
-  IncludeFileInfo info(1, m_clp->getSymbolTable()->registerSymbol(m_fileName),
+  IncludeFileInfo info(1, m_clp->mutableSymbolTable()->registerSymbol(m_fileName),
                        1, 1);
   m_includeFileInfo.push(info);
   unsigned int linesWriten = 0;
@@ -583,7 +583,7 @@ void AnalyzeFile::analyze() {
             m_splitFiles.clear();
             m_lineOffsets.clear();
             Location loc(0, 0, 0,
-                         m_clp->getSymbolTable()->registerSymbol(m_fileName));
+                         m_clp->mutableSymbolTable()->registerSymbol(m_fileName));
             Error err(ErrorDefinition::PA_CANNOT_SPLIT_FILE, loc);
             m_clp->getErrorContainer()->addError(err);
             m_clp->getErrorContainer()->printMessages();
@@ -620,7 +620,7 @@ void AnalyzeFile::analyze() {
           m_splitFiles.clear();
           m_lineOffsets.clear();
           Location loc(0, 0, 0,
-                       m_clp->getSymbolTable()->registerSymbol(m_fileName));
+                       m_clp->mutableSymbolTable()->registerSymbol(m_fileName));
           Error err(ErrorDefinition::PA_CANNOT_SPLIT_FILE, loc);
           m_clp->getErrorContainer()->addError(err);
           m_clp->getErrorContainer()->printMessages();
@@ -652,7 +652,7 @@ void AnalyzeFile::analyze() {
           m_splitFiles.clear();
           m_lineOffsets.clear();
           Location loc(0, 0, 0,
-                       m_clp->getSymbolTable()->registerSymbol(m_fileName));
+                       m_clp->mutableSymbolTable()->registerSymbol(m_fileName));
           Error err(ErrorDefinition::PA_CANNOT_SPLIT_FILE, loc);
           m_clp->getErrorContainer()->addError(err);
           m_clp->getErrorContainer()->printMessages();
@@ -724,7 +724,7 @@ void AnalyzeFile::analyze() {
         m_splitFiles.clear();
         m_lineOffsets.clear();
         Location loc(0, 0, 0,
-                     m_clp->getSymbolTable()->registerSymbol(m_fileName));
+                     m_clp->mutableSymbolTable()->registerSymbol(m_fileName));
         Error err(ErrorDefinition::PA_CANNOT_SPLIT_FILE, loc);
         m_clp->getErrorContainer()->addError(err);
         m_clp->getErrorContainer()->printMessages();

--- a/src/SourceCompile/AntlrParserHandler.h
+++ b/src/SourceCompile/AntlrParserHandler.h
@@ -24,6 +24,10 @@
 #ifndef ANTLRPARSERHANDLER_H
 #define ANTLRPARSERHANDLER_H
 
+#include "parser/SV3_1aLexer.h"
+#include "parser/SV3_1aParser.h"
+#include "antlr4-runtime.h"
+
 namespace SURELOG {
 
 class AntlrParserErrorListener;

--- a/src/SourceCompile/CompileSourceFile.cpp
+++ b/src/SourceCompile/CompileSourceFile.cpp
@@ -188,7 +188,7 @@ bool CompileSourceFile::pythonAPI_() {
   }
   if (getCommandLineParser()->pythonEvalScriptPerFile()) {
     PythonAPI::evalScriptPerFile(
-        getCommandLineParser()->getSymbolTable()->getSymbol(
+        getCommandLineParser()->getSymbolTable().getSymbol(
             getCommandLineParser()->pythonEvalScriptPerFileId()),
         m_errors, m_parser->getFileContent(), m_interpState);
   }
@@ -218,7 +218,7 @@ bool CompileSourceFile::parse_() {
 bool CompileSourceFile::preprocess_() {
   Precompiled* prec = Precompiled::getSingleton();
   std::string root = getSymbolTable()->getSymbol(m_fileId);
-  root = FileUtils::fileName(root);
+  root = FileUtils::basename(root);
 
   PreprocessFile::SpecialInstructions instructions(
       PreprocessFile::SpecialInstructions::DontMute,

--- a/src/SourceCompile/CompileSourceFile.h
+++ b/src/SourceCompile/CompileSourceFile.h
@@ -29,10 +29,10 @@
 
 #include "SourceCompile/ParseFile.h"
 #include "SourceCompile/AnalyzeFile.h"
+#include "SourceCompile/PreprocessFile.h"
 
 namespace SURELOG {
 
-class PreprocessFile;
 class ParseFile;
 class Compiler;
 class PythonListen;

--- a/src/SourceCompile/Compiler.cpp
+++ b/src/SourceCompile/Compiler.cpp
@@ -14,6 +14,8 @@
  limitations under the License.
  */
 
+#include "SourceCompile/Compiler.h"
+
 /*
  * File:   Compiler.cpp
  * Author: alain
@@ -22,23 +24,25 @@
  */
 #include <stdint.h>
 #include <cstdlib>
+
 #include "CommandLine/CommandLineParser.h"
+#include "DesignCompile/CompileDesign.h"
 #include "ErrorReporting/ErrorContainer.h"
-#include "SourceCompile/SymbolTable.h"
+#include "Library/ParseLibraryDef.h"
+#include "Package/Precompiled.h"
+#include "SourceCompile/AnalyzeFile.h"
+#include "SourceCompile/CheckCompile.h"
 #include "SourceCompile/CompilationUnit.h"
-#include "SourceCompile/PreprocessFile.h"
 #include "SourceCompile/CompilationUnit.h"
 #include "SourceCompile/CompileSourceFile.h"
-#include "SourceCompile/Compiler.h"
-#include "SourceCompile/CheckCompile.h"
-#include "antlr4-runtime.h"
-#include "DesignCompile/CompileDesign.h"
-#include "SourceCompile/AnalyzeFile.h"
-#include "Library/ParseLibraryDef.h"
+#include "SourceCompile/PreprocessFile.h"
+#include "SourceCompile/SymbolTable.h"
+#include "Utils/ContainerUtils.h"
 #include "Utils/FileUtils.h"
-#include "Package/Precompiled.h"
 #include "Utils/StringUtils.h"
 #include "Utils/Timer.h"
+#include "antlr4-runtime.h"
+
 #include <math.h>
 using namespace antlr4;
 
@@ -46,7 +50,7 @@ using namespace antlr4;
 #include "SourceCompile/CheckCompile.h"
 
 #if (defined(_MSC_VER) || defined(__MINGW32__) || defined(__CYGWIN__))
-  #include <process.h>  // Has to be included before <thread>
+#  include <process.h>  // Has to be included before <thread>
 #endif
 
 #include <mutex>
@@ -72,16 +76,12 @@ Compiler::Compiler(CommandLineParser* commandLineParser, ErrorContainer* errors,
 #endif
 }
 
-Compiler::Compiler(const Compiler& orig) {}
-
 Compiler::~Compiler() {
   std::map<SymbolId, PreprocessFile::AntlrParserHandler*>::iterator itr;
   for (itr = m_antlrPpMap.begin(); itr != m_antlrPpMap.end(); itr++) {
     delete (*itr).second;
   }
-  if (m_commonCompilationUnit) {
-    delete m_commonCompilationUnit;
-  }
+  delete m_commonCompilationUnit;
   cleanup_();
 }
 
@@ -111,12 +111,8 @@ bool Compiler::compileOneFile_(CompileSourceFile* compiler,
   return status;
 }
 
-bool Compiler::isLibraryFile(SymbolId id) {
-  if (m_libraryFiles.find(id) == m_libraryFiles.end()) {
-    return false;
-  } else {
-    return true;
-  }
+bool Compiler::isLibraryFile(SymbolId id) const {
+  return (m_libraryFiles.find(id) != m_libraryFiles.end());
 }
 
 bool Compiler::ppinit_() {
@@ -129,30 +125,29 @@ bool Compiler::ppinit_() {
   // Source files (.v, .sv on the command line)
   std::set<SymbolId> sourceFiles;
   unsigned int size = m_commandLineParser->getSourceFiles().size();
-  for (unsigned int i = 0; i < size; i++) {
+  for (const SymbolId source_file_id : m_commandLineParser->getSourceFiles()) {
     SymbolTable* symbols = m_symbolTable;
     if (m_commandLineParser->fileunit()) {
       comp_unit = new CompilationUnit(true);
       m_compilationUnits.push_back(comp_unit);
-      symbols = new SymbolTable(*m_commandLineParser->getSymbolTable());
+      symbols = new SymbolTable(m_commandLineParser->getSymbolTable());
       m_symbolTables.push_back(symbols);
     }
     ErrorContainer* errors = new ErrorContainer(symbols);
     m_errorContainers.push_back(errors);
     errors->regiterCmdLine(m_commandLineParser);
 
-    SymbolId id = m_commandLineParser->getSourceFiles()[i];
-
-    std::string fileName = m_commandLineParser->getSymbolTable()->getSymbol(id);
-    std::string fullPath = FileUtils::getFullPath(fileName);
-    SymbolId fullPathId =
-        m_commandLineParser->getSymbolTable()->registerSymbol(fullPath);
+    const std::string fileName = m_commandLineParser->getSymbolTable()
+      .getSymbol(source_file_id);
+    const std::string fullPath = FileUtils::getFullPath(fileName);
+    const SymbolId fullPathId =
+        m_commandLineParser->mutableSymbolTable()->registerSymbol(fullPath);
     Library* library = m_librarySet->getLibrary(fullPathId);
     sourceFiles.insert(fullPathId);
 
     CompileSourceFile* compiler = new CompileSourceFile(
-        m_commandLineParser->getSourceFiles()[i], m_commandLineParser, errors,
-        this, symbols, comp_unit, library);
+      source_file_id, m_commandLineParser, errors,
+      this, symbols, comp_unit, library);
     m_compilers.push_back(compiler);
   }
 
@@ -168,7 +163,7 @@ bool Compiler::ppinit_() {
   for (auto path : m_commandLineParser->getLibraryPaths()) {
     for (auto ext : m_commandLineParser->getLibraryExtensions()) {
       auto files = FileUtils::collectFiles(
-          path, ext, m_commandLineParser->getSymbolTable());
+          path, ext, m_commandLineParser->mutableSymbolTable());
       for (auto file : files) {
         libFiles.insert(file);
       }
@@ -179,7 +174,7 @@ bool Compiler::ppinit_() {
     if (m_commandLineParser->fileunit()) {
       comp_unit = new CompilationUnit(true);
       m_compilationUnits.push_back(comp_unit);
-      symbols = new SymbolTable(*m_commandLineParser->getSymbolTable());
+      symbols = new SymbolTable(m_commandLineParser->getSymbolTable());
       m_symbolTables.push_back(symbols);
     }
     ErrorContainer* errors = new ErrorContainer(symbols);
@@ -187,11 +182,11 @@ bool Compiler::ppinit_() {
     errors->regiterCmdLine(m_commandLineParser);
 
     std::string fullPath = FileUtils::getFullPath(
-        m_commandLineParser->getSymbolTable()->getSymbol(id));
+        m_commandLineParser->getSymbolTable().getSymbol(id));
 
     // This line registers the file in the "work" library:
     SymbolId fullPathId =
-        m_commandLineParser->getSymbolTable()->registerSymbol(fullPath);
+        m_commandLineParser->mutableSymbolTable()->registerSymbol(fullPath);
     /*Library* library  = */ m_librarySet->getLibrary(fullPathId);
     m_libraryFiles.insert(id);
     m_libraryFiles.insert(fullPathId);
@@ -222,7 +217,7 @@ bool Compiler::ppinit_() {
       if (m_commandLineParser->fileunit()) {
         comp_unit = new CompilationUnit(true);
         m_compilationUnits.push_back(comp_unit);
-        symbols = new SymbolTable(*m_commandLineParser->getSymbolTable());
+        symbols = new SymbolTable(m_commandLineParser->getSymbolTable());
         m_symbolTables.push_back(symbols);
       }
       ErrorContainer* errors = new ErrorContainer(symbols);
@@ -299,7 +294,7 @@ bool Compiler::createMultiProcess_() {
       Precompiled* prec = Precompiled::getSingleton();
       for (unsigned int i = 0; i < m_compilers.size(); i++) {
         std::string root = m_compilers[i]->getSymbolTable()->getSymbol(m_compilers[i]->getFileId());
-        root = FileUtils::fileName(root);
+        root = FileUtils::basename(root);
         if (prec->isFilePrecompiled(root)) {
           continue;
         }
@@ -338,12 +333,12 @@ bool Compiler::createMultiProcess_() {
         absoluteIndex++;
         std::string fileName = compiler->getSymbolTable()->getSymbol(
                                         compiler->getPpOutputFileId());
-        std::string targetname = std::to_string(absoluteIndex) + "_"  + FileUtils::fileName(fileName);
+        std::string targetname = std::to_string(absoluteIndex) + "_"  + FileUtils::basename(fileName);
         targets.push_back(targetname);
         ofs <<"add_custom_command(OUTPUT " << targetname << std::endl;
         ofs <<"  COMMAND " << full_exe_path << fileUnit <<
                             " -parseonly -mt 0 -mp 0 -nostdout -nobuiltin -l "
-                           <<  directory + FileUtils::fileName(targetname) + ".log" << " " << fileName << std::endl;
+                           <<  directory + FileUtils::basename(targetname) + ".log" << " " << fileName << std::endl;
         ofs << ")" << std::endl;
       }
 
@@ -360,12 +355,12 @@ bool Compiler::createMultiProcess_() {
           lastFile = fileName;
         }
         if (!fileList.empty()) {
-          std::string targetname = std::to_string(absoluteIndex) + "_" + FileUtils::fileName(lastFile);
+          std::string targetname = std::to_string(absoluteIndex) + "_" + FileUtils::basename(lastFile);
           targets.push_back(targetname);
           ofs << "add_custom_command(OUTPUT " << targetname << std::endl;
           ofs << "  COMMAND " << full_exe_path << fileUnit <<
                   " -parseonly -mt 0 -mp 0 -nostdout -nobuiltin -l "
-                  << directory + FileUtils::fileName(targetname) + ".log" << " " << fileList << std::endl;
+                  << directory + FileUtils::basename(targetname) + ".log" << " " << fileList << std::endl;
           ofs << ")" << std::endl;
         }
       }
@@ -390,82 +385,74 @@ bool Compiler::createMultiProcess_() {
   return true;
 }
 
+static int calculateEffectiveThreads(int nbThreads) {
+  if (nbThreads <= 4)
+    return nbThreads;
+  return (int) (log(((float) nbThreads + 1.0) / 4.0) * 10.0);
+}
+
 bool Compiler::parseinit_() {
-  Precompiled* prec = Precompiled::getSingleton();
+  Precompiled* const prec = Precompiled::getSingleton();
+
   // Single out the large files.
   // Small files are going to be scheduled in multiple threads based on size.
   // Large files are going to be compiled in a different batch in multithread
 
   if (!m_commandLineParser->fileunit()) {
-    unsigned int size = m_symbolTables.size();
-    for (unsigned int i = 0; i < size; i++) {
-      delete m_symbolTables[i];
-    }
-    size = m_errorContainers.size();
-    for (unsigned int i = 0; i < size; i++) {
-      delete m_errorContainers[i];
-    }
-    m_symbolTables.clear();
-    m_errorContainers.clear();
+    DeleteContainerPointersAndClear(&m_symbolTables);
+    DeleteContainerPointersAndClear(&m_errorContainers);
   }
 
   std::vector<CompileSourceFile*> tmp_compilers;
-  unsigned int size = m_compilers.size();
-  for (unsigned int i = 0; i < size; i++) {
-    std::string fileName = m_compilers[i]->getSymbolTable()->getSymbol(
-        m_compilers[i]->getPpOutputFileId());
-    std::string origFile = m_compilers[i]->getSymbolTable()->getSymbol(
-        m_compilers[i]->getFileId());
-    unsigned int nbThreads = m_commandLineParser->getNbMaxTreads();
-    std::string root = FileUtils::fileName(fileName);
-    if (prec->isFilePrecompiled(root)) {
-      nbThreads = 0;
-    }
-    int effectiveNbThreads = 0;
+  for (CompileSourceFile *const compiler : m_compilers) {
+    const std::string fileName = compiler->getSymbolTable()->getSymbol(
+      compiler->getPpOutputFileId());
+    const std::string origFile = compiler->getSymbolTable()->getSymbol(
+      compiler->getFileId());
+    const std::string root = FileUtils::basename(fileName);
+    const unsigned int nbThreads = prec->isFilePrecompiled(root)
+      ? 0
+      : m_commandLineParser->getNbMaxTreads();
 
-    if (nbThreads > 4)
-      effectiveNbThreads = (int) (log(((float) nbThreads + 1.0) / 4.0) * 10.0);
-    else
-      effectiveNbThreads = nbThreads;
+    const int effectiveNbThreads = calculateEffectiveThreads(nbThreads);
 
-    AnalyzeFile* fileAnalyzer = new AnalyzeFile(
-        m_commandLineParser, m_design, fileName, origFile, effectiveNbThreads);
+    AnalyzeFile* const fileAnalyzer = new AnalyzeFile(
+      m_commandLineParser, m_design, fileName, origFile, effectiveNbThreads);
     fileAnalyzer->analyze();
-    m_compilers[i]->setFileAnalyzer(fileAnalyzer);
+    compiler->setFileAnalyzer(fileAnalyzer);
     if (fileAnalyzer->getSplitFiles().size() > 1) {
       // Schedule parent
-      m_compilersParentFiles.push_back(m_compilers[i]);
-      m_compilers[i]->initParser();
+      m_compilersParentFiles.push_back(compiler);
+      compiler->initParser();
 
       if (!m_commandLineParser->fileunit()) {
         SymbolTable* symbols =
-            new SymbolTable(*m_commandLineParser->getSymbolTable());
+          new SymbolTable(m_commandLineParser->getSymbolTable());
         m_symbolTables.push_back(symbols);
-        m_compilers[i]->setSymbolTable(symbols);
+        compiler->setSymbolTable(symbols);
         // fileContent->setSymbolTable(symbols);
         ErrorContainer* errors = new ErrorContainer(symbols);
         m_errorContainers.push_back(errors);
         errors->regiterCmdLine(m_commandLineParser);
-        m_compilers[i]->setErrorContainer(errors);
+        compiler->setErrorContainer(errors);
       }
 
-      FileContent* fileContent =
-          new FileContent(m_compilers[i]->getParser()->getFileId(0),
-                          m_compilers[i]->getParser()->getLibrary(),
-                          m_compilers[i]->getSymbolTable(),
-                          m_compilers[i]->getErrorContainer(), NULL, 0);
-      m_compilers[i]->getParser()->setFileContent(fileContent);
+      compiler->getParser()->setFileContent(
+        new FileContent(compiler->getParser()->getFileId(0),
+                        compiler->getParser()->getLibrary(),
+                        compiler->getSymbolTable(),
+                        compiler->getErrorContainer(), NULL, 0));
 
       int j = 0;
-      for (auto chunk : fileAnalyzer->getSplitFiles()) {
+      for (auto& chunk : fileAnalyzer->getSplitFiles()) {
         SymbolTable* symbols =
-            new SymbolTable(*m_commandLineParser->getSymbolTable());
+          new SymbolTable(m_commandLineParser->getSymbolTable());
         m_symbolTables.push_back(symbols);
         SymbolId ppId = symbols->registerSymbol(chunk);
         symbols->registerSymbol(
-            m_compilers[i]->getParser()->getFileName(LINE1));
+          compiler->getParser()->getFileName(LINE1));
         CompileSourceFile* chunkCompiler = new CompileSourceFile(
-            m_compilers[i], ppId, fileAnalyzer->getLineOffsets()[j]);
+          compiler, ppId, fileAnalyzer->getLineOffsets()[j]);
         // Schedule chunk
         tmp_compilers.push_back(chunkCompiler);
 
@@ -476,29 +463,29 @@ bool Compiler::parseinit_() {
         chunkCompiler->setErrorContainer(errors);
         // chunkCompiler->getParser ()->setFileContent (fileContent);
 
-        FileContent* fileContent =
-            new FileContent(m_compilers[i]->getParser()->getFileId(0),
-                            m_compilers[i]->getParser()->getLibrary(), symbols,
-                            errors, NULL, ppId);
-        chunkCompiler->getParser()->setFileContent(fileContent);
-        getDesign()->addFileContent(m_compilers[i]->getParser()->getFileId(0),
-                                    fileContent);
+        FileContent* const chunkFileContent =
+          new FileContent(compiler->getParser()->getFileId(0),
+                          compiler->getParser()->getLibrary(), symbols,
+                          errors, NULL, ppId);
+        chunkCompiler->getParser()->setFileContent(chunkFileContent);
+        getDesign()->addFileContent(compiler->getParser()->getFileId(0),
+                                    chunkFileContent);
 
         j++;
       }
     } else {
       if (!m_commandLineParser->fileunit()) {
         SymbolTable* symbols =
-            new SymbolTable(*m_commandLineParser->getSymbolTable());
+          new SymbolTable(m_commandLineParser->getSymbolTable());
         m_symbolTables.push_back(symbols);
-        m_compilers[i]->setSymbolTable(symbols);
+        compiler->setSymbolTable(symbols);
         ErrorContainer* errors = new ErrorContainer(symbols);
         m_errorContainers.push_back(errors);
         errors->regiterCmdLine(m_commandLineParser);
-        m_compilers[i]->setErrorContainer(errors);
+        compiler->setErrorContainer(errors);
       }
 
-      tmp_compilers.push_back(m_compilers[i]);
+      tmp_compilers.push_back(compiler);
     }
   }
   m_compilers = tmp_compilers;
@@ -508,91 +495,73 @@ bool Compiler::parseinit_() {
 
 bool Compiler::pythoninit_() { return parseinit_(); }
 
-ErrorContainer::Stats Compiler::getErrorStats() {
+ErrorContainer::Stats Compiler::getErrorStats() const {
   ErrorContainer::Stats stats;
-  unsigned int size = m_errorContainers.size();
-  for (unsigned int i = 0; i < size; i++) {
-    ErrorContainer::Stats tmp;
-    tmp = m_errorContainers[i]->getErrorStats();
-    stats += tmp;
+  for (const auto &s : m_errorContainers) {
+    stats += s->getErrorStats();
   }
 
   return stats;
 }
 
 bool Compiler::cleanup_() {
-  unsigned int size = m_compilers.size();
-  for (unsigned int i = 0; i < size; i++) {
-    delete m_compilers[i];
-  }
-  size = m_compilationUnits.size();
-  for (unsigned int i = 0; i < size; i++) {
-    delete m_compilationUnits[i];
-  }
-  size = m_symbolTables.size();
-  for (unsigned int i = 0; i < size; i++) {
-    delete m_symbolTables[i];
-  }
-  size = m_errorContainers.size();
-  for (unsigned int i = 0; i < size; i++) {
-    delete m_errorContainers[i];
-  }
+  DeleteContainerPointersAndClear(&m_compilers);
+  DeleteContainerPointersAndClear(&m_compilationUnits);
+  DeleteContainerPointersAndClear(&m_symbolTables);
+  DeleteContainerPointersAndClear(&m_errorContainers);
   return true;
 }
 
 bool Compiler::compileFileSet_(CompileSourceFile::Action action,
                                bool allowMultithread,
                                std::vector<CompileSourceFile*>& container) {
-  unsigned short maxThreadCount = m_commandLineParser->getNbMaxTreads();
-  if (allowMultithread == false) {
-    maxThreadCount = 0;
-  }
+  const unsigned short maxThreadCount = allowMultithread
+    ? m_commandLineParser->getNbMaxTreads()
+    : 0;
 
   if (maxThreadCount == 0) {
     // Single thread
-    unsigned int size = container.size();
-    for (unsigned int i = 0; i < size; i++) {
-      container[i]->setPythonInterp(PythonAPI::getMainInterp());
-      bool status = compileOneFile_(container[i], action);
-      m_errors->appendErrors(*container[i]->getErrorContainer());
+    for (CompileSourceFile *const source : container) {
+      source->setPythonInterp(PythonAPI::getMainInterp());
+      bool status = compileOneFile_(source, action);
+      m_errors->appendErrors(*source->getErrorContainer());
       m_errors->printMessages(m_commandLineParser->muteStdout());
-      if ((!status) || container[i]->getErrorContainer()->hasFatalErrors())
+      if ((!status) || source->getErrorContainer()->hasFatalErrors())
         return false;
     }
   } else if (getCommandLineParser()->useTbb() &&
              (action != CompileSourceFile::Action::Parse)) {
 #ifdef USETBB
     // TBB Thread management
-    int maxThreadCount = m_commandLineParser->getNbMaxTreads();
-    if (allowMultithread == false) {
-      maxThreadCount = 0;
-    }
-    unsigned int size = container.size();
+    const int maxThreadCount = allowMultithread
+      ? m_commandLineParser->getNbMaxTreads()
+      : 0;
+
     if (maxThreadCount) {
-      for (unsigned int i = 0; i < size; i++) {
-        m_taskGroup.run(FunctorCompileOneFile(container[i], action));
+      for (CompileSourceFile *const source : container) {
+        m_taskGroup.run(FunctorCompileOneFile(source, action));
       }
       m_taskGroup.wait();
       bool fatalErrors = false;
-      for (unsigned int i = 0; i < size; i++) {
+      for (CompileSourceFile *const source : container) {
         // Promote report to master error container
-        m_errors->appendErrors(*container[i]->getErrorContainer());
-        if (container[i]->getErrorContainer()->hasFatalErrors()) {
+        m_errors->appendErrors(*source->getErrorContainer());
+        if (source->getErrorContainer()->hasFatalErrors()) {
           fatalErrors = true;
         }
         if (getCommandLineParser()->pythonListener()) {
-          container[i]->shutdownPythonInterp();
+          source->shutdownPythonInterp();
         }
         m_errors->printMessages(m_commandLineParser->muteStdout());
       }
       if (fatalErrors) return false;
     } else {
-      for (unsigned int i = 0; i < size; i++) {
-        container[i]->setPythonInterp(PythonAPI::getMainInterp());
-        bool status = compileOneFile_(container[i], action);
-        m_errors->appendErrors(*container[i]->getErrorContainer());
+      for (CompileSourceFile *const source : container) {
+        source->setPythonInterp(PythonAPI::getMainInterp());
+        bool status = compileOneFile_(source, action);
+        m_errors->appendErrors(*souirce->getErrorContainer());
         m_errors->printMessages(m_commandLineParser->muteStdout());
-        if ((!status) || container[i]->getErrorContainer()->hasFatalErrors())
+        if ((!status) || source->getErrorContainer()->hasFatalErrors())
           return false;
       }
     }
@@ -603,13 +572,10 @@ bool Compiler::compileFileSet_(CompileSourceFile::Action action,
     // Optimize the load balance, try to even out the work in each thread by the
     // size of the files
     std::vector<std::vector<CompileSourceFile*>> jobArray(maxThreadCount);
+    std::vector<unsigned long> jobSize(maxThreadCount, 0);
 
-    std::vector<unsigned long> jobSize(maxThreadCount);
-
-    for (unsigned short i = 0; i < maxThreadCount; i++) jobSize[i] = 0;
-
-    for (unsigned int i = 0; i < container.size(); i++) {
-      unsigned int size = container[i]->getJobSize(action);
+    for (CompileSourceFile *const source : container) {
+      const unsigned int size = source->getJobSize(action);
       unsigned int newJobIndex = 0;
       uint64_t minJobQueue = ULLONG_MAX;
       for (unsigned short ii = 0; ii < maxThreadCount; ii++) {
@@ -620,7 +586,7 @@ bool Compiler::compileFileSet_(CompileSourceFile::Action action,
       }
 
       jobSize[newJobIndex] += size;
-      jobArray[newJobIndex].push_back(container[i]);
+      jobArray[newJobIndex].push_back(source);
     }
 
     if (getCommandLineParser()->profile()) {
@@ -669,21 +635,19 @@ bool Compiler::compileFileSet_(CompileSourceFile::Action action,
       threads.push_back(th);
     }
 
-    // Sync the threads
-    for (unsigned int th = 0; th < threads.size(); th++) {
-      threads[th]->join();
+    // Wait for all of them to finish
+    for (auto &t : threads) {
+      t->join();
     }
 
     // Delete the threads
-    for (unsigned int th = 0; th < threads.size(); th++) {
-      delete threads[th];
-    }
+    DeleteContainerPointersAndClear(&threads);
 
     // Promote report to master error container
     bool fatalErrors = false;
-    for (unsigned int j = 0; j < container.size(); j++) {
-      m_errors->appendErrors(*container[j]->getErrorContainer());
-      if (container[j]->getErrorContainer()->hasFatalErrors())
+    for (CompileSourceFile *const source : container) {
+      m_errors->appendErrors(*source->getErrorContainer());
+      if (source->getErrorContainer()->hasFatalErrors())
         fatalErrors = true;
     }
     m_errors->printMessages(m_commandLineParser->muteStdout());
@@ -815,7 +779,7 @@ bool Compiler::compile() {
       }
 
       if (m_commandLineParser->pythonEvalScript()) {
-        PythonAPI::evalScript(m_commandLineParser->getSymbolTable()->getSymbol(
+        PythonAPI::evalScript(m_commandLineParser->getSymbolTable().getSymbol(
                                   m_commandLineParser->pythonEvalScriptId()),
                               m_design);
         if (m_commandLineParser->profile()) {
@@ -830,7 +794,7 @@ bool Compiler::compile() {
       m_errors->printMessages(m_commandLineParser->muteStdout());
     }
 
-    std::string directory = m_commandLineParser->getSymbolTable()->getSymbol(m_commandLineParser->getFullCompileDir());
+    std::string directory = m_commandLineParser->getSymbolTable().getSymbol(m_commandLineParser->getFullCompileDir());
     std::string uhdmFile = directory + "/surelog.uhdm";
     m_uhdmDesign = compileDesign->writeUHDM(uhdmFile);
     // Do not delete as now UHDM has to live past the compilation step

--- a/src/SourceCompile/Compiler.h
+++ b/src/SourceCompile/Compiler.h
@@ -28,29 +28,34 @@ limitations under the License.
 #include <set>
 #include <map>
 #include <thread>
-#include "Design/Design.h"
-#include "Library/LibrarySet.h"
+
 #include "Config/ConfigSet.h"
+#include "Design/Design.h"
+#include "ErrorReporting/ErrorContainer.h"
+#include "Library/LibrarySet.h"
+#include "SourceCompile/CompileSourceFile.h"
 #include "SourceCompile/PreprocessFile.h"
+#include "SourceCompile/SymbolTable.h"
 #include "sv_vpi_user.h"
 
 #ifdef USETBB
-#include <tbb/task.h>
-#include <tbb/task_group.h>
-#include "tbb/task_scheduler_init.h"
+#  include <tbb/task.h>
+#  include <tbb/task_group.h>
+#  include "tbb/task_scheduler_init.h"
 #endif
 
 namespace SURELOG {
 
 class PreprocessFile;
+class FileContent;
 
 class Compiler {
  public:
   Compiler(CommandLineParser* commandLineParser, ErrorContainer* errors,
            SymbolTable* symbolTable);
-  bool compile();
-  Compiler(const Compiler& orig);
   virtual ~Compiler();
+
+  bool compile();
   CommandLineParser* getCommandLineParser() { return m_commandLineParser; }
   SymbolTable* getSymbolTable() { return m_symbolTable; }
   ErrorContainer* getErrorContainer() { return m_errors; }
@@ -62,17 +67,20 @@ class Compiler {
   void registerAntlrPpHandlerForId(SymbolId id,
                                    PreprocessFile::AntlrParserHandler* pp);
   PreprocessFile::AntlrParserHandler* getAntlrPpHandlerForId(SymbolId);
-  ErrorContainer::Stats getErrorStats();
+
   LibrarySet* getLibrarySet() { return m_librarySet; }
   Design* getDesign() { return m_design; }
   vpiHandle getUhdmDesign() { return m_uhdmDesign; }
-  bool isLibraryFile(SymbolId id);
+
+  ErrorContainer::Stats getErrorStats() const;
+  bool isLibraryFile(SymbolId id) const;
 
 #ifdef USETBB
   tbb::task_group& getTaskGroup() { return m_taskGroup; }
 #endif
 
  private:
+  Compiler(const Compiler& orig) = delete;
   bool parseLibrariesDef_();
 
   bool ppinit_();

--- a/src/SourceCompile/ParseFile.cpp
+++ b/src/SourceCompile/ParseFile.cpp
@@ -157,7 +157,7 @@ SymbolId ParseFile::getFileId(unsigned int line) {
     bool inRange = false;
     unsigned int indexOpeningRange = 0;
     unsigned int index = infos.size() - 1;
-    while(1) {     
+    while(1) {
       if ((line >= infos[index].m_originalLine) && (infos[index].m_type == 2)) {
         const std::string& file = pp->getSymbol(infos[index].m_sectionFile);
         SymbolId fileId = getSymbolTable()->registerSymbol(file);
@@ -197,11 +197,11 @@ unsigned int ParseFile::getLineNb(unsigned int line) {
     unsigned int indexOpeningRange = 0;
     unsigned int index = infos.size() - 1;
     while (1) {
-   
+
       if ((line >= infos[index].m_originalLine) && (infos[index].m_type == 2)) {
         return (infos[index].m_sectionStartLine + (line - infos[index].m_originalLine));
       }
-     
+
       if (infos[index].m_type == 2) {
         if (!inRange) {
           inRange = true;
@@ -249,7 +249,7 @@ bool ParseFile::parseOneFile_(std::string fileName, unsigned int lineOffset) {
   std::string suffix = StringUtils::leaf(fileName);
   VerilogVersion version = pp->getVerilogVersion();
   if (version != VerilogVersion::NoVersion) {
-    switch (version) {        
+    switch (version) {
     case VerilogVersion::NoVersion:
       break;
     case VerilogVersion::Verilog1995:
@@ -269,14 +269,14 @@ bool ParseFile::parseOneFile_(std::string fileName, unsigned int lineOffset) {
       break;
     }
   } else {
-    std::string baseFileName = FileUtils::fileName(fileName);
+    std::string baseFileName = FileUtils::basename(fileName);
     if ((suffix == "sv") || (clp->fullSVMode()) || (clp->isSVFile(baseFileName))) {
       antlrParserHandler->m_lexer->sverilog = true;
     } else {
       antlrParserHandler->m_lexer->sverilog = false;
     }
   }
- 
+
   antlrParserHandler->m_lexer->removeErrorListeners();
   antlrParserHandler->m_lexer->addErrorListener(
       antlrParserHandler->m_errorListener);
@@ -343,7 +343,7 @@ std::string ParseFile::getProfileInfo() {
 
 bool ParseFile::parse() {
   Precompiled* prec = Precompiled::getSingleton();
-  std::string root = FileUtils::fileName(this->getPpFileName());
+  std::string root = FileUtils::basename(this->getPpFileName());
   bool precompiled = false;
   if (prec->isFilePrecompiled(root)) precompiled = true;
 
@@ -413,7 +413,7 @@ bool ParseFile::parse() {
       if (!cache.save()) {
         return false;
       }
-      
+
       if (getCompileSourceFile()->getCommandLineParser()->profile()) {
         m_profileInfo += "Cache saving: " + std::to_string(tmr.elapsed_rounded ()) + "\n";
         std::cout << "Cache saving: " + std::to_string(tmr.elapsed_rounded ()) + "\n" << std::flush;

--- a/src/SourceCompile/ParseFile.h
+++ b/src/SourceCompile/ParseFile.h
@@ -23,18 +23,21 @@
 
 #ifndef PARSEFILE_H
 #define PARSEFILE_H
+
 #include <string>
 
+#include "Design/FileContent.h"
+#include "SourceCompile/AntlrParserHandler.h"
 #include "parser/SV3_1aLexer.h"
 #include "parser/SV3_1aParser.h"
-#include "SourceCompile/AntlrParserHandler.h"
-#include "Design/FileContent.h"
+#include "SourceCompile/CompilationUnit.h"
 
 namespace SURELOG {
 
 class SV3_1aTreeShapeListener;
 class SV3_1aPythonListener;
 class AntlrParserErrorListener;
+class CompileSourceFile;
 
 class ParseFile {
  public:

--- a/src/SourceCompile/PreprocessFile.cpp
+++ b/src/SourceCompile/PreprocessFile.cpp
@@ -296,7 +296,7 @@ bool PreprocessFile::preprocess() {
   m_result = "";
   std::string fileName = getSymbol(m_fileId);
   Precompiled* prec = Precompiled::getSingleton();
-  std::string root = FileUtils::fileName(fileName);
+  std::string root = FileUtils::basename(fileName);
   bool precompiled = false;
   if (prec->isFilePrecompiled(root)) precompiled = true;
 

--- a/src/Utils/ContainerUtils.h
+++ b/src/Utils/ContainerUtils.h
@@ -1,0 +1,27 @@
+/* -*- c++ -*-
+ Copyright 2019 Alain Dargelas
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#ifndef CONTAINER_UTILS_H_
+#define CONTAINER_UTILS_H_
+
+// Delete all pointers in a sequence container and clear()'s it.
+template<typename Container>
+void DeleteContainerPointersAndClear(Container *c) {
+  for (auto &item : *c) delete item;
+  c->clear();
+}
+
+#endif  // CONTAINER_UTILS_H_

--- a/src/Utils/FileUtils.cpp
+++ b/src/Utils/FileUtils.cpp
@@ -55,21 +55,21 @@
 
 using namespace SURELOG;
 
-bool FileUtils::fileExists(const std::string name) {
+bool FileUtils::fileExists(const std::string& name) {
   std::error_code ec;
   return fs::exists(name, ec);
 }
 
-unsigned long FileUtils::fileSize(const std::string name) {
+unsigned long FileUtils::fileSize(const std::string& name) {
   std::error_code ec;
   return fs::file_size(name, ec);
 }
 
-bool FileUtils::fileIsDirectory(const std::string name) {
+bool FileUtils::fileIsDirectory(const std::string& name) {
   return fs::is_directory(name);
 }
 
-bool FileUtils::fileIsRegular(const std::string name) {
+bool FileUtils::fileIsRegular(const std::string& name) {
   return fs::is_regular_file(name);
 }
 
@@ -102,18 +102,13 @@ int FileUtils::mkDir(const char* path) {
   return fs::is_directory(dirpath) ? 0 : -1;
 }
 
-std::string FileUtils::getPathName(const std::string path) {
-  fs::path fs_path(path);
-  return fs_path.has_parent_path() ? (fs::path(path).parent_path() += fs::path::preferred_separator).string() : "";
-}
-
-std::string FileUtils::getFullPath(const std::string path) {
+std::string FileUtils::getFullPath(const std::string& path) {
   std::error_code ec;
   fs::path fullPath = fs::canonical(path, ec);
   return ec ? path : fullPath.string();
 }
 
-bool FileUtils::getFullPath(const std::string path, std::string* const result) {
+bool FileUtils::getFullPath(const std::string& path, std::string* result) {
   std::error_code ec;
   fs::path fullPath = fs::canonical(path, ec);
   bool found = (!ec && fileIsRegular(fullPath.string()));
@@ -134,8 +129,8 @@ std::vector<SymbolId> FileUtils::collectFiles(SymbolId dirPath, SymbolId ext,
                       symbols);
 }
 
-std::vector<SymbolId> FileUtils::collectFiles(const std::string dirPath,
-                                              const std::string ext,
+std::vector<SymbolId> FileUtils::collectFiles(const std::string& dirPath,
+                                              const std::string& ext,
                                               SymbolTable* symbols) {
   std::vector<SymbolId> result;
   if (fileIsDirectory(dirPath)) {
@@ -222,18 +217,23 @@ std::vector<SymbolId> FileUtils::collectFiles(const std::string& pathSpec,
   return result;
 }
 
-std::string FileUtils::getFileContent(const std::string filename) {
+std::string FileUtils::getFileContent(const std::string& filename) {
   std::ifstream in(filename, std::ios::in | std::ios::binary);
   if (in) {
-    std::ostringstream contents;
-    contents << in.rdbuf();
-    in.close();
-    return (contents.str());
+    std::string result;
+    result.assign(std::istreambuf_iterator<char>(in),
+                  std::istreambuf_iterator<char>());
+    return result;
   }
   return "FAILED_TO_LOAD_CONTENT";
 }
 
-std::string FileUtils::fileName(std::string str) {
+std::string FileUtils::getPathName(const std::string& path) {
+  fs::path fs_path(path);
+  return fs_path.has_parent_path() ? (fs::path(path).parent_path() += fs::path::preferred_separator).string() : "";
+}
+
+std::string FileUtils::basename(const std::string& str) {
   return fs::path(str).filename().string();
 }
 
@@ -241,11 +241,11 @@ std::string FileUtils::getPreferredPath(const std::string& path) {
   return fs::path(path).make_preferred().string();
 }
 
-std::string FileUtils::makeRelativePath(std::string path) {
+std::string FileUtils::makeRelativePath(const std::string& in_path) {
   const std::string separator(1, fs::path::preferred_separator);
   // Standardize it so we can avoid special cases and wildcards!
-  fs::path p(path);
-  path = p.make_preferred().string();
+  fs::path p(in_path);
+  std::string path = p.make_preferred().string();
   // Handle Windows specific absolute paths
   if (p.is_absolute() && (path.length() > 1) && (path[1] == ':')) path[1] = '$';
   // Swap "..\" (or "../") for "__\" (or "__/")

--- a/src/Utils/FileUtils.h
+++ b/src/Utils/FileUtils.h
@@ -34,28 +34,28 @@ class SymbolTable;
 
 class FileUtils final {
  public:
-  static bool fileExists(const std::string name);
-  static bool fileIsRegular(const std::string name);
-  static bool fileIsDirectory(const std::string name);
+  static bool fileExists(const std::string& name);
+  static bool fileIsRegular(const std::string& name);
+  static bool fileIsDirectory(const std::string& name);
   static SymbolId locateFile(SymbolId file, SymbolTable* symbols,
                              const std::vector<SymbolId>& paths);
   static int mkDir(const char* path);
-  static std::string getFullPath(const std::string path);
-  static bool getFullPath(const std::string path, std::string *const result);
-  static std::string getPathName(const std::string path);
-  static std::string fileName(std::string str);
-  static unsigned long fileSize(const std::string name);
-  static std::vector<SymbolId> collectFiles(const std::string dirPath,
-                                            const std::string extension,
+  static std::string getFullPath(const std::string& path);
+  static bool getFullPath(const std::string& path, std::string *result);
+  static std::string getPathName(const std::string& path);
+  static std::string basename(const std::string& str);
+  static unsigned long fileSize(const std::string& name);
+  static std::vector<SymbolId> collectFiles(const std::string& dirPath,
+                                            const std::string& extension,
                                             SymbolTable* symbols);
   static std::vector<SymbolId> collectFiles(SymbolId dirPath,
                                             SymbolId extension,
                                             SymbolTable* symbols);
   static std::vector<SymbolId> collectFiles(const std::string &pathSpec,
                                             SymbolTable *const symbols);
-  static std::string getFileContent(const std::string name);
-  static std::string getPreferredPath(const std::string &path);
-  static std::string makeRelativePath(std::string path);
+  static std::string getFileContent(const std::string& name);
+  static std::string getPreferredPath(const std::string& path);
+  static std::string makeRelativePath(const std::string& path);
 
  private:
   FileUtils() = delete;


### PR DESCRIPTION
 * In various Compiler iniit functions: use range loops over
   items instead of traditional array size iteration
   (possible since c++11)
 * FileUtil: make std::string arguments const std::string&
 * FileUtil: rename fileName to basename() as this is the
   usual name for such function and it is easier to grep for.
 * CommandLine: provide getSymbolTable() that returns a const
   symbol table for look-up and mutableSymbolTable() that
   returns a pointer for modifiable symbols. This makes it
   easier to reason about code as it is clearly possible to
   see where things are added.
 * IWYU: the Compiler.h was heavily depending on where
   it was included, as it required symbols that it otherwise
   'accidentally' acquired in the place where it was used.
   Simple fix: include as _first_ thing in the Compiler.cpp
   so that it is possible to find all the missing dependencies
   (it requireed to add headers to some other places).
 * Also added a little ContainerUtil, which right now only has a function that deletes pionters
   in an vector, then clears the vector; a common operation, which then saved a few lines
   of loop-code in Compiler.cc

Just code cleanup changes, no semantic changes.

Signed-off-by: Henner Zeller <h.zeller@acm.org>