### PR TITLE
Remove unnecessary virtual destructor from ConfigSet.

### DIFF
--- a/src/Config/ConfigSet.cpp
+++ b/src/Config/ConfigSet.cpp
@@ -20,16 +20,13 @@
  *
  * Created on February 10, 2018, 11:14 PM
  */
-#include "SourceCompile/SymbolTable.h"
-#include "Design/FileContent.h"
 #include "Config/ConfigSet.h"
+
 using namespace SURELOG;
 
-ConfigSet::~ConfigSet() {}
-
-Config* ConfigSet::getConfig(std::string configName) {
-  for (unsigned int i = 0; i < m_configs.size(); i++) {
-    if (m_configs[i].getName() == configName) return &m_configs[i];
+Config* ConfigSet::getMutableConfigByName(std::string_view configName) {
+  for (auto &config : m_configs) {
+    if (config.getName() == configName) return &config;
   }
-  return NULL;
+  return nullptr;
 }

--- a/src/Config/ConfigSet.h
+++ b/src/Config/ConfigSet.h
@@ -23,23 +23,26 @@
 
 #ifndef CONFIGSET_H
 #define CONFIGSET_H
+
 #include "Config/Config.h"
+
 #include <vector>
+#include <string_view>
 
 namespace SURELOG {
 
-class ConfigSet {
- public:
-  ConfigSet() {}
-  virtual ~ConfigSet();
-  void addConfig(Config& config) { m_configs.push_back(config); }
-  std::vector<Config>& getAllConfigs() { return m_configs; }
-  Config* getConfig(std::string configName);
+class ConfigSet final {
+public:
+  void addConfig(const Config& config) { m_configs.emplace_back(config); }
+  std::vector<Config>& getAllMutableConfigs() { return m_configs; }
+  Config* getMutableConfigByName(std::string_view configName);
 
- private:
+  // Are there places where we can return a non-mutable config ?
+
+private:
   std::vector<Config> m_configs;
 };
 
-};  // namespace SURELOG
+}  // namespace SURELOG
 
 #endif /* CONFIGSET_H */


### PR DESCRIPTION
Also change the accessor names to more clearly document that
we return a mutable config here. This will help later to find
all the places that can be re-considered to constify.

Signed-off-by: Henner Zeller <h.zeller@acm.org>