### PR TITLE
TimeInfo: use enum class for enums and direct member initialization.

### DIFF
--- a/src/Cache/PPCache.cpp
+++ b/src/Cache/PPCache.cpp
@@ -354,12 +354,12 @@ bool PPCache::save() {
   for (auto info : timeinfoList) {
     if (info.m_fileId != m_pp->getFileId(0)) continue;
     auto timeInfo = CACHE::CreateTimeInfo(
-        builder, info.m_type,
-        canonicalSymbols.getId(
-            m_pp->getCompileSourceFile()->getSymbolTable()->getSymbol(
-                info.m_fileId)),
-        info.m_line, info.m_timeUnit, info.m_timeUnitValue,
-        info.m_timePrecision, info.m_timePrecisionValue);
+      builder, static_cast<uint16_t>(info.m_type),
+      canonicalSymbols.getId(
+        m_pp->getCompileSourceFile()->getSymbolTable()->getSymbol(
+          info.m_fileId)),
+      info.m_line, static_cast<uint16_t>(info.m_timeUnit), info.m_timeUnitValue,
+      static_cast<uint16_t>(info.m_timePrecision), info.m_timePrecisionValue);
     timeinfo_vec.push_back(timeInfo);
   }
   auto timeinfoFBList = builder.CreateVector(timeinfo_vec);

--- a/src/Cache/ParseCache.cpp
+++ b/src/Cache/ParseCache.cpp
@@ -209,12 +209,12 @@ bool ParseCache::save() {
     DesignElement& elem = fcontent->getDesignElements()[i];
     TimeInfo& info = elem.m_timeInfo;
     auto timeInfo = CACHE::CreateTimeInfo(
-        builder, info.m_type,
-        canonicalSymbols.getId(
-            m_parse->getCompileSourceFile()->getSymbolTable()->getSymbol(
-                info.m_fileId)),
-        info.m_line, info.m_timeUnit, info.m_timeUnitValue,
-        info.m_timePrecision, info.m_timePrecisionValue);
+      builder, static_cast<uint16_t>(info.m_type),
+      canonicalSymbols.getId(
+        m_parse->getCompileSourceFile()->getSymbolTable()->getSymbol(
+          info.m_fileId)),
+      info.m_line, static_cast<uint16_t>(info.m_timeUnit), info.m_timeUnitValue,
+      static_cast<uint16_t>(info.m_timePrecision), info.m_timePrecisionValue);
     element_vec.push_back(PARSECACHE::CreateDesignElement(
         builder,
         canonicalSymbols.getId(

--- a/src/Design/TimeInfo.cpp
+++ b/src/Design/TimeInfo.cpp
@@ -28,16 +28,16 @@ using namespace SURELOG;
 
 TimeInfo::Unit TimeInfo::unitFromString(std::string_view s) {
   if (s == "s")
-    return Second;
+    return Unit::Second;
   else if (s == "ms")
-    return Millisecond;
+    return Unit::Millisecond;
   else if (s == "us")
-    return Microsecond;
+    return Unit::Microsecond;
   else if (s == "ns")
-    return Nanosecond;
+    return Unit::Nanosecond;
   else if (s == "ps")
-    return Picosecond;
+    return Unit::Picosecond;
   else if (s == "fs")
-    return Femtosecond;
-  return Picosecond;
+    return Unit::Femtosecond;
+  return Unit::Picosecond;
 }

--- a/src/Design/TimeInfo.h
+++ b/src/Design/TimeInfo.h
@@ -31,18 +31,9 @@
 namespace SURELOG {
 
 class TimeInfo final {
- public:
-  TimeInfo()
-      : m_type(None),
-        m_fileId(0),
-        m_line(0),
-        m_timeUnit(Second),
-        m_timeUnitValue(0.0f),
-        m_timePrecision(Second),
-        m_timePrecisionValue(0.0f) {}
-
-  enum Type { None, Timescale, TimeUnitTimePrecision };
-  enum Unit {
+public:
+  enum class Type { None, Timescale, TimeUnitTimePrecision };
+  enum class Unit {
     Second,
     Millisecond,
     Microsecond,
@@ -51,13 +42,13 @@ class TimeInfo final {
     Femtosecond
   };
 
-  Type m_type;
-  SymbolId m_fileId;
-  unsigned int m_line;
-  Unit m_timeUnit;
-  double m_timeUnitValue;
-  Unit m_timePrecision;
-  double m_timePrecisionValue;
+  Type m_type = Type::None;
+  SymbolId m_fileId = 0;
+  unsigned int m_line = 0;
+  Unit m_timeUnit = Unit::Second;
+  double m_timeUnitValue = 0.0;
+  Unit m_timePrecision = Unit::Second;
+  double m_timePrecisionValue = 0.0;
 
   static Unit unitFromString(std::string_view s);
 };

--- a/src/SourceCompile/CheckCompile.cpp
+++ b/src/SourceCompile/CheckCompile.cpp
@@ -96,9 +96,9 @@ bool CheckCompile::checkTimescale_() {
           elem.m_type == DesignElement::Package ||
           elem.m_type == DesignElement::Primitive ||
           elem.m_type == DesignElement::Program) {
-        if (elem.m_timeInfo.m_type == TimeInfo::TimeUnitTimePrecision) {
+        if (elem.m_timeInfo.m_type == TimeInfo::Type::TimeUnitTimePrecision) {
           timeUnitUsed = true;
-        } else if (elem.m_timeInfo.m_type == TimeInfo::Timescale) {
+        } else if (elem.m_timeInfo.m_type == TimeInfo::Type::Timescale) {
           timeScaleUsed = true;
           Location loc(m_compiler->getSymbolTable()->registerSymbol(
                            fileContent->getSymbolTable()->getSymbol(

--- a/src/SourceCompile/SV3_1aPpTreeShapeListener.cpp
+++ b/src/SourceCompile/SV3_1aPpTreeShapeListener.cpp
@@ -436,9 +436,9 @@ void SV3_1aPpTreeShapeListener::enterMacroInstanceWithArgs(
       }
     }
     if (macroBody.empty()) {
-      for (int i = 0; i < nbCRinArgs; i++) 
+      for (int i = 0; i < nbCRinArgs; i++)
         macroBody += "\n";
-    } 
+    }
 
     m_pp->append(pre + macroBody + post);
     // if (macroArgs.find('`') != std::string::npos)
@@ -856,7 +856,7 @@ void SV3_1aPpTreeShapeListener::enterTimescale_directive(SV3_1aPpParser::Timesca
   forwardToParser(ctx);
 
   TimeInfo compUnitTimeInfo;
-  compUnitTimeInfo.m_type = TimeInfo::Timescale;
+  compUnitTimeInfo.m_type = TimeInfo::Type::Timescale;
   compUnitTimeInfo.m_fileId = m_pp->getFileId(0);
   std::pair<int, int> lineCol = ParseUtils::getLineColumn(ctx->TIMESCALE());
   compUnitTimeInfo.m_line = lineCol.first;

--- a/src/SourceCompile/SV3_1aTreeShapeHelper.cpp
+++ b/src/SourceCompile/SV3_1aTreeShapeHelper.cpp
@@ -164,7 +164,7 @@ unsigned int SV3_1aTreeShapeHelper::getFileLine(ParserRuleContext* ctx,
 std::pair<double, TimeInfo::Unit> SV3_1aTreeShapeHelper::getTimeValue(
     SV3_1aParser::Time_literalContext* ctx) {
   double actual_value = 0;
-  TimeInfo::Unit unit = TimeInfo::Second;
+  TimeInfo::Unit unit = TimeInfo::Unit::Second;
   if (ctx->Integral_number())
     actual_value = atoi(ctx->Integral_number()->getText().c_str());
   if (ctx->Real_number())

--- a/src/SourceCompile/SV3_1aTreeShapeListener.cpp
+++ b/src/SourceCompile/SV3_1aTreeShapeListener.cpp
@@ -101,25 +101,25 @@ void SV3_1aTreeShapeListener::exitModule_declaration(
   m_nestedElements.pop();
 }
 
-void SV3_1aTreeShapeListener::exitClass_constructor_declaration(SV3_1aParser::Class_constructor_declarationContext * ctx) { 
+void SV3_1aTreeShapeListener::exitClass_constructor_declaration(SV3_1aParser::Class_constructor_declarationContext * ctx) {
   if (ctx->ENDFUNCTION())
     addVObject((ParserRuleContext*) ctx->ENDFUNCTION(), VObjectType::slEndfunction);
-  addVObject (ctx, VObjectType::slClass_constructor_declaration); 
+  addVObject (ctx, VObjectType::slClass_constructor_declaration);
 }
 
-void SV3_1aTreeShapeListener::exitFunction_body_declaration(SV3_1aParser::Function_body_declarationContext * ctx) { 
+void SV3_1aTreeShapeListener::exitFunction_body_declaration(SV3_1aParser::Function_body_declarationContext * ctx) {
   if (ctx->ENDFUNCTION())
     addVObject((ParserRuleContext*) ctx->ENDFUNCTION(), VObjectType::slEndfunction);
-  addVObject (ctx, VObjectType::slFunction_body_declaration); 
+  addVObject (ctx, VObjectType::slFunction_body_declaration);
 }
 
-void SV3_1aTreeShapeListener::exitTask_body_declaration(SV3_1aParser::Task_body_declarationContext * ctx) { 
+void SV3_1aTreeShapeListener::exitTask_body_declaration(SV3_1aParser::Task_body_declarationContext * ctx) {
   if (ctx->ENDTASK())
     addVObject((ParserRuleContext*) ctx->ENDTASK(), VObjectType::slEndtask);
-  addVObject (ctx, VObjectType::slTask_body_declaration); 
+  addVObject (ctx, VObjectType::slTask_body_declaration);
 }
 
-void SV3_1aTreeShapeListener::exitJump_statement(SV3_1aParser::Jump_statementContext * ctx) { 
+void SV3_1aTreeShapeListener::exitJump_statement(SV3_1aParser::Jump_statementContext * ctx) {
   if (ctx->BREAK()) {
     addVObject((ParserRuleContext*) ctx->BREAK(), VObjectType::slBreakStmt);
   } else if (ctx->CONTINUE()) {
@@ -127,28 +127,28 @@ void SV3_1aTreeShapeListener::exitJump_statement(SV3_1aParser::Jump_statementCon
   } else if (ctx->RETURN()) {
     addVObject((ParserRuleContext*) ctx->RETURN(), VObjectType::slReturnStmt);
   }
-  addVObject (ctx, VObjectType::slJump_statement); 
+  addVObject (ctx, VObjectType::slJump_statement);
 }
 
-void SV3_1aTreeShapeListener::exitClass_declaration(SV3_1aParser::Class_declarationContext * ctx) { 
+void SV3_1aTreeShapeListener::exitClass_declaration(SV3_1aParser::Class_declarationContext * ctx) {
   if (ctx->ENDCLASS())
-    addVObject ((ParserRuleContext*) ctx->ENDCLASS(), VObjectType::slEndclass); 
-  addVObject (ctx, VObjectType::slClass_declaration); 
+    addVObject ((ParserRuleContext*) ctx->ENDCLASS(), VObjectType::slEndclass);
+  addVObject (ctx, VObjectType::slClass_declaration);
 }
 
-void SV3_1aTreeShapeListener::exitInterface_class_declaration(SV3_1aParser::Interface_class_declarationContext * ctx)  { 
+void SV3_1aTreeShapeListener::exitInterface_class_declaration(SV3_1aParser::Interface_class_declarationContext * ctx)  {
   if (ctx->ENDCLASS())
-    addVObject ((ParserRuleContext*) ctx->ENDCLASS(), VObjectType::slEndclass); 
-  addVObject (ctx, VObjectType::slInterface_class_declaration); 
+    addVObject ((ParserRuleContext*) ctx->ENDCLASS(), VObjectType::slEndclass);
+  addVObject (ctx, VObjectType::slInterface_class_declaration);
 }
 
 void SV3_1aTreeShapeListener::exitChecker_declaration(SV3_1aParser::Checker_declarationContext * ctx) {
   if (ctx->ENDCHECKER())
-    addVObject ((ParserRuleContext*) ctx->ENDCHECKER(), VObjectType::slEndchecker); 
-  addVObject (ctx, VObjectType::slChecker_declaration); 
+    addVObject ((ParserRuleContext*) ctx->ENDCHECKER(), VObjectType::slEndchecker);
+  addVObject (ctx, VObjectType::slChecker_declaration);
 }
 
-   
+
 void SV3_1aTreeShapeListener::enterSlline(
     SV3_1aParser::SllineContext * /*ctx*/) {}
 
@@ -200,185 +200,185 @@ void SV3_1aTreeShapeListener::exitInterface_declaration(
     SV3_1aParser::Interface_declarationContext *ctx) {
   if (ctx->EXTERN() == NULL)
     if (ctx->ENDINTERFACE())
-      addVObject ((ParserRuleContext*) ctx->ENDINTERFACE(), VObjectType::slEndinterface); 
+      addVObject ((ParserRuleContext*) ctx->ENDINTERFACE(), VObjectType::slEndinterface);
   addVObject(ctx, VObjectType::slInterface_declaration);
   m_nestedElements.pop();
 }
 
-void SV3_1aTreeShapeListener::exitProperty_expr(SV3_1aParser::Property_exprContext * ctx) { 
+void SV3_1aTreeShapeListener::exitProperty_expr(SV3_1aParser::Property_exprContext * ctx) {
   if (ctx->ENDCASE()) {
-    addVObject ((ParserRuleContext*) ctx->ENDCASE(), VObjectType::slEndcase); 
+    addVObject ((ParserRuleContext*) ctx->ENDCASE(), VObjectType::slEndcase);
   }
-  addVObject (ctx, VObjectType::slProperty_expr); 
+  addVObject (ctx, VObjectType::slProperty_expr);
 }
 
-void SV3_1aTreeShapeListener::exitGenerate_module_case_statement(SV3_1aParser::Generate_module_case_statementContext * ctx) { 
+void SV3_1aTreeShapeListener::exitGenerate_module_case_statement(SV3_1aParser::Generate_module_case_statementContext * ctx) {
   if (ctx->ENDCASE())
-    addVObject ((ParserRuleContext*) ctx->ENDCASE(), VObjectType::slEndcase); 
-  addVObject (ctx, VObjectType::slGenerate_module_case_statement); 
+    addVObject ((ParserRuleContext*) ctx->ENDCASE(), VObjectType::slEndcase);
+  addVObject (ctx, VObjectType::slGenerate_module_case_statement);
 }
 
-void SV3_1aTreeShapeListener::exitGenerate_interface_case_statement(SV3_1aParser::Generate_interface_case_statementContext * ctx) { 
+void SV3_1aTreeShapeListener::exitGenerate_interface_case_statement(SV3_1aParser::Generate_interface_case_statementContext * ctx) {
   if (ctx->ENDCASE())
-    addVObject ((ParserRuleContext*) ctx->ENDCASE(), VObjectType::slEndcase); 
-  addVObject (ctx, VObjectType::slGenerate_interface_case_statement); 
+    addVObject ((ParserRuleContext*) ctx->ENDCASE(), VObjectType::slEndcase);
+  addVObject (ctx, VObjectType::slGenerate_interface_case_statement);
 }
 
-void SV3_1aTreeShapeListener::exitCase_generate_construct(SV3_1aParser::Case_generate_constructContext * ctx) { 
+void SV3_1aTreeShapeListener::exitCase_generate_construct(SV3_1aParser::Case_generate_constructContext * ctx) {
   if (ctx->ENDCASE())
-    addVObject ((ParserRuleContext*) ctx->ENDCASE(), VObjectType::slEndcase); 
-  addVObject (ctx, VObjectType::slCase_generate_construct); 
+    addVObject ((ParserRuleContext*) ctx->ENDCASE(), VObjectType::slEndcase);
+  addVObject (ctx, VObjectType::slCase_generate_construct);
 }
 
-void SV3_1aTreeShapeListener::exitCase_statement(SV3_1aParser::Case_statementContext * ctx) { 
-  if (ctx->ENDCASE()) 
-    addVObject ((ParserRuleContext*) ctx->ENDCASE(), VObjectType::slEndcase); 
-  addVObject (ctx, VObjectType::slCase_statement); 
-}
-
-void SV3_1aTreeShapeListener::exitRandcase_statement(SV3_1aParser::Randcase_statementContext * ctx) { 
+void SV3_1aTreeShapeListener::exitCase_statement(SV3_1aParser::Case_statementContext * ctx) {
   if (ctx->ENDCASE())
-    addVObject ((ParserRuleContext*) ctx->ENDCASE(), VObjectType::slEndcase); 
+    addVObject ((ParserRuleContext*) ctx->ENDCASE(), VObjectType::slEndcase);
+  addVObject (ctx, VObjectType::slCase_statement);
+}
+
+void SV3_1aTreeShapeListener::exitRandcase_statement(SV3_1aParser::Randcase_statementContext * ctx) {
+  if (ctx->ENDCASE())
+    addVObject ((ParserRuleContext*) ctx->ENDCASE(), VObjectType::slEndcase);
   addVObject (ctx, VObjectType::slRandcase_statement);
 }
 
-void SV3_1aTreeShapeListener::exitRs_case(SV3_1aParser::Rs_caseContext * ctx) { 
+void SV3_1aTreeShapeListener::exitRs_case(SV3_1aParser::Rs_caseContext * ctx) {
   if (ctx->ENDCASE())
-    addVObject ((ParserRuleContext*) ctx->ENDCASE(), VObjectType::slEndcase); 
-  addVObject (ctx, VObjectType::slRs_case); 
+    addVObject ((ParserRuleContext*) ctx->ENDCASE(), VObjectType::slEndcase);
+  addVObject (ctx, VObjectType::slRs_case);
 }
 
-void SV3_1aTreeShapeListener::exitSequence_declaration(SV3_1aParser::Sequence_declarationContext * ctx) { 
+void SV3_1aTreeShapeListener::exitSequence_declaration(SV3_1aParser::Sequence_declarationContext * ctx) {
   if (ctx->ENDSEQUENCE())
-    addVObject ((ParserRuleContext*) ctx->ENDSEQUENCE(), VObjectType::slEndsequence); 
-  addVObject (ctx, VObjectType::slSequence_declaration); 
+    addVObject ((ParserRuleContext*) ctx->ENDSEQUENCE(), VObjectType::slEndsequence);
+  addVObject (ctx, VObjectType::slSequence_declaration);
 }
 
-void SV3_1aTreeShapeListener::exitRandsequence_statement(SV3_1aParser::Randsequence_statementContext * ctx) { 
+void SV3_1aTreeShapeListener::exitRandsequence_statement(SV3_1aParser::Randsequence_statementContext * ctx) {
   if (ctx->ENDSEQUENCE())
-    addVObject ((ParserRuleContext*) ctx->ENDSEQUENCE(), VObjectType::slEndsequence); 
-  addVObject (ctx, VObjectType::slRandsequence_statement); 
+    addVObject ((ParserRuleContext*) ctx->ENDSEQUENCE(), VObjectType::slEndsequence);
+  addVObject (ctx, VObjectType::slRandsequence_statement);
 }
 
 void SV3_1aTreeShapeListener::exitSeq_block(SV3_1aParser::Seq_blockContext * ctx) {
   if (ctx->END())
-    addVObject ((ParserRuleContext*) ctx->END(), VObjectType::slEnd);  
-  addVObject (ctx, VObjectType::slSeq_block); 
+    addVObject ((ParserRuleContext*) ctx->END(), VObjectType::slEnd);
+  addVObject (ctx, VObjectType::slSeq_block);
 }
 
 
-void SV3_1aTreeShapeListener::exitGenerate_module_named_block(SV3_1aParser::Generate_module_named_blockContext * ctx) { 
+void SV3_1aTreeShapeListener::exitGenerate_module_named_block(SV3_1aParser::Generate_module_named_blockContext * ctx) {
   if (ctx->END())
-    addVObject ((ParserRuleContext*) ctx->END(), VObjectType::slEnd);  
-  addVObject (ctx, VObjectType::slGenerate_module_named_block); 
+    addVObject ((ParserRuleContext*) ctx->END(), VObjectType::slEnd);
+  addVObject (ctx, VObjectType::slGenerate_module_named_block);
 }
 
-void SV3_1aTreeShapeListener::exitGenerate_module_block(SV3_1aParser::Generate_module_blockContext * ctx) { 
+void SV3_1aTreeShapeListener::exitGenerate_module_block(SV3_1aParser::Generate_module_blockContext * ctx) {
   if (ctx->END())
-    addVObject ((ParserRuleContext*) ctx->END(), VObjectType::slEnd);  
-  addVObject (ctx, VObjectType::slGenerate_module_block); 
+    addVObject ((ParserRuleContext*) ctx->END(), VObjectType::slEnd);
+  addVObject (ctx, VObjectType::slGenerate_module_block);
 }
 
-void SV3_1aTreeShapeListener::exitGenerate_interface_named_block(SV3_1aParser::Generate_interface_named_blockContext * ctx)  { 
+void SV3_1aTreeShapeListener::exitGenerate_interface_named_block(SV3_1aParser::Generate_interface_named_blockContext * ctx)  {
   if (ctx->END())
-    addVObject ((ParserRuleContext*) ctx->END(), VObjectType::slEnd);  
-  addVObject (ctx, VObjectType::slGenerate_interface_named_block); 
+    addVObject ((ParserRuleContext*) ctx->END(), VObjectType::slEnd);
+  addVObject (ctx, VObjectType::slGenerate_interface_named_block);
 }
 
-void SV3_1aTreeShapeListener::exitGenerate_interface_block(SV3_1aParser::Generate_interface_blockContext * ctx) { 
+void SV3_1aTreeShapeListener::exitGenerate_interface_block(SV3_1aParser::Generate_interface_blockContext * ctx) {
   if (ctx->END())
-    addVObject ((ParserRuleContext*) ctx->END(), VObjectType::slEnd);  
-  addVObject (ctx, VObjectType::slGenerate_interface_block); 
+    addVObject ((ParserRuleContext*) ctx->END(), VObjectType::slEnd);
+  addVObject (ctx, VObjectType::slGenerate_interface_block);
 }
 
-void SV3_1aTreeShapeListener::exitGenerate_block(SV3_1aParser::Generate_blockContext * ctx) { 
+void SV3_1aTreeShapeListener::exitGenerate_block(SV3_1aParser::Generate_blockContext * ctx) {
   if (ctx->END())
-    addVObject ((ParserRuleContext*) ctx->END(), VObjectType::slEnd);  
-  addVObject (ctx, VObjectType::slGenerate_block); 
+    addVObject ((ParserRuleContext*) ctx->END(), VObjectType::slEnd);
+  addVObject (ctx, VObjectType::slGenerate_block);
 }
 
 void SV3_1aTreeShapeListener::exitNamed_port_connection(SV3_1aParser::Named_port_connectionContext * ctx) {
    if (ctx->DOTSTAR())
-    addVObject ((ParserRuleContext*) ctx->DOTSTAR(), VObjectType::slDotStar);  
+    addVObject ((ParserRuleContext*) ctx->DOTSTAR(), VObjectType::slDotStar);
   addVObject (ctx, VObjectType::slNamed_port_connection);
 }
 
 void SV3_1aTreeShapeListener::exitPattern(SV3_1aParser::PatternContext * ctx) {
   if (ctx->DOTSTAR())
-    addVObject ((ParserRuleContext*) ctx->DOTSTAR(), VObjectType::slDotStar);  
+    addVObject ((ParserRuleContext*) ctx->DOTSTAR(), VObjectType::slDotStar);
   addVObject (ctx, VObjectType::slPattern);
 }
 
-void SV3_1aTreeShapeListener::exitSpecify_block(SV3_1aParser::Specify_blockContext * ctx) { 
+void SV3_1aTreeShapeListener::exitSpecify_block(SV3_1aParser::Specify_blockContext * ctx) {
   if (ctx->ENDSPECIFY())
     addVObject ((ParserRuleContext*) ctx->ENDSPECIFY(), VObjectType::slEndspecify);
   addVObject (ctx, VObjectType::slSpecify_block);
 }
 
-void SV3_1aTreeShapeListener::exitConfig_declaration(SV3_1aParser::Config_declarationContext * ctx) { 
+void SV3_1aTreeShapeListener::exitConfig_declaration(SV3_1aParser::Config_declarationContext * ctx) {
   if (ctx->ENDCONFIG())
     addVObject ((ParserRuleContext*) ctx->ENDCONFIG(), VObjectType::slEndconfig);
-  addVObject (ctx, VObjectType::slConfig_declaration); 
+  addVObject (ctx, VObjectType::slConfig_declaration);
 }
 
-void SV3_1aTreeShapeListener::exitProperty_declaration(SV3_1aParser::Property_declarationContext * ctx) { 
+void SV3_1aTreeShapeListener::exitProperty_declaration(SV3_1aParser::Property_declarationContext * ctx) {
   if (ctx->ENDPROPERTY())
     addVObject ((ParserRuleContext*) ctx->ENDPROPERTY(), VObjectType::slEndproperty);
-  addVObject (ctx, VObjectType::slProperty_declaration); 
+  addVObject (ctx, VObjectType::slProperty_declaration);
 }
 
-void SV3_1aTreeShapeListener::exitCovergroup_declaration(SV3_1aParser::Covergroup_declarationContext * ctx) { 
+void SV3_1aTreeShapeListener::exitCovergroup_declaration(SV3_1aParser::Covergroup_declarationContext * ctx) {
   if (ctx->ENDGROUP())
     addVObject ((ParserRuleContext*) ctx->ENDGROUP(), VObjectType::slEndgroup);
-  addVObject (ctx, VObjectType::slCovergroup_declaration); 
+  addVObject (ctx, VObjectType::slCovergroup_declaration);
 }
 
-void SV3_1aTreeShapeListener::exitGenerated_module_instantiation(SV3_1aParser::Generated_module_instantiationContext * ctx) { 
+void SV3_1aTreeShapeListener::exitGenerated_module_instantiation(SV3_1aParser::Generated_module_instantiationContext * ctx) {
  if (ctx->ENDGENERATE())
     addVObject ((ParserRuleContext*) ctx->ENDGENERATE(), VObjectType::slEndgenerate);
-  addVObject (ctx, VObjectType::slGenerated_module_instantiation); 
+  addVObject (ctx, VObjectType::slGenerated_module_instantiation);
 }
 
-void SV3_1aTreeShapeListener::exitGenerated_interface_instantiation(SV3_1aParser::Generated_interface_instantiationContext * ctx)  { 
+void SV3_1aTreeShapeListener::exitGenerated_interface_instantiation(SV3_1aParser::Generated_interface_instantiationContext * ctx)  {
   if (ctx->ENDGENERATE())
     addVObject ((ParserRuleContext*) ctx->ENDGENERATE(), VObjectType::slEndgenerate);
-  addVObject (ctx, VObjectType::slGenerated_interface_instantiation); 
+  addVObject (ctx, VObjectType::slGenerated_interface_instantiation);
 }
 
-void SV3_1aTreeShapeListener::exitGenerate_region(SV3_1aParser::Generate_regionContext * ctx) { 
+void SV3_1aTreeShapeListener::exitGenerate_region(SV3_1aParser::Generate_regionContext * ctx) {
   if (ctx->ENDGENERATE())
     addVObject ((ParserRuleContext*) ctx->ENDGENERATE(), VObjectType::slEndgenerate);
-  addVObject (ctx, VObjectType::slGenerate_region); 
+  addVObject (ctx, VObjectType::slGenerate_region);
 }
 
-void SV3_1aTreeShapeListener::exitUdp_declaration(SV3_1aParser::Udp_declarationContext * ctx) { 
+void SV3_1aTreeShapeListener::exitUdp_declaration(SV3_1aParser::Udp_declarationContext * ctx) {
   if (ctx->ENDPRIMITIVE())
     addVObject ((ParserRuleContext*) ctx->ENDPRIMITIVE(), VObjectType::slEndprimitive);
-  addVObject (ctx, VObjectType::slUdp_declaration); 
-}
- 
-void SV3_1aTreeShapeListener::exitCombinational_body(SV3_1aParser::Combinational_bodyContext * ctx) { 
-  if (ctx->ENDTABLE())
-    addVObject ((ParserRuleContext*) ctx->ENDTABLE(), VObjectType::slEndtable);
-  addVObject (ctx, VObjectType::slCombinational_body); 
+  addVObject (ctx, VObjectType::slUdp_declaration);
 }
 
-void SV3_1aTreeShapeListener::exitSequential_body(SV3_1aParser::Sequential_bodyContext * ctx) { 
+void SV3_1aTreeShapeListener::exitCombinational_body(SV3_1aParser::Combinational_bodyContext * ctx) {
   if (ctx->ENDTABLE())
     addVObject ((ParserRuleContext*) ctx->ENDTABLE(), VObjectType::slEndtable);
-  addVObject (ctx, VObjectType::slSequential_body); 
+  addVObject (ctx, VObjectType::slCombinational_body);
 }
 
-void SV3_1aTreeShapeListener::exitClocking_declaration(SV3_1aParser::Clocking_declarationContext * ctx) { 
+void SV3_1aTreeShapeListener::exitSequential_body(SV3_1aParser::Sequential_bodyContext * ctx) {
+  if (ctx->ENDTABLE())
+    addVObject ((ParserRuleContext*) ctx->ENDTABLE(), VObjectType::slEndtable);
+  addVObject (ctx, VObjectType::slSequential_body);
+}
+
+void SV3_1aTreeShapeListener::exitClocking_declaration(SV3_1aParser::Clocking_declarationContext * ctx) {
   if (ctx->ENDCLOCKING())
     addVObject ((ParserRuleContext*) ctx->ENDCLOCKING(), VObjectType::slEndclocking);
-  addVObject (ctx, VObjectType::slClocking_declaration); 
+  addVObject (ctx, VObjectType::slClocking_declaration);
 }
 
-void SV3_1aTreeShapeListener::exitPackage_declaration(SV3_1aParser::Package_declarationContext * ctx)  { 
+void SV3_1aTreeShapeListener::exitPackage_declaration(SV3_1aParser::Package_declarationContext * ctx)  {
   if (ctx->ENDPACKAGE())
-    addVObject ((ParserRuleContext*) ctx->ENDPACKAGE(), VObjectType::slEndpackage); 
-  addVObject (ctx, VObjectType::slPackage_declaration); 
+    addVObject ((ParserRuleContext*) ctx->ENDPACKAGE(), VObjectType::slEndpackage);
+  addVObject (ctx, VObjectType::slPackage_declaration);
 }
 
 void SV3_1aTreeShapeListener::enterProgram_declaration(
@@ -426,7 +426,7 @@ void SV3_1aTreeShapeListener::enterPackage_declaration(
 void SV3_1aTreeShapeListener::enterTimeUnitsDecl_TimeUnit(
     SV3_1aParser::TimeUnitsDecl_TimeUnitContext *ctx) {
   if (m_currentElement) {
-    m_currentElement->m_timeInfo.m_type = TimeInfo::TimeUnitTimePrecision;
+    m_currentElement->m_timeInfo.m_type = TimeInfo::Type::TimeUnitTimePrecision;
     auto pair = getTimeValue(ctx->time_literal());
     m_currentElement->m_timeInfo.m_timeUnitValue = pair.first;
     m_currentElement->m_timeInfo.m_timeUnit = pair.second;
@@ -436,7 +436,7 @@ void SV3_1aTreeShapeListener::enterTimeUnitsDecl_TimeUnit(
 void SV3_1aTreeShapeListener::enterTimescale_directive(SV3_1aParser::Timescale_directiveContext *ctx)
 {
   TimeInfo compUnitTimeInfo;
-  compUnitTimeInfo.m_type = TimeInfo::Timescale;
+  compUnitTimeInfo.m_type = TimeInfo::Type::Timescale;
   compUnitTimeInfo.m_fileId = m_pf->getFileId(0);
   std::pair<int, int> lineCol = ParseUtils::getLineColumn(ctx->TICK_TIMESCALE());
   compUnitTimeInfo.m_line = lineCol.first;
@@ -460,7 +460,7 @@ void SV3_1aTreeShapeListener::enterTimescale_directive(SV3_1aParser::Timescale_d
 void SV3_1aTreeShapeListener::enterTimeUnitsDecl_TimePrecision(
     SV3_1aParser::TimeUnitsDecl_TimePrecisionContext *ctx) {
   if (m_currentElement) {
-    m_currentElement->m_timeInfo.m_type = TimeInfo::TimeUnitTimePrecision;
+    m_currentElement->m_timeInfo.m_type = TimeInfo::Type::TimeUnitTimePrecision;
     auto pair = getTimeValue(ctx->time_literal());
     m_currentElement->m_timeInfo.m_timePrecisionValue = pair.first;
     m_currentElement->m_timeInfo.m_timePrecision = pair.second;
@@ -470,7 +470,7 @@ void SV3_1aTreeShapeListener::enterTimeUnitsDecl_TimePrecision(
 void SV3_1aTreeShapeListener::enterTimeUnitsDecl_TimeUnitTimePrecision(
     SV3_1aParser::TimeUnitsDecl_TimeUnitTimePrecisionContext *ctx) {
   if (m_currentElement) {
-    m_currentElement->m_timeInfo.m_type = TimeInfo::TimeUnitTimePrecision;
+    m_currentElement->m_timeInfo.m_type = TimeInfo::Type::TimeUnitTimePrecision;
     auto pair = getTimeValue(ctx->time_literal(0));
     m_currentElement->m_timeInfo.m_timeUnitValue = pair.first;
     m_currentElement->m_timeInfo.m_timeUnit = pair.second;
@@ -483,7 +483,7 @@ void SV3_1aTreeShapeListener::enterTimeUnitsDecl_TimeUnitTimePrecision(
 void SV3_1aTreeShapeListener::enterTimeUnitsDecl_TimeUnitDiv(
     SV3_1aParser::TimeUnitsDecl_TimeUnitDivContext *ctx) {
   if (m_currentElement) {
-    m_currentElement->m_timeInfo.m_type = TimeInfo::TimeUnitTimePrecision;
+    m_currentElement->m_timeInfo.m_type = TimeInfo::Type::TimeUnitTimePrecision;
     auto pair = getTimeValue(ctx->time_literal(0));
     m_currentElement->m_timeInfo.m_timeUnitValue = pair.first;
     m_currentElement->m_timeInfo.m_timeUnit = pair.second;
@@ -496,7 +496,7 @@ void SV3_1aTreeShapeListener::enterTimeUnitsDecl_TimeUnitDiv(
 void SV3_1aTreeShapeListener::enterTimeUnitsDecl_TimePrecisionTimeUnit(
     SV3_1aParser::TimeUnitsDecl_TimePrecisionTimeUnitContext *ctx) {
   if (m_currentElement) {
-    m_currentElement->m_timeInfo.m_type = TimeInfo::TimeUnitTimePrecision;
+    m_currentElement->m_timeInfo.m_type = TimeInfo::Type::TimeUnitTimePrecision;
     auto pair = getTimeValue(ctx->time_literal(1));
     m_currentElement->m_timeInfo.m_timeUnitValue = pair.first;
     m_currentElement->m_timeInfo.m_timeUnit = pair.second;
@@ -581,10 +581,10 @@ void SV3_1aTreeShapeListener::exitPound_delay_value(
   SV3_1aParser::Pound_delay_valueContext *ctx) {
   if (ctx->Pound_delay()) {
      addVObject(ctx, ctx->Pound_delay()->getText(),
-             VObjectType::slIntConst);  
+             VObjectType::slIntConst);
   } else if (ctx->delay_value()) {
      addVObject(ctx, ctx->delay_value()->getText(),
-             VObjectType::slIntConst);  
+             VObjectType::slIntConst);
   }
 }
 
@@ -616,7 +616,7 @@ void SV3_1aTreeShapeListener::exitIdentifier(
     ident = ctx->RANDOMIZE()->getText();
   else if (ctx->SAMPLE())
     ident = ctx->SAMPLE()->getText();
-  
+
   // !!! Don't forget to change CompileModule.cpp type checker !!!
   addVObject(ctx, ident, VObjectType::slStringConst);
 
@@ -625,7 +625,7 @@ void SV3_1aTreeShapeListener::exitIdentifier(
   }
 }
 
-void SV3_1aTreeShapeListener::exitUnique_priority(SV3_1aParser::Unique_priorityContext * ctx) { 
+void SV3_1aTreeShapeListener::exitUnique_priority(SV3_1aParser::Unique_priorityContext * ctx) {
   if (ctx->PRIORITY()) {
     addVObject((ParserRuleContext *)ctx->PRIORITY(), VObjectType::slPriority);
   } else if (ctx->UNIQUE()) {
@@ -633,18 +633,18 @@ void SV3_1aTreeShapeListener::exitUnique_priority(SV3_1aParser::Unique_priorityC
   } else if (ctx->UNIQUE0()) {
     addVObject((ParserRuleContext *)ctx->UNIQUE0(), VObjectType::slUnique0);
   }
-  addVObject (ctx, VObjectType::slUnique_priority); 
+  addVObject (ctx, VObjectType::slUnique_priority);
 }
 
-void SV3_1aTreeShapeListener::exitCase_keyword(SV3_1aParser::Case_keywordContext * ctx) { 
+void SV3_1aTreeShapeListener::exitCase_keyword(SV3_1aParser::Case_keywordContext * ctx) {
   if (ctx->CASE()) {
     addVObject((ParserRuleContext *)ctx->CASE(), VObjectType::slCase);
   } else  if (ctx->CASEX()) {
     addVObject((ParserRuleContext *)ctx->CASEX(), VObjectType::slCaseX);
   } else  if (ctx->CASEZ()) {
     addVObject((ParserRuleContext *)ctx->CASEZ(), VObjectType::slCaseZ);
-  } 
-  addVObject (ctx, VObjectType::slCase_keyword); 
+  }
+  addVObject (ctx, VObjectType::slCase_keyword);
 }
 
 void SV3_1aTreeShapeListener::exitPart_select_op_column(SV3_1aParser::Part_select_op_columnContext * ctx) {
@@ -654,15 +654,15 @@ void SV3_1aTreeShapeListener::exitPart_select_op_column(SV3_1aParser::Part_selec
     addVObject(ctx, VObjectType::slDecPartSelectOp);
   } else  if (ctx->COLUMN()) {
     addVObject(ctx, VObjectType::slColumnPartSelectOp);
-  }  
+  }
 }
 
-void SV3_1aTreeShapeListener::exitPart_select_op(SV3_1aParser::Part_select_opContext * ctx) { 
+void SV3_1aTreeShapeListener::exitPart_select_op(SV3_1aParser::Part_select_opContext * ctx) {
   if (ctx->INC_PART_SELECT_OP()) {
     addVObject (ctx, VObjectType::slIncPartSelectOp);
   } else  if (ctx->DEC_PART_SELECT_OP()) {
     addVObject(ctx, VObjectType::slDecPartSelectOp);
-  } 
+  }
 }
 
 void SV3_1aTreeShapeListener::exitSystem_task_names(SV3_1aParser::System_task_namesContext * ctx) {
@@ -672,13 +672,13 @@ void SV3_1aTreeShapeListener::exitSystem_task_names(SV3_1aParser::System_task_na
   else if (ctx->REALTIME())
     addVObject((ParserRuleContext *)ctx->REALTIME(), ident, VObjectType::slStringConst);
   else if (ctx->ASSERT())
-    addVObject((ParserRuleContext *)ctx->ASSERT(), ident, VObjectType::slStringConst); 
+    addVObject((ParserRuleContext *)ctx->ASSERT(), ident, VObjectType::slStringConst);
   else if (ctx->Simple_identifier().size())
-    addVObject((ParserRuleContext *)ctx->Simple_identifier()[0], ident, VObjectType::slStringConst);  
+    addVObject((ParserRuleContext *)ctx->Simple_identifier()[0], ident, VObjectType::slStringConst);
   else if (ctx->SIGNED())
-    addVObject((ParserRuleContext *)ctx->SIGNED(), ident, VObjectType::slStringConst);    
+    addVObject((ParserRuleContext *)ctx->SIGNED(), ident, VObjectType::slStringConst);
   else if (ctx->UNSIGNED())
-    addVObject((ParserRuleContext *)ctx->UNSIGNED(), ident, VObjectType::slStringConst);      
+    addVObject((ParserRuleContext *)ctx->UNSIGNED(), ident, VObjectType::slStringConst);
   addVObject(ctx, VObjectType::slSystem_task_names);
 }
 
@@ -747,16 +747,16 @@ void SV3_1aTreeShapeListener::exitFile_path_spec(
   }
 }
 
-void SV3_1aTreeShapeListener::exitAnonymous_program(SV3_1aParser::Anonymous_programContext * ctx)  { 
+void SV3_1aTreeShapeListener::exitAnonymous_program(SV3_1aParser::Anonymous_programContext * ctx)  {
   if (ctx->ENDPROGRAM())
     addVObject ((ParserRuleContext*)ctx->ENDPROGRAM(), VObjectType::slEndprogram);
   addVObject (ctx, VObjectType::slAnonymous_program);
 }
 
-void SV3_1aTreeShapeListener::exitProgram_declaration(SV3_1aParser::Program_declarationContext * ctx) { 
+void SV3_1aTreeShapeListener::exitProgram_declaration(SV3_1aParser::Program_declarationContext * ctx) {
   if (ctx->ENDPROGRAM())
     addVObject ((ParserRuleContext*)ctx->ENDPROGRAM(), VObjectType::slEndprogram);
-  addVObject (ctx, VObjectType::slProgram_declaration); 
+  addVObject (ctx, VObjectType::slProgram_declaration);
 }
 
 void SV3_1aTreeShapeListener::exitProcedural_continuous_assignment(SV3_1aParser::Procedural_continuous_assignmentContext * ctx) {
@@ -768,11 +768,11 @@ void SV3_1aTreeShapeListener::exitProcedural_continuous_assignment(SV3_1aParser:
     addVObject ((ParserRuleContext*)ctx->FORCE(), VObjectType::slForce);
   } else if (ctx->RELEASE()) {
     addVObject ((ParserRuleContext*)ctx->RELEASE(), VObjectType::slRelease);
-  } 
-  addVObject (ctx, VObjectType::slProcedural_continuous_assignment); 
+  }
+  addVObject (ctx, VObjectType::slProcedural_continuous_assignment);
 }
-   
-void SV3_1aTreeShapeListener::exitDrive_strength(SV3_1aParser::Drive_strengthContext * ctx)  { 
+
+void SV3_1aTreeShapeListener::exitDrive_strength(SV3_1aParser::Drive_strengthContext * ctx)  {
   if (ctx->SUPPLY0()) {
     addVObject ((ParserRuleContext*)ctx->SUPPLY0(), VObjectType::slSupply0);
   } else if (ctx->STRONG0()) {
@@ -781,7 +781,7 @@ void SV3_1aTreeShapeListener::exitDrive_strength(SV3_1aParser::Drive_strengthCon
     addVObject ((ParserRuleContext*)ctx->PULL0(), VObjectType::slPull0);
   } else if (ctx->WEAK0()) {
     addVObject ((ParserRuleContext*)ctx->WEAK0(), VObjectType::slWeak0);
-  } 
+  }
   if (ctx->SUPPLY1()) {
     addVObject ((ParserRuleContext*)ctx->SUPPLY1(), VObjectType::slSupply1);
   } else if (ctx->STRONG1()) {
@@ -790,17 +790,17 @@ void SV3_1aTreeShapeListener::exitDrive_strength(SV3_1aParser::Drive_strengthCon
     addVObject ((ParserRuleContext*)ctx->PULL1(), VObjectType::slPull1);
   } else if (ctx->WEAK1()) {
     addVObject ((ParserRuleContext*)ctx->WEAK1(), VObjectType::slWeak1);
-  } 
+  }
 
   if (ctx->HIGHZ0()) {
     addVObject ((ParserRuleContext*)ctx->HIGHZ0(), VObjectType::slHighZ0);
   } else if (ctx->HIGHZ1()) {
     addVObject ((ParserRuleContext*)ctx->HIGHZ1(), VObjectType::slHighZ1);
   }
-  addVObject (ctx, VObjectType::slDrive_strength); 
+  addVObject (ctx, VObjectType::slDrive_strength);
 }
 
-void SV3_1aTreeShapeListener::exitStrength0(SV3_1aParser::Strength0Context * ctx)  { 
+void SV3_1aTreeShapeListener::exitStrength0(SV3_1aParser::Strength0Context * ctx)  {
   if (ctx->SUPPLY0()) {
     addVObject ((ParserRuleContext*)ctx->SUPPLY0(), VObjectType::slSupply0);
   } else if (ctx->STRONG0()) {
@@ -809,8 +809,8 @@ void SV3_1aTreeShapeListener::exitStrength0(SV3_1aParser::Strength0Context * ctx
     addVObject ((ParserRuleContext*)ctx->PULL0(), VObjectType::slPull0);
   } else if (ctx->WEAK0()) {
     addVObject ((ParserRuleContext*)ctx->WEAK0(), VObjectType::slWeak0);
-  } 
-  addVObject (ctx, VObjectType::slStrength0); 
+  }
+  addVObject (ctx, VObjectType::slStrength0);
 }
 
 void SV3_1aTreeShapeListener::exitAction_block(SV3_1aParser::Action_blockContext * ctx)
@@ -831,7 +831,7 @@ void SV3_1aTreeShapeListener::exitEvent_trigger(SV3_1aParser::Event_triggerConte
 }
 
 
-void SV3_1aTreeShapeListener::exitStrength1(SV3_1aParser::Strength1Context * ctx)  { 
+void SV3_1aTreeShapeListener::exitStrength1(SV3_1aParser::Strength1Context * ctx)  {
   if (ctx->SUPPLY1()) {
     addVObject ((ParserRuleContext*)ctx->SUPPLY1(), VObjectType::slSupply1);
   } else if (ctx->STRONG1()) {
@@ -840,11 +840,11 @@ void SV3_1aTreeShapeListener::exitStrength1(SV3_1aParser::Strength1Context * ctx
     addVObject ((ParserRuleContext*)ctx->PULL1(), VObjectType::slPull1);
   } else if (ctx->WEAK1()) {
     addVObject ((ParserRuleContext*)ctx->WEAK1(), VObjectType::slWeak1);
-  } 
-  addVObject (ctx, VObjectType::slStrength1); 
+  }
+  addVObject (ctx, VObjectType::slStrength1);
 }
 
-void SV3_1aTreeShapeListener::exitCharge_strength(SV3_1aParser::Charge_strengthContext * ctx) { 
+void SV3_1aTreeShapeListener::exitCharge_strength(SV3_1aParser::Charge_strengthContext * ctx) {
   if (ctx->SMALL()) {
     addVObject ((ParserRuleContext*)ctx->SMALL(), VObjectType::slSmall);
   } else if (ctx->MEDIUM()) {
@@ -852,19 +852,19 @@ void SV3_1aTreeShapeListener::exitCharge_strength(SV3_1aParser::Charge_strengthC
   } else if (ctx->LARGE()) {
     addVObject ((ParserRuleContext*)ctx->LARGE(), VObjectType::slLarge);
   }
-  addVObject (ctx, VObjectType::slCharge_strength); 
+  addVObject (ctx, VObjectType::slCharge_strength);
 }
 
-void SV3_1aTreeShapeListener::exitStream_operator(SV3_1aParser::Stream_operatorContext * ctx) { 
+void SV3_1aTreeShapeListener::exitStream_operator(SV3_1aParser::Stream_operatorContext * ctx) {
   if (ctx->SHIFT_RIGHT()) {
     addVObject ((ParserRuleContext*)ctx->SHIFT_RIGHT(), VObjectType::slBinOp_ShiftRight);
   } else if (ctx->SHIFT_LEFT()) {
     addVObject ((ParserRuleContext*)ctx->SHIFT_LEFT(), VObjectType::slBinOp_ShiftLeft);
-  } 
-  addVObject (ctx, VObjectType::slStream_operator); 
+  }
+  addVObject (ctx, VObjectType::slStream_operator);
 }
 
-void SV3_1aTreeShapeListener::exitLoop_statement(SV3_1aParser::Loop_statementContext * ctx) { 
+void SV3_1aTreeShapeListener::exitLoop_statement(SV3_1aParser::Loop_statementContext * ctx) {
   if (ctx->DO()) {
     addVObject ((ParserRuleContext*)ctx->DO(), VObjectType::slDo);
   } else if (ctx->FOREVER()) {
@@ -877,11 +877,11 @@ void SV3_1aTreeShapeListener::exitLoop_statement(SV3_1aParser::Loop_statementCon
     addVObject ((ParserRuleContext*)ctx->FOR(), VObjectType::slFor);
   } else if (ctx->FOREACH()) {
     addVObject ((ParserRuleContext*)ctx->FOREACH(), VObjectType::slForeach);
-  } 
-  addVObject (ctx, VObjectType::slLoop_statement); 
+  }
+  addVObject (ctx, VObjectType::slLoop_statement);
 }
 
- 
+
 void SV3_1aTreeShapeListener::exitPackage_scope(
     SV3_1aParser::Package_scopeContext *ctx) {
    std::string ident;
@@ -912,7 +912,7 @@ void SV3_1aTreeShapeListener::exitPackage_scope(
 
   if (ident.size() > SV_MAX_IDENTIFIER_SIZE) {
     logError(ErrorDefinition::PA_MAX_LENGTH_IDENTIFIER, ctx, ident);
-  }    
+  }
 }
 
 void SV3_1aTreeShapeListener::enterUnconnected_drive_directive(


### PR DESCRIPTION
For type-safety and readability.
We now have to explicitly cast them to the flatbuffer uint16_t cache
values, but this make that transition explicit.

Signed-off-by: Henner Zeller <h.zeller@acm.org>