### PR TITLE
Remove global-namespace polluting using namespace in headers.

### DIFF
--- a/src/DesignCompile/CompileDesign.h
+++ b/src/DesignCompile/CompileDesign.h
@@ -26,7 +26,6 @@
 
 #include "Serializer.h"
 #include "sv_vpi_user.h"
-using namespace UHDM;
 
 namespace SURELOG {
 
@@ -41,7 +40,7 @@ public:
 
 
   Compiler* getCompiler() { return m_compiler; }
-  virtual Serializer& getSerializer() { return m_serializer; }
+  virtual UHDM::Serializer& getSerializer() { return m_serializer; }
   void lockSerializer() { m_serializerMutex.lock(); }
   void unlockSerializer() { m_serializerMutex.unlock(); }
 
@@ -61,7 +60,7 @@ private:
   std::vector<ErrorContainer*> m_errorContainers;
 
   std::mutex m_serializerMutex;
-  Serializer m_serializer;
+  UHDM::Serializer m_serializer;
 };
 
 }  // namespace SURELOG

--- a/src/DesignCompile/CompileExpression.cpp
+++ b/src/DesignCompile/CompileExpression.cpp
@@ -49,6 +49,7 @@
 #include "ErrorReporting/ErrorContainer.h"
 
 using namespace SURELOG;
