### PR TITLE
Use emplace_back() for faster appends to vectors.

### DIFF
--- a/src/CommandLine/CommandLineParser.cpp
+++ b/src/CommandLine/CommandLineParser.cpp
@@ -459,7 +459,7 @@ bool CommandLineParser::parseCommandLine(int argc, const char** argv) {
   std::vector<std::string> all_arguments;
   std::vector<std::string> cmd_line;
   for (int i = 1; i < argc; i++) {
-    cmd_line.push_back(argv[i]);
+    cmd_line.emplace_back(argv[i]);
     if (!strcmp(argv[i], "-cd")) {
       std::string newDir = argv[i + 1];
       int ret = chdir(newDir.c_str());

--- a/src/DesignCompile/DesignElaboration.cpp
+++ b/src/DesignCompile/DesignElaboration.cpp
@@ -294,7 +294,7 @@ bool DesignElaboration::identifyTopModules_() {
                 element.m_line, 0, topid);
             if (itr == m_uniqueTopLevelModules.end()) {
               m_uniqueTopLevelModules.insert(topname);
-              m_topLevelModules.push_back(std::make_pair(topname, file.second));
+              m_topLevelModules.emplace_back(topname, file.second);
               toplevelModuleFound = true;
               Error err(ErrorDefinition::ELAB_TOP_LEVEL_MODULE, loc);
               m_compileDesign->getCompiler()->getErrorContainer()->addError(

--- a/src/DesignCompile/PackageAndRootElaboration.cpp
+++ b/src/DesignCompile/PackageAndRootElaboration.cpp
@@ -64,7 +64,7 @@ bool PackageAndRootElaboration::bindTypedefs_() {
     FileContent* fC = file.second;
     for (auto typed : fC->getTypeDefMap()) {
       TypeDef* typd = typed.second;
-      defs.push_back(std::make_pair(typd, fC));
+      defs.emplace_back(typd, fC);
     }
   }
 
@@ -72,7 +72,7 @@ bool PackageAndRootElaboration::bindTypedefs_() {
     Package* pack = package.second;
     for (auto typed : pack->getTypeDefMap()) {
       TypeDef* typd = typed.second;
-      defs.push_back(std::make_pair(typd, pack));
+      defs.emplace_back(typd, pack);
     }
   }
 
@@ -80,7 +80,7 @@ bool PackageAndRootElaboration::bindTypedefs_() {
     Program* program = program_def.second;
     for (auto typed : program->getTypeDefMap()) {
       TypeDef* typd = typed.second;
-      defs.push_back(std::make_pair(typd, program));
+      defs.emplace_back(typd, program);
     }
   }
 

--- a/src/DesignCompile/TestbenchElaboration.cpp
+++ b/src/DesignCompile/TestbenchElaboration.cpp
@@ -60,7 +60,7 @@ bool TestbenchElaboration::bindTypedefs_() {
     FileContent* fC = file.second;
     for (auto typed : fC->getTypeDefMap()) {
       TypeDef* typd = typed.second;
-      defs.push_back(std::make_pair(typd, fC));
+      defs.emplace_back(typd, fC);
     }
   }
 
@@ -68,7 +68,7 @@ bool TestbenchElaboration::bindTypedefs_() {
     Package* pack = package.second;
     for (auto typed : pack->getTypeDefMap()) {
       TypeDef* typd = typed.second;
-      defs.push_back(std::make_pair(typd, pack));
+      defs.emplace_back(typd, pack);
     }
   }
 
@@ -76,7 +76,7 @@ bool TestbenchElaboration::bindTypedefs_() {
     Program* program = program_def.second;
     for (auto typed : program->getTypeDefMap()) {
       TypeDef* typd = typed.second;
-      defs.push_back(std::make_pair(typd, program));
+      defs.emplace_back(typd, program);
     }
   }
 
@@ -84,7 +84,7 @@ bool TestbenchElaboration::bindTypedefs_() {
     ClassDefinition* classp = class_def.second;
     for (auto typed : classp->getTypeDefMap()) {
       TypeDef* typd = typed.second;
-      defs.push_back(std::make_pair(typd, classp));
+      defs.emplace_back(typd, classp);
     }
   }
 
@@ -184,15 +184,15 @@ void computeVarChain(const FileContent* fC, NodeId nodeId,
         NodeId child = fC->Child(nodeId);
         VObjectType childType = fC->Type(child);
         if (childType == VObjectType::slThis_keyword)
-          var_chain.push_back("this");
+          var_chain.emplace_back("this");
         else if (childType == VObjectType::slSuper_keyword)
-          var_chain.push_back("super");
+          var_chain.emplace_back("super");
         else
-          var_chain.push_back("UNKNOWN_TYPE");
+          var_chain.emplace_back("UNKNOWN_TYPE");
         break;
       }
       default:
-        var_chain.push_back("UNKNOWN_NAME");
+        var_chain.emplace_back("UNKNOWN_NAME");
         break;
     }
     nodeId = fC->Sibling(nodeId);

--- a/src/SourceCompile/AnalyzeFile.cpp
+++ b/src/SourceCompile/AnalyzeFile.cpp
@@ -160,7 +160,7 @@ void AnalyzeFile::analyze() {
   std::vector<std::string> allLines;
   std::string prev_keyword;
   std::string prev_prev_keyword;
-  allLines.push_back("FILLER LINE");
+  allLines.emplace_back("FILLER LINE");
   const std::regex import_regex("import[ ]+[a-zA-Z_0-9:\\*]+[ ]*;");
   std::smatch pieces_match;
   std::string fileLevelImportSection;


### PR DESCRIPTION
Also, in case of e.g. inserting std::pairs, this is also
a bit more readable.

Signed-off-by: Henner Zeller <h.zeller@acm.org>