### PR TITLE
Simplify Precompiled and remove unused virtual destructor.

### DIFF
--- a/src/Package/Precompiled.cpp
+++ b/src/Package/Precompiled.cpp
@@ -23,47 +23,33 @@
 
 #include "Package/Precompiled.h"
 
-Precompiled* Precompiled::m_singleton = NULL;
-
 Precompiled::Precompiled() {
   addPrecompiled("uvm_pkg", "uvm_pkg.sv");
   addPrecompiled("ovm_pkg", "ovm_pkg.sv");
 }
 
 Precompiled* Precompiled::getSingleton() {
-  if (m_singleton == NULL) m_singleton = new Precompiled();
-  return m_singleton;
+  static Precompiled* const singleton = new Precompiled();
+  return singleton;
 }
 
-void Precompiled::addPrecompiled(std::string packageName,
-                                 std::string fileName) {
-  m_packageMap.insert(std::make_pair(packageName, fileName));
+void Precompiled::addPrecompiled(const std::string& packageName,
+                                 const std::string& fileName) {
+  m_packageMap.insert({packageName, fileName});
   m_packageFileSet.insert(fileName);
 }
 
-std::string Precompiled::getFileName(std::string packageName) {
-  auto itr = m_packageMap.find(packageName);
-  if (itr == m_packageMap.end()) {
-    return "";
-  } else {
-    return (*itr).second;
-  }
+std::string Precompiled::getFileName(const std::string& packageName) const {
+  auto found = m_packageMap.find(packageName);
+  return (found == m_packageMap.end()) ? "" : found->second;
 }
 
-bool Precompiled::isFilePrecompiled(std::string fileName) {
-  auto itr = m_packageFileSet.find(fileName);
-  if (itr == m_packageFileSet.end()) {
-    return false;
-  } else {
-    return true;
-  }
+bool Precompiled::isFilePrecompiled(const std::string& fileName) const {
+  auto found = m_packageFileSet.find(fileName);
+  return (found != m_packageFileSet.end());
 }
 
-bool Precompiled::isPackagePrecompiled(std::string packageName) {
-  auto itr = m_packageMap.find(packageName);
-  if (itr == m_packageMap.end()) {
-    return false;
-  } else {
-    return true;
-  }
+bool Precompiled::isPackagePrecompiled(const std::string& packageName) const {
+  auto found = m_packageMap.find(packageName);
+  return(found != m_packageMap.end());
 }

--- a/src/Package/Precompiled.h
+++ b/src/Package/Precompiled.h
@@ -21,29 +21,29 @@
  * Created on April 28, 2018, 10:27 AM
  */
 #include <string>
-#include <set>
-#include <map>
+#include <unordered_set>
+#include <unordered_map>
 
 #ifndef PRECOMPILED_H
 #define PRECOMPILED_H
 
-class Precompiled {
- public:
-  Precompiled();
-  void addPrecompiled(std::string package_name, std::string fileName);
-
+class Precompiled final {
+public:
   static Precompiled* getSingleton();
 
-  std::string getFileName(std::string packageName);
-  bool isFilePrecompiled(std::string fileName);
-  bool isPackagePrecompiled(std::string package);
+  void addPrecompiled(const std::string& package_name,
+                      const std::string& fileName);
 
-  virtual ~Precompiled(){};
+  std::string getFileName(const std::string& packageName) const;
+  bool isFilePrecompiled(const std::string& fileName) const;
+  bool isPackagePrecompiled(const std::string& package) const;
 
- private:
-  std::map<std::string, std::string> m_packageMap;
-  std::set<std::string> m_packageFileSet;
-  static Precompiled* m_singleton;
+private:
+  Precompiled();  // Only accessed via singleton.
+  Precompiled(const Precompiled&) = delete;
+
+  std::unordered_map<std::string, std::string> m_packageMap;
+  std::unordered_set<std::string> m_packageFileSet;
 };
 
 #endif /* PRECOMPILED_H */


### PR DESCRIPTION
Also move the constructors to private, as the only access is
through the singleton.

Signed-off-by: Henner Zeller <h.zeller@acm.org>