+using namespace UHDM;
 
 static unsigned int get_value(const UHDM::expr* expr) {
   const UHDM::constant* hs = dynamic_cast<const UHDM::constant*> (expr);
@@ -63,13 +64,13 @@ static unsigned int get_value(const UHDM::expr* expr) {
   return 0;
 }
 
-any* CompileHelper::compileSelectExpression(DesignComponent* component,
-                                            const FileContent* fC,
-                                            NodeId Bit_select,
-                                            const std::string& name,
-                                            CompileDesign* compileDesign,
-                                            UHDM::any* pexpr,
-                                            ValuedComponentI* instance) {
+UHDM::any* CompileHelper::compileSelectExpression(DesignComponent* component,
+                                                  const FileContent* fC,
+                                                  NodeId Bit_select,
+                                                  const std::string& name,
+                                                  CompileDesign* compileDesign,
+                                                  UHDM::any* pexpr,
+                                                  ValuedComponentI* instance) {
   UHDM::Serializer& s = compileDesign->getSerializer();
   UHDM::any* result = nullptr;
   if (fC->Child(Bit_select) && fC->Sibling(Bit_select)) {
@@ -165,7 +166,7 @@ UHDM::any* CompileHelper::compileExpression(
   if (parentType == VObjectType::slValue_range) {
     UHDM::operation* list_op = s.MakeOperation();
     list_op->VpiOpType(vpiListOp);
-    VectorOfany* operands = s.MakeAnyVec();
+    UHDM::VectorOfany* operands = s.MakeAnyVec();
     list_op->Operands(operands);
     NodeId lexpr = child;
     NodeId rexpr = fC->Sibling(lexpr);
@@ -457,7 +458,7 @@ UHDM::any* CompileHelper::compileExpression(
 
         operation->Operands(operands);
         NodeId rval = fC->Sibling(op);
-        
+
         if (fC->Type(rval) == VObjectType::slAttribute_instance) {
           UHDM::VectorOfattribute* attributes = compileAttributes(component, fC, rval, compileDesign);
           while (fC->Type(rval) == slAttribute_instance)
@@ -774,7 +775,7 @@ UHDM::any* CompileHelper::compileExpression(
       case VObjectType::slNumber_TickB1:
       case VObjectType::slNumber_Tick1:
       case VObjectType::slInitVal_1Tickb1:
-      case VObjectType::slInitVal_1TickB1: 
+      case VObjectType::slInitVal_1TickB1:
       case VObjectType::slScalar_1Tickb1:
       case VObjectType::slScalar_1TickB1:
       case VObjectType::slScalar_Tickb1:
@@ -893,7 +894,7 @@ UHDM::any* CompileHelper::compileExpression(
           operation->VpiOpType(vpiStreamLROp);
         else
           operation->VpiOpType(vpiStreamRLOp);
-        
+
         if (exp_slice)
           operands->push_back(exp_slice);
         UHDM::any* exp_var = compileExpression(component, fC, Expression, compileDesign, pexpr, instance, reduce);
@@ -1093,7 +1094,7 @@ UHDM::any* CompileHelper::compileExpression(
       unsupported_expr* exp = s.MakeUnsupported_expr();
       std::string fileContent = FileUtils::getFileContent(fC->getFileName());
       std::string lineText = StringUtils::getLineInString(fileContent, fC->Line(the_node));
-      Location loc (symbols->registerSymbol(fC->getFileName(the_node)), fC->Line(the_node), 0 , 
+      Location loc (symbols->registerSymbol(fC->getFileName(the_node)), fC->Line(the_node), 0 ,
                     symbols->registerSymbol(std::string("<")+ fC->printObject(the_node) + std::string("> ") + lineText));
       Error err(ErrorDefinition::UHDM_UNSUPPORTED_EXPR, loc);
       errors->addError(err);

--- a/src/DesignCompile/CompileHelper.cpp
+++ b/src/DesignCompile/CompileHelper.cpp
@@ -44,6 +44,7 @@
 #include "UhdmWriter.h"
 
 using namespace SURELOG;
+using namespace UHDM;
 
 bool CompileHelper::importPackage(DesignComponent* scope, Design* design,
                                   const FileContent* fC, NodeId id) {

--- a/src/DesignCompile/CompileHelper_test.cpp
+++ b/src/DesignCompile/CompileHelper_test.cpp
@@ -56,6 +56,8 @@
 #include "gmock/gmock.h"
 #include "vpi_visitor.h"
 
+using namespace UHDM;
+
 class MockFileContent : public SURELOG::FileContent {
   public:
     MockFileContent() : FileContent(0, nullptr, nullptr, nullptr, nullptr, 0){};
@@ -66,7 +68,9 @@ UHDM::Serializer sharedSerializer;
 class MockCompileDesign : public SURELOG::CompileDesign {
   public:
     MockCompileDesign() : CompileDesign(nullptr) {}
-    virtual UHDM::Serializer& getSerializer() {return sharedSerializer;}
+    virtual UHDM::Serializer& getSerializer() override {
+      return sharedSerializer;
+    }
 };
 // Need this to get serializer for VpiName, VpiValue etc.
 MockCompileDesign cd;

--- a/src/DesignCompile/CompileStmt.cpp
+++ b/src/DesignCompile/CompileStmt.cpp
@@ -42,6 +42,7 @@
 #include "ErrorReporting/ErrorContainer.h"
 
 using namespace SURELOG;
+using namespace UHDM;
 
 VectorOfany* CompileHelper::compileStmt(
   DesignComponent* component,
@@ -306,7 +307,7 @@ VectorOfany* CompileHelper::compileStmt(
       // wait fork
       UHDM::wait_fork* waitst = s.MakeWait_fork();
       stmt = waitst;
-    } else if (fC->Type(Expression) == slExpression) { 
+    } else if (fC->Type(Expression) == slExpression) {
       // wait
       NodeId Statement_or_null = fC->Sibling(Expression);
       UHDM::wait_stmt* waitst = s.MakeWait_stmt();
@@ -335,7 +336,7 @@ VectorOfany* CompileHelper::compileStmt(
       while (Hierarchical_identifier && (fC->Type(Hierarchical_identifier) == slHierarchical_identifier)) {
         UHDM::any* cond_exp =
           compileExpression(component, fC, Hierarchical_identifier, compileDesign);
-        conditions->push_back(cond_exp);  
+        conditions->push_back(cond_exp);
         Hierarchical_identifier = fC->Sibling(Hierarchical_identifier);
       }
       NodeId Action_block = Hierarchical_identifier;
@@ -504,7 +505,7 @@ VectorOfany* CompileHelper::compileStmt(
 VectorOfany* CompileHelper::compileDataDeclaration(DesignComponent* component,
                                                    const FileContent* fC,
                                                    NodeId nodeId,
-                                                   CompileDesign* compileDesign, 
+                                                   CompileDesign* compileDesign,
                                                    UHDM::any* pstmt) {
   UHDM::Serializer& s = compileDesign->getSerializer();
   VectorOfany* results = nullptr;
@@ -545,16 +546,16 @@ VectorOfany* CompileHelper::compileDataDeclaration(DesignComponent* component,
         while (tmp && (fC->Type(tmp) != slExpression)) {
           tmp = fC->Sibling(tmp);
         }
-        NodeId Expression = tmp; 
+        NodeId Expression = tmp;
 
         variables* var = (variables*)compileVariable(
             component, fC, Data_type, compileDesign, nullptr, nullptr, true);
-               
+
         if (var) {
           var->VpiConstantVariable(static_status);
           var->VpiAutomatic(automatic_status);
           var->VpiName(fC->SymName(Var));
-        
+
           if (unpackedDimensions) {
             array_var* arr = s.MakeArray_var();
             arr->Ranges(unpackedDimensions);
@@ -577,11 +578,11 @@ VectorOfany* CompileHelper::compileDataDeclaration(DesignComponent* component,
         if (Expression) {
           expr* rhs =
             (expr*)compileExpression(component, fC, Expression, compileDesign);
-          if (rhs) 
+          if (rhs)
             rhs->VpiParent(assign_stmt);
           assign_stmt->Rhs(rhs);
-        } 
-        
+        }
+
         Variable_decl_assignment = fC->Sibling(Variable_decl_assignment);
       }
       break;
@@ -619,12 +620,12 @@ UHDM::any* CompileHelper::compileImmediateAssertion(
     if_stmt_id = 0;
   } else {
     NodeId else_keyword = fC->Sibling(if_stmt_id);
-    if (else_keyword) 
+    if (else_keyword)
       else_stmt_id = fC->Sibling(else_keyword);
   }
   UHDM::any* expr = compileExpression(component, fC, Expression, compileDesign, pstmt, instance, true);
   VectorOfany* if_stmts = nullptr;
-  if (if_stmt_id) 
+  if (if_stmt_id)
     if_stmts = compileStmt(component, fC, if_stmt_id, compileDesign, pstmt);
   UHDM::any* if_stmt  = nullptr;
   if (if_stmts)
@@ -1090,7 +1091,7 @@ bool CompileHelper::compileTask(
     if (fC->Type(Tf_port_list) == slStatement_or_null)
       Statement_or_null = Tf_port_list;
   }
-   
+
   NodeId MoreStatement_or_null = fC->Sibling(Statement_or_null);
   if (fC->Type(MoreStatement_or_null) == VObjectType::slEndtask) {
     MoreStatement_or_null = 0;

--- a/src/DesignCompile/CompileType.cpp
+++ b/src/DesignCompile/CompileType.cpp
@@ -42,6 +42,7 @@
 #include "UhdmWriter.h"
 
 using namespace SURELOG;
+using namespace UHDM;
 
 UHDM::any* CompileHelper::compileVariable(
   DesignComponent* component, const FileContent* fC, NodeId variable,

--- a/src/DesignCompile/NetlistElaboration.cpp
+++ b/src/DesignCompile/NetlistElaboration.cpp
@@ -56,6 +56,7 @@
 #include "UhdmWriter.h"
 
 using namespace SURELOG;
+using namespace UHDM;
 
 NetlistElaboration::NetlistElaboration(CompileDesign* compileDesign)
     : TestbenchElaboration(compileDesign) {
@@ -311,13 +312,13 @@ bool NetlistElaboration::high_conn_(ModuleInstance* instance) {
         any* net = nullptr;
         if (!sigName.empty()) {
           net = bind_net_(parent, sigName);
-        } 
+        }
 
         if ((!sigName.empty()) && (hexpr == nullptr)) {
           ref_obj* ref = s.MakeRef_obj();
           ref->VpiFile(fC->getFileName());
           ref->VpiLineNo(fC->Line(sigId));
-          ref->VpiName(sigName);   
+          ref->VpiName(sigName);
           p->High_conn(ref);
           ref->Actual_group(net);
         } else {
@@ -772,7 +773,7 @@ bool NetlistElaboration::elab_ports_nets_(ModuleInstance* instance, ModuleInstan
 
         } else {
           // Vars
- 
+
           if (dtype) {
             dtype = dtype->getActual();
             if (const Enum* en = dynamic_cast<const Enum*>(dtype)) {

--- a/src/DesignCompile/NetlistElaboration.h
+++ b/src/DesignCompile/NetlistElaboration.h
@@ -38,7 +38,7 @@ class NetlistElaboration : public TestbenchElaboration {
   NetlistElaboration(CompileDesign* compileDesign);
   NetlistElaboration(const NetlistElaboration& orig) = delete;
   bool elaborate() override;
-  
+
   virtual ~NetlistElaboration() override;
 
  private:
@@ -46,18 +46,18 @@ class NetlistElaboration : public TestbenchElaboration {
    bool high_conn_(ModuleInstance* instance);
    bool elab_interfaces_(ModuleInstance* instance);
    bool elab_generates_(ModuleInstance* instance);
-   interface* elab_interface_(ModuleInstance* instance, ModuleInstance* interf_instance, const std::string& instName,  
-                       const std::string& defName, ModuleDefinition* mod, 
-                       const std::string& fileName, int lineNb);
-   modport* elab_modport_(ModuleInstance* instance, const std::string& instName,  
+  UHDM::interface* elab_interface_(ModuleInstance* instance, ModuleInstance* interf_instance, const std::string& instName,
                        const std::string& defName, ModuleDefinition* mod,
-                       const std::string& fileName, int lineNb, const std::string& modPortName);                    
+                       const std::string& fileName, int lineNb);
+  UHDM::modport* elab_modport_(ModuleInstance* instance, const std::string& instName,
+                       const std::string& defName, ModuleDefinition* mod,
+                       const std::string& fileName, int lineNb, const std::string& modPortName);
    bool elab_ports_nets_(ModuleInstance* instance);
    bool elab_ports_nets_(ModuleInstance* instance, ModuleInstance* child, Netlist* parentNetlist, Netlist* netlist,
                          DesignComponent* comp, const std::string& prefix);
-   
-   any* bind_net_(ModuleInstance* instance, const std::string& name);
-   
+
+  UHDM::any* bind_net_(ModuleInstance* instance, const std::string& name);
+
    ExprBuilder m_exprBuilder;
    SymbolTable* m_symbols;
    ErrorContainer* m_errors;

--- a/src/SourceCompile/CommonListenerHelper.cpp
+++ b/src/SourceCompile/CommonListenerHelper.cpp
@@ -46,13 +46,10 @@ int CommonListenerHelper::LastObjIndex() {
   return m_fileContent->getVObjects().size() - 1;
 }
 
-int CommonListenerHelper::ObjectIndexFromContext(tree::ParseTree* ctx) {
-  ContextToObjectMap::iterator itr = m_contextToObjectMap.find(ctx);
-  if (itr == m_contextToObjectMap.end()) {
-    return -1;
-  } else {
-    return (*itr).second;
-  }
+int CommonListenerHelper::ObjectIndexFromContext(
+  const antlr4::tree::ParseTree* ctx) const {
+  auto found = m_contextToObjectMap.find(ctx);
+  return (found == m_contextToObjectMap.end()) ? -1 : found->second;
 }
 
 VObject& CommonListenerHelper::Object(NodeId index) {

--- a/src/SourceCompile/CommonListenerHelper.h
+++ b/src/SourceCompile/CommonListenerHelper.h
@@ -49,7 +49,7 @@ public:
 
   int LastObjIndex();
 
-  int ObjectIndexFromContext(tree::ParseTree* ctx);
+  int ObjectIndexFromContext(const antlr4::tree::ParseTree* ctx) const;
 
   VObject& Object(NodeId index);
 
@@ -69,24 +69,27 @@ public:
 
   unsigned int& Line(NodeId index);
 
-  int addVObject(ParserRuleContext* ctx, const std::string &name, VObjectType objtype);
+  int addVObject(antlr4::ParserRuleContext* ctx,
+                 const std::string &name, VObjectType objtype);
 
-  int addVObject(ParserRuleContext* ctx, VObjectType objtype);
+  int addVObject(antlr4::ParserRuleContext* ctx, VObjectType objtype);
 
-  void addParentChildRelations(int indexParent, ParserRuleContext* ctx);
+  void addParentChildRelations(int indexParent, antlr4::ParserRuleContext* ctx);
 
-  NodeId getObjectId(ParserRuleContext* ctx);
+  NodeId getObjectId(antlr4::ParserRuleContext* ctx);
 
   FileContent* getFileContent() { return m_fileContent; }
 
-  virtual unsigned int getFileLine(ParserRuleContext* ctx, SymbolId& fileId) = 0;
+  virtual unsigned int getFileLine(antlr4::ParserRuleContext* ctx,
+                                   SymbolId& fileId) = 0;
 
 private:
-  int addVObject(ParserRuleContext* ctx, SymbolId sym, VObjectType objtype);
+  int addVObject(antlr4::ParserRuleContext* ctx,
+                 SymbolId sym, VObjectType objtype);
 
 protected:
   FileContent* m_fileContent;
-  typedef std::unordered_map<tree::ParseTree*, NodeId> ContextToObjectMap;
+  typedef std::unordered_map<const antlr4::tree::ParseTree*, NodeId> ContextToObjectMap;
   ContextToObjectMap m_contextToObjectMap;
   antlr4::CommonTokenStream* m_tokens;
 };

--- a/src/Utils/ParseUtils.cpp
+++ b/src/Utils/ParseUtils.cpp
@@ -22,10 +22,11 @@
  */
 
 #include "antlr4-runtime.h"
-using namespace antlr4;
+
 #include <vector>
 #include "Utils/ParseUtils.h"
 
+using namespace antlr4;
 using namespace SURELOG;
 
 std::pair<int, int> ParseUtils::getLineColumn(tree::TerminalNode* node) {

--- a/src/Utils/ParseUtils.h
+++ b/src/Utils/ParseUtils.h
@@ -26,25 +26,25 @@
 #include "antlr4-runtime.h"
 #include "ParserRuleContext.h"
 
-using namespace antlr4;  // TODO: remove using namespace in header
-
 namespace SURELOG {
 
 class ParseUtils final {
 public:
-  static std::pair<int, int> getLineColumn(CommonTokenStream* stream,
+  using ParseTree = antlr4::tree::ParseTree;
+
+  static std::pair<int, int> getLineColumn(antlr4::CommonTokenStream* stream,
                                            antlr4::ParserRuleContext* context);
 
-  static std::pair<int, int> getLineColumn(tree::TerminalNode* node);
+  static std::pair<int, int> getLineColumn(antlr4::tree::TerminalNode* node);
 
-  static std::vector<tree::ParseTree*> getTopTokenList(tree::ParseTree* tree);
+  static std::vector<ParseTree*> getTopTokenList(ParseTree* tree);
   static void tokenizeAtComma(std::vector<std::string>& actualArgs,
-                              const std::vector<tree::ParseTree*>& tokens);
+                              const std::vector<ParseTree*>& tokens);
 
-  static std::vector<Token*> getFlatTokenList(tree::ParseTree* tree);
+  static std::vector<antlr4::Token*> getFlatTokenList(ParseTree* tree);
 
-  static void inOrderTraversal(std::vector<Token*>& tokens,
-                               tree::ParseTree* parent);
+  static void inOrderTraversal(std::vector<antlr4::Token*>& tokens,
+                               ParseTree* parent);
 
 private:
   ParseUtils() = delete;


### PR DESCRIPTION
Limit Using declarations to compilation units.

Signed-off-by: Henner Zeller <h.zeller@acm.org>