### PR TITLE
Document and unit-test various ltrim()/rtrim() functions and leaf().

### DIFF
--- a/src/Utils/StringUtils.cpp
+++ b/src/Utils/StringUtils.cpp
@@ -254,16 +254,6 @@ std::string& StringUtils::ltrim(std::string& str, char c) {
   return str;
 }
 
-bool StringUtils::ltrimStat(std::string& str, char c) {
-  auto it1 =
-      std::find_if(str.begin(), str.end(), [c](char ch) { return (ch == c); });
-  if (it1 != str.end()) {
-    str.erase(str.begin(), it1 + 1);
-    return true;
-  }
-  return false;
-}
-
 std::string StringUtils::leaf(std::string str) {
   char c = '.';
   auto it1 = std::find_if(str.rbegin(), str.rend(),

--- a/src/Utils/StringUtils.h
+++ b/src/Utils/StringUtils.h
@@ -63,13 +63,27 @@ class StringUtils {
 
   // TODO: these should not modify strings, but rather return trimmed
   // std::string_views.
+
+  // Modify string, removing spaces on both ends.
   static std::string& trim(std::string& str);
+
+  // Modify string string, remove whitespace at the beginning of the string.
   static std::string& ltrim(std::string& str);
+
+  // Modify string and remove a _single_ character of c at the beginning if
+  // it exists (yes, it does not what it looks like it should do. Rename?)
   static std::string& ltrim(std::string& str, char c);
-  static bool ltrimStat(std::string& str, char c);
+
+  // Modify string string, remove whitespace at the end of the string.
   static std::string& rtrim(std::string& str);
-  static std::string& rtrimEqual(std::string& str);
+
+  // Modify string and remove a _single_ character of c at the end if
+  // it exists (yes, it does not what it looks like it should do. Rename?)
   static std::string& rtrim(std::string& str, char c);
+
+  // Trim and modify string at assignment character.
+  static std::string& rtrimEqual(std::string& str);
+
   static std::string leaf(std::string str);
 
   // In given string "str", replace all occurences of "from" with "to"

--- a/src/Utils/StringUtils.h
+++ b/src/Utils/StringUtils.h
@@ -64,26 +64,31 @@ class StringUtils {
   // TODO: these should not modify strings, but rather return trimmed
   // std::string_views.
 
-  // Modify string, removing spaces on both ends.
-  static std::string& trim(std::string& str);
-
   // Modify string string, remove whitespace at the beginning of the string.
   static std::string& ltrim(std::string& str);
-
-  // Modify string and remove a _single_ character of c at the beginning if
-  // it exists (yes, it does not what it looks like it should do. Rename?)
-  static std::string& ltrim(std::string& str, char c);
 
   // Modify string string, remove whitespace at the end of the string.
   static std::string& rtrim(std::string& str);
 
-  // Modify string and remove a _single_ character of c at the end if
-  // it exists (yes, it does not what it looks like it should do. Rename?)
+  // Modify string, removing spaces on both ends.
+  static std::string& trim(std::string& str);
+
+  // Erase left of the string until given character is reached. If this
+  // is not reached, the string is unchanged. Modifies string.
+  // TODO: this name is confusing, as it does not do the same as the other
+  // trim functions (which trim characters until there is none)
+  static std::string& ltrim(std::string& str, char c);
+
+  // Erase right of the string until given character is reached. If this
+  // is not reached, the string is unchanged. Modifies string.
+  // TODO: this name is confusing, as it does not do the same as the other
+  // trim functions (which trim characters until there is none)
   static std::string& rtrim(std::string& str, char c);
 
   // Trim and modify string at assignment character.
   static std::string& rtrimEqual(std::string& str);
 
+  // Return the last element of a dot-separated path foo.bar.baz -> baz
   static std::string leaf(std::string str);
 
   // In given string "str", replace all occurences of "from" with "to"

--- a/src/Utils/StringUtils_test.cpp
+++ b/src/Utils/StringUtils_test.cpp
@@ -78,22 +78,26 @@ TEST(StringUtilsTest, InPlaceSpaceTrimming) {
   EXPECT_EQ("hello world", str);
 }
 
-TEST(StringUtilsTest, InPlaceCharTrimming) {
+TEST(StringUtilsTest, InPlaceEraseUntilChar) {
   std::string str;
 
-  // These trim methods only remove a single character of the chosen
-  // character. This is surprising and should either be fixed according to
-  // the expectations (all characters of the chosen characters from the
-  // left or right are removed), or the method should be renamed
-  // trimOneChar() or something.
-  // Until that is decided, this test merely documents it.
-  str = "TTT-TTT";
-  StringUtils::ltrim(str, 'T');
-  EXPECT_EQ("TT-TTT", str);
+  // Erase up to the character
+  str = "abcdefg";
+  StringUtils::ltrim(str, 'd');
+  EXPECT_EQ("efg", str);
 
-  str = "TTT-TTT";
-  StringUtils::rtrim(str, 'T');
-  EXPECT_EQ("TTT-TT", str);
+  str = "abcdefg";
+  StringUtils::rtrim(str, 'd');
+  EXPECT_EQ("abc", str);
+
+  // No change if string not found
+  str = "abcdefg";
+  StringUtils::ltrim(str, 'x');
+  EXPECT_EQ("abcdefg", str);
+
+  str = "abcdefg";
+  StringUtils::rtrim(str, 'x');
+  EXPECT_EQ("abcdefg", str);
 }
 
 TEST(StringUtilsTest, InPlaceRtrimEqual) {

--- a/src/Utils/StringUtils_test.cpp
+++ b/src/Utils/StringUtils_test.cpp
@@ -62,7 +62,53 @@ TEST(StringUtilsTest, GetFirstNonEmptyToken) {
   EXPECT_NE("hello", StringUtils::getFirstNonEmptyToken({"", " ", "hello"}));
 }
 
-// TODO: tests for various trim functions.
+TEST(StringUtilsTest, InPlaceSpaceTrimming) {
+  std::string str;
+
+  str = " \thello world\t ";
+  StringUtils::ltrim(str);
+  EXPECT_EQ("hello world\t ", str);
+
+  str = " \thello world\t ";
+  StringUtils::rtrim(str);
+  EXPECT_EQ(" \thello world", str);
+
+  str = " \thello world\t ";
+  StringUtils::trim(str);
+  EXPECT_EQ("hello world", str);
+}
+
+TEST(StringUtilsTest, InPlaceCharTrimming) {
+  std::string str;
+
+  // These trim methods only remove a single character of the chosen
+  // character. This is surprising and should either be fixed according to
+  // the expectations (all characters of the chosen characters from the
+  // left or right are removed), or the method should be renamed
+  // trimOneChar() or something.
+  // Until that is decided, this test merely documents it.
+  str = "TTT-TTT";
+  StringUtils::ltrim(str, 'T');
+  EXPECT_EQ("TT-TTT", str);
+
+  str = "TTT-TTT";
+  StringUtils::rtrim(str, 'T');
+  EXPECT_EQ("TTT-TT", str);
+}
+
+TEST(StringUtilsTest, InPlaceRtrimEqual) {
+  std::string str = " this is some  =  assignment ";
+
+  StringUtils::rtrimEqual(str);
+  EXPECT_EQ(" this is some  ", str);
+}
+
+TEST(StringUtilsTest, Leaf) {
+  EXPECT_EQ("baz", StringUtils::leaf("foo.bar.baz"));
+  EXPECT_EQ("", StringUtils::leaf("foo.bar."));
+  EXPECT_EQ("", StringUtils::leaf(""));
+  EXPECT_EQ("foo", StringUtils::leaf(".foo"));
+}
 
 TEST(StringUtilsTest, ReplaceAll) {
   EXPECT_EQ("The String With Space",


### PR DESCRIPTION
  * Also found that the trim functions that take a character to trim
    don't exactly behave as the name implies. Not changed functionality
    here, just documenting for now.
  * Removed ltrimStat() which had a name that did not hint what
    it was supposed to be doing; it was also not used anywhere
    in the code base.

Signed-off-by: Henner Zeller <h.zeller@acm.org>