### PR TITLE
Document reason for virtual base class.

### DIFF
--- a/src/Common/ClockingBlockHolder.h
+++ b/src/Common/ClockingBlockHolder.h
@@ -35,7 +35,7 @@ class ClockingBlockHolder {
  public:
   typedef std::map<SymbolId, ClockingBlock> ClockingBlockMap;
 
-  virtual ~ClockingBlockHolder() {}
+  virtual ~ClockingBlockHolder() {}  // virtual as used as interface
 
   ClockingBlockMap& getClockingBlockMap() { return m_clockingBlockMap; }
   void addClockingBlock(SymbolId blockId, ClockingBlock& block);

--- a/src/Common/PortNetHolder.h
+++ b/src/Common/PortNetHolder.h
@@ -31,7 +31,7 @@ class Signal;
 
 class PortNetHolder {
 public:
-  virtual ~PortNetHolder();
+  virtual ~PortNetHolder();  // virtual as used as interface
 
   std::vector<Signal*>& getPorts() { return m_ports;  }
   std::vector<Signal*>& getSignals() {return m_signals;  }


### PR DESCRIPTION
I am using grep to find all the places that have virtual
destructors to see if they can be removed. Once it is
clear that they are needed, documenting helps to not stumble
upon this again.

Signed-off-by: Henner Zeller <h.zeller@acm.org>