### PR TITLE
Remove unnecessary virtual destructors in some classes never extended.

### DIFF
--- a/src/DesignCompile/CompileClass.cpp
+++ b/src/DesignCompile/CompileClass.cpp
@@ -44,8 +44,6 @@
 
 using namespace SURELOG;
 
-CompileClass::~CompileClass() {}
-
 int FunctorCompileClass::operator()() const {
   CompileClass* instance =
       new CompileClass(m_compileDesign, m_class, m_design, m_symbols, m_errors);

--- a/src/DesignCompile/CompileClass.h
+++ b/src/DesignCompile/CompileClass.h
@@ -37,6 +37,7 @@ struct FunctorCompileClass {
         m_design(design),
         m_symbols(symbols),
         m_errors(errors) {}
+
   int operator()() const;
 
  private:
@@ -47,7 +48,7 @@ struct FunctorCompileClass {
   ErrorContainer* m_errors;
 };
 
-class CompileClass {
+class CompileClass final {
  public:
   CompileClass(CompileDesign* compiler, ClassDefinition* classDef,
                Design* design, SymbolTable* symbols, ErrorContainer* errors)
@@ -59,17 +60,19 @@ class CompileClass {
     m_helper.seterrorReporting(errors, symbols);
   }
 
-  virtual ~CompileClass();
-
   bool compile();
 
  private:
-  CompileDesign* m_compileDesign;
-  ClassDefinition* m_class;
-  Design* m_design;
-  SymbolTable* m_symbols;
-  ErrorContainer* m_errors;
+  CompileClass(const CompileClass &) = delete;
+
+  CompileDesign* const m_compileDesign;
+  ClassDefinition* const m_class;
+  Design* const m_design;
+  SymbolTable* const m_symbols;
+  ErrorContainer* const m_errors;
+
   CompileHelper m_helper;
+
   bool compile_class_parameters_(const FileContent* fC, NodeId id);
   bool compile_class_property_(const FileContent* fC, NodeId id);
   bool compile_class_method_(const FileContent* fC, NodeId id);
@@ -82,6 +85,6 @@ class CompileClass {
   bool compile_class_type_(const FileContent* fC, NodeId id);
 };
 
-};  // namespace SURELOG
+}  // namespace SURELOG
 
 #endif /* COMPILECLASS_H */

--- a/src/DesignCompile/CompileDesign.cpp
+++ b/src/DesignCompile/CompileDesign.cpp
@@ -68,10 +68,6 @@ using namespace SURELOG;
 
 CompileDesign::CompileDesign(Compiler* compiler) : m_compiler(compiler) {}
 
-CompileDesign::CompileDesign(const CompileDesign& orig) {}
-
-CompileDesign::~CompileDesign() {}
-
 bool CompileDesign::compile() {
   Location loc(0);
   Error err1(ErrorDefinition::COMP_COMPILE, loc);

--- a/src/DesignCompile/CompileDesign.h
+++ b/src/DesignCompile/CompileDesign.h
@@ -30,21 +30,23 @@ using namespace UHDM;
 
 namespace SURELOG {
 
-class CompileDesign {
- public:
+class CompileDesign final {
+public:
   CompileDesign(Compiler* compiler);
 
   bool compile();
   bool elaborate();
   vpiHandle writeUHDM(const std::string& fileName);
 
-  CompileDesign(const CompileDesign& orig);
-  virtual ~CompileDesign();
+
   Compiler* getCompiler() { return m_compiler; }
-  Serializer& getSerializer() { return m_serializer; } 
+  Serializer& getSerializer() { return m_serializer; }
   void lockSerializer() { m_serializerMutex.lock(); }
   void unlockSerializer() { m_serializerMutex.unlock(); }
- private:
+
+private:
+  CompileDesign(const CompileDesign& orig) = delete;
+
   template <class ObjectType, class ObjectMapType, typename FunctorType>
   void compileMT_(ObjectMapType& objects, int maxThreadCount);
 
@@ -53,7 +55,7 @@ class CompileDesign {
   bool compilation_();
   bool elaboration_();
 
-  Compiler* m_compiler;
+  Compiler* const m_compiler;
   std::vector<SymbolTable*> m_symbolTables;
   std::vector<ErrorContainer*> m_errorContainers;
 
@@ -61,6 +63,6 @@ class CompileDesign {
   Serializer m_serializer;
 };
 
-};  // namespace SURELOG
+}  // namespace SURELOG
 
 #endif /* COMPILEDESIGN_H */

--- a/src/DesignCompile/CompileDesign.h
+++ b/src/DesignCompile/CompileDesign.h
@@ -30,9 +30,10 @@ using namespace UHDM;
 
 namespace SURELOG {
 
-class CompileDesign final {
+class CompileDesign {
 public:
   CompileDesign(Compiler* compiler);
+  virtual ~CompileDesign() {}  // Used in MockCompileDesign
 
   bool compile();
   bool elaborate();
@@ -40,7 +41,7 @@ public:
 
 
   Compiler* getCompiler() { return m_compiler; }
-  Serializer& getSerializer() { return m_serializer; }
+  virtual Serializer& getSerializer() { return m_serializer; }
   void lockSerializer() { m_serializerMutex.lock(); }
   void unlockSerializer() { m_serializerMutex.unlock(); }
 

--- a/src/DesignCompile/CompileFileContent.cpp
+++ b/src/DesignCompile/CompileFileContent.cpp
@@ -50,8 +50,6 @@ int FunctorCompileFileContent::operator()() const {
   return true;
 }
 
-CompileFileContent::~CompileFileContent() {}
-
 bool CompileFileContent::compile() { return collectObjects_(); }
 
 bool CompileFileContent::collectObjects_() {

--- a/src/DesignCompile/CompileFileContent.h
+++ b/src/DesignCompile/CompileFileContent.h
@@ -47,8 +47,8 @@ struct FunctorCompileFileContent {
   ErrorContainer* m_errors;
 };
 
-class CompileFileContent {
- public:
+class CompileFileContent final {
+public:
   CompileFileContent(CompileDesign* compiler, FileContent* file, Design* design,
                      SymbolTable* symbols, ErrorContainer* errors)
       : m_compileDesign(compiler),
@@ -61,18 +61,19 @@ class CompileFileContent {
 
   bool compile();
 
-  virtual ~CompileFileContent();
+private:
+  CompileFileContent(const CompileFileContent&) = delete;
 
- private:
   bool collectObjects_();
-  CompileDesign* m_compileDesign;
-  FileContent* m_fileContent;
-  Design* m_design;
-  SymbolTable* m_symbols;
-  ErrorContainer* m_errors;
+  CompileDesign* const m_compileDesign;
+  FileContent* const m_fileContent;
+  Design* const m_design;
+  SymbolTable* const m_symbols;
+  ErrorContainer* const m_errors;
+
   CompileHelper m_helper;
 };
 
-};  // namespace SURELOG
+}  // namespace SURELOG
 
 #endif /* COMPILEFILECONTENT_H */

--- a/src/DesignCompile/CompileHelper.cpp
+++ b/src/DesignCompile/CompileHelper.cpp
@@ -45,8 +45,6 @@
 
 using namespace SURELOG;
 
-CompileHelper::~CompileHelper() {}
-
 bool CompileHelper::importPackage(DesignComponent* scope, Design* design,
                                   const FileContent* fC, NodeId id) {
   FileCNodeId fnid(fC, id);
@@ -254,7 +252,7 @@ const DataType* CompileHelper::compileTypeDef(DesignComponent* scope, const File
       typespecs = scope->Typespecs();
       if (typespecs == nullptr) {
         typespecs = s.MakeTypespecVec();
-        scope->Typespecs(typespecs);   
+        scope->Typespecs(typespecs);
       }
     }
   }
@@ -314,7 +312,7 @@ const DataType* CompileHelper::compileTypeDef(DesignComponent* scope, const File
 
   const NodeId type_name = fC->Sibling(data_type);
   const std::string name = fC->SymName(type_name);
-  
+
   if (scope) {
     const TypeDef* prevDef = scope->getTypeDef(name);
     if (prevDef) {
@@ -365,7 +363,7 @@ const DataType* CompileHelper::compileTypeDef(DesignComponent* scope, const File
       UHDM::typespec* ts = compileTypespec(scope, fC, enum_base_type, compileDesign, nullptr, nullptr, true);
       ts->VpiName(name);
       st->setTypespec(ts);
-      if (typespecs) 
+      if (typespecs)
         typespecs->push_back(ts);
     } else if (struct_or_union_type == VObjectType::slUnion_keyword) {
       Union* st = new Union(fC, type_name, enum_base_type);
@@ -374,7 +372,7 @@ const DataType* CompileHelper::compileTypeDef(DesignComponent* scope, const File
       UHDM::typespec* ts = compileTypespec(scope, fC, enum_base_type, compileDesign, nullptr, nullptr, true);
       ts->VpiName(name);
       st->setTypespec(ts);
-      if (typespecs) 
+      if (typespecs)
         typespecs->push_back(ts);
     }
 
@@ -420,7 +418,7 @@ const DataType* CompileHelper::compileTypeDef(DesignComponent* scope, const File
     }
 
     UHDM::enum_typespec* enum_t = s.MakeEnum_typespec();
-    if (typespecs) 
+    if (typespecs)
       typespecs->push_back(enum_t);
     the_enum->setTypespec(enum_t);
     enum_t->VpiName(name);
@@ -461,7 +459,7 @@ const DataType* CompileHelper::compileTypeDef(DesignComponent* scope, const File
       UHDM::typespec* ts = compileTypespec(scope, fC, stype, compileDesign, nullptr, nullptr, true);
       if (ts) {
         ts->VpiName(name);
-        if (typespecs) 
+        if (typespecs)
           typespecs->push_back(ts);
       }
       simple->setTypespec(ts);
@@ -477,7 +475,7 @@ const DataType* CompileHelper::compileTypeDef(DesignComponent* scope, const File
       UHDM::typespec* ts = compileTypespec(scope, fC, stype, compileDesign, nullptr, nullptr, true);
       if (ts) {
         ts->VpiName(name);
-        if (typespecs) 
+        if (typespecs)
           typespecs->push_back(ts);
       }
       simple->setTypespec(ts);
@@ -1305,8 +1303,8 @@ bool CompileHelper::compileNetDeclaration(DesignComponent* component,
       List_of_net_decl_assignments = net;
     }
   }
-  if (nettype == VObjectType::slIntVec_TypeLogic || 
-      nettype == VObjectType::slNetType_Wire || 
+  if (nettype == VObjectType::slIntVec_TypeLogic ||
+      nettype == VObjectType::slNetType_Wire ||
       nettype == VObjectType::slIntVec_TypeReg )
     compileContinuousAssignment(component, fC, List_of_net_decl_assignments, compileDesign);
 
@@ -1464,7 +1462,7 @@ n<> u<17> t<Continuous_assign> p<18> c<16> l<4>
     if (Expression && (fC->Type(Expression) != slUnpacked_dimension)) {
       // LHS
       NodeId Ps_or_hierarchical_identifier = Net_lvalue;
-      if (fC->Child(Net_lvalue)) 
+      if (fC->Child(Net_lvalue))
         Ps_or_hierarchical_identifier = fC->Child(Net_lvalue);
       UHDM::any* lhs_exp =
           compileExpression(component, fC, Ps_or_hierarchical_identifier, compileDesign);
@@ -1867,10 +1865,10 @@ UHDM::assignment* CompileHelper::compileBlockingAssignment(DesignComponent* comp
       AssignOp_Assign = 0;
     } else if (fC->Type(AssignOp_Assign) == VObjectType::slDelay_or_event_control) {
       Delay_or_event_control = AssignOp_Assign;
-      Expression = fC->Sibling(AssignOp_Assign); 
+      Expression = fC->Sibling(AssignOp_Assign);
       AssignOp_Assign = 0;
     } else {
-      Expression = fC->Sibling(AssignOp_Assign); 
+      Expression = fC->Sibling(AssignOp_Assign);
     }
     rhs_rf = compileExpression(component, fC, Expression, compileDesign);
   } else if (fC->Type(Operator_assignment) == slHierarchical_identifier) {
@@ -1903,7 +1901,7 @@ UHDM::assignment* CompileHelper::compileBlockingAssignment(DesignComponent* comp
   }
   if (AssignOp_Assign)
     assign->VpiOpType(UhdmWriter::getVpiOpType(fC->Type(AssignOp_Assign)));
-  else 
+  else
     assign->VpiOpType(vpiAssignmentOp);
   if (blocking)
     assign->VpiBlocking(true);

--- a/src/DesignCompile/CompileHelper.h
+++ b/src/DesignCompile/CompileHelper.h
@@ -41,7 +41,7 @@ class Design;
 class CompileDesign;
 typedef std::vector<TfPortItem*> TfPortList;
 
-class CompileHelper {
+class CompileHelper final {
 public:
   CompileHelper() {}
 
@@ -232,11 +232,11 @@ public:
                                     const FileContent* fC, NodeId nodeId,
                                     CompileDesign* compileDesign);
 
-  virtual ~CompileHelper();
+private:
+  CompileHelper(const CompileHelper&) = delete;
 
- private:
-  ErrorContainer* m_errors;
-  SymbolTable* m_symbols;
+  ErrorContainer* m_errors = nullptr;
+  SymbolTable* m_symbols = nullptr;
   ExprBuilder m_exprBuilder;
 };
 

--- a/src/DesignCompile/CompileHelper_test.cpp
+++ b/src/DesignCompile/CompileHelper_test.cpp
@@ -66,7 +66,7 @@ UHDM::Serializer sharedSerializer;
 class MockCompileDesign : public SURELOG::CompileDesign {
   public:
     MockCompileDesign() : CompileDesign(nullptr) {}
-    UHDM::Serializer& getSerializer() {return sharedSerializer;}
+    virtual UHDM::Serializer& getSerializer() {return sharedSerializer;}
 };
 // Need this to get serializer for VpiName, VpiValue etc.
 MockCompileDesign cd;

--- a/src/DesignCompile/CompileModule.cpp
+++ b/src/DesignCompile/CompileModule.cpp
@@ -46,8 +46,6 @@
 
 using namespace SURELOG;
 
-CompileModule::~CompileModule() {}
-
 int FunctorCompileModule::operator()() const {
   CompileModule* instance = new CompileModule(m_compileDesign, m_module,
                                               m_design, m_symbols, m_errors, m_instance);

--- a/src/DesignCompile/CompileModule.h
+++ b/src/DesignCompile/CompileModule.h
@@ -51,8 +51,8 @@ struct FunctorCompileModule {
   ValuedComponentI* m_instance;
 };
 
-class CompileModule {
- public:
+class CompileModule final {
+public:
   CompileModule(CompileDesign* compiler, ModuleDefinition* module,
                 Design* design, SymbolTable* symbols, ErrorContainer* errors, ValuedComponentI* instance = nullptr)
       : m_compileDesign(compiler),
@@ -66,24 +66,24 @@ class CompileModule {
 
   bool compile();
 
-  virtual ~CompileModule();
+private:
+  CompileModule(const CompileModule&) = delete;
 
- private:
   bool collectModuleObjects_();
   bool checkModule_();
   bool collectInterfaceObjects_();
   bool checkInterface_();
   void compileClockingBlock_(const FileContent* fC, NodeId id);
 
-  CompileDesign* m_compileDesign;
-  ModuleDefinition* m_module;
-  Design* m_design;
-  SymbolTable* m_symbols;
-  ErrorContainer* m_errors;
+  CompileDesign* const m_compileDesign;
+  ModuleDefinition* const m_module;
+  Design* const m_design;
+  SymbolTable* const m_symbols;
+  ErrorContainer* const m_errors;
   CompileHelper m_helper;
-  ValuedComponentI* m_instance;
+  ValuedComponentI* const m_instance;
 };
 
-};  // namespace SURELOG
+}  // namespace SURELOG
 
 #endif /* COMPILEMODULE_H */

--- a/src/DesignCompile/CompilePackage.cpp
+++ b/src/DesignCompile/CompilePackage.cpp
@@ -52,8 +52,6 @@ int FunctorCompilePackage::operator()() const {
   return true;
 }
 
-CompilePackage::~CompilePackage() {}
-
 bool CompilePackage::compile() {
   if (!m_package) return false;
   m_package->m_exprBuilder.seterrorReporting(m_errors, m_symbols);

--- a/src/DesignCompile/CompilePackage.h
+++ b/src/DesignCompile/CompilePackage.h
@@ -45,7 +45,7 @@ struct FunctorCompilePackage {
   ErrorContainer* m_errors;
 };
 
-class CompilePackage {
+class CompilePackage final {
  public:
   CompilePackage(CompileDesign* compiler, Package* package, Design* design,
                  SymbolTable* symbols, ErrorContainer* errors)
@@ -59,18 +59,17 @@ class CompilePackage {
 
   bool compile();
 
-  virtual ~CompilePackage();
-
  private:
   bool collectObjects_();
+
   CompileDesign* m_compileDesign;
-  Package* m_package;
-  Design* m_design;
-  SymbolTable* m_symbols;
-  ErrorContainer* m_errors;
+  Package* const m_package;
+  Design* const m_design;
+  SymbolTable* const m_symbols;
+  ErrorContainer* const m_errors;
   CompileHelper m_helper;
 };
 
-};  // namespace SURELOG
+}  // namespace SURELOG
 
 #endif /* COMPILEPACKAGE_H */

--- a/src/DesignCompile/CompileProgram.h
+++ b/src/DesignCompile/CompileProgram.h
@@ -49,7 +49,7 @@ struct FunctorCompileProgram {
 };
 
 class CompileProgram : public CompileToolbox {
- public:
+public:
   CompileProgram(CompileDesign* compiler, Program* program, Design* design,
                  SymbolTable* symbols, ErrorContainer* errors)
       : m_compileDesign(compiler),
@@ -64,15 +64,16 @@ class CompileProgram : public CompileToolbox {
 
   ~CompileProgram() override;
 
- private:
-  CompileDesign* m_compileDesign;
-  Program* m_program;
-  Design* m_design;
-  SymbolTable* m_symbols;
-  ErrorContainer* m_errors;
+private:
+  CompileDesign* const m_compileDesign;
+  Program* const m_program;
+  Design* const m_design;
+  SymbolTable* const m_symbols;
+  ErrorContainer* const m_errors;
+
   CompileHelper m_helper;
 };
 
-};  // namespace SURELOG
+}  // namespace SURELOG
 
 #endif /* COMPILEPROGRAM_H */

--- a/src/DesignCompile/CompileToolbox.h
+++ b/src/DesignCompile/CompileToolbox.h
@@ -26,19 +26,19 @@
 
 namespace SURELOG {
 
+// TODO: this looks like not really used or at least should be provided
+// as standalone function ?
 class CompileToolbox {
- public:
+public:
   CompileToolbox();
 
-  virtual ~CompileToolbox();
+  virtual ~CompileToolbox();  // Used as inheritance functionality provider.
 
- protected:
+protected:
   virtual bool compileInitialBlock_(FileContent* fC, NodeId nodeId,
                                     DesignComponent* component);
-
- private:
 };
 
-};  // namespace SURELOG
+}  // namespace SURELOG
 
 #endif /* COMPILETOOLBOX_H */


### PR DESCRIPTION
Also, remove copy constructors and make instance variables that are
only set in the constructor const.

Signed-off-by: Henner Zeller <h.zeller@acm.org>