### PR TITLE
Remove virtual destructor in the ParseUtils static method collection.

### DIFF
--- a/src/Utils/ParseUtils.cpp
+++ b/src/Utils/ParseUtils.cpp
@@ -28,12 +28,6 @@ using namespace antlr4;
 
 using namespace SURELOG;
 
-ParseUtils::ParseUtils() {}
-
-ParseUtils::ParseUtils(const ParseUtils& orig) {}
-
-ParseUtils::~ParseUtils() {}
-
 std::pair<int, int> ParseUtils::getLineColumn(tree::TerminalNode* node) {
   Token* token = node->getSymbol();
   int lineNb = token->getLine();

--- a/src/Utils/ParseUtils.h
+++ b/src/Utils/ParseUtils.h
@@ -47,7 +47,7 @@ public:
                                tree::ParseTree* parent);
 
 private:
-  ParseUtils();
+  ParseUtils() = delete;
   ParseUtils(const ParseUtils& orig) = delete;
 };
 

--- a/src/Utils/ParseUtils.h
+++ b/src/Utils/ParseUtils.h
@@ -25,11 +25,13 @@
 #define PARSEUTILS_H
 #include "antlr4-runtime.h"
 #include "ParserRuleContext.h"
-using namespace antlr4;
+
+using namespace antlr4;  // TODO: remove using namespace in header
+
 namespace SURELOG {
 
-class ParseUtils {
- public:
+class ParseUtils final {
+public:
   static std::pair<int, int> getLineColumn(CommonTokenStream* stream,
                                            antlr4::ParserRuleContext* context);
 
@@ -44,14 +46,11 @@ class ParseUtils {
   static void inOrderTraversal(std::vector<Token*>& tokens,
                                tree::ParseTree* parent);
 
- private:
+private:
   ParseUtils();
-  ParseUtils(const ParseUtils& orig);
-  virtual ~ParseUtils();
-
- private:
+  ParseUtils(const ParseUtils& orig) = delete;
 };
 
-};  // namespace SURELOG
+}  // namespace SURELOG
 
 #endif /* PARSEUTILS_H */


### PR DESCRIPTION
Signed-off-by: Henner Zeller <h.zeller@acm.org>