### PR TITLE
Bug fix: undo ErrorReporting change.

### DIFF
--- a/src/Cache/Cache.cpp
+++ b/src/Cache/Cache.cpp
@@ -132,20 +132,23 @@ Cache::cacheErrors(flatbuffers::FlatBufferBuilder& builder,
                    SymbolTable& canonicalSymbols,
                    ErrorContainer* errorContainer, SymbolTable* symbols,
                    SymbolId subjectId) {
+  std::vector<Error>& errors = errorContainer->getErrors();
   std::vector<flatbuffers::Offset<SURELOG::CACHE::Error>> error_vec;
-  for (const Error& error : errorContainer->getErrors()) {
-    const std::vector<Location>& locs = error.getLocations();
+  for (unsigned int i = 0; i < errors.size(); i++) {
+    Error& error = errors[i];
+    std::vector<Location>& locs = error.getLocations();
     if (locs.size()) {
       bool matchSubject = false;
-      for (const auto& loc : locs) {
-        if (loc.m_fileId == subjectId) {
+      for (unsigned int j = 0; j < locs.size(); j++) {
+        if (locs[j].m_fileId == subjectId) {
           matchSubject = true;
           break;
         }
       }
       if (matchSubject) {
         std::vector<flatbuffers::Offset<SURELOG::CACHE::Location>> location_vec;
-        for (const auto& loc : locs) {
+        for (unsigned int j = 0; j < locs.size(); j++) {
+          Location& loc = locs[j];
           SymbolId canonicalFileId =
             canonicalSymbols.registerSymbol(symbols->getSymbol(loc.m_fileId));
           SymbolId canonicalObjectId =

--- a/src/ErrorReporting/Error.cpp
+++ b/src/ErrorReporting/Error.cpp
@@ -25,24 +25,25 @@
 
 using namespace SURELOG;
 
-Error::Error(ErrorDefinition::ErrorType errorId, const Location& loc,
-             const std::vector<Location>* extraLocs) : m_errorId(errorId) {
+Error::Error(ErrorDefinition::ErrorType errorId, Location& loc,
+             std::vector<Location>* extraLocs)
+    : m_errorId(errorId), m_reported(false), m_waived(false) {
   m_locations.push_back(loc);
   if (extraLocs) {
-    m_locations.insert(m_locations.begin(),
-                       extraLocs->begin(), extraLocs->end());
+    for (auto loc : (*extraLocs)) m_locations.push_back(loc);
   }
 }
 
-Error::Error(ErrorDefinition::ErrorType errorId,
-             const Location& loc, const Location& extra) : m_errorId(errorId) {
+Error::Error(ErrorDefinition::ErrorType errorId, Location& loc, Location& extra)
+    : m_errorId(errorId), m_reported(false), m_waived(false) {
   m_locations.push_back(loc);
   m_locations.push_back(extra);
 }
 
 Error::Error(ErrorDefinition::ErrorType errorId,
-             const std::vector<Location>& locations)
-  : m_locations(locations), m_errorId(errorId) {
+             std::vector<Location>& locations)
+    : m_errorId(errorId), m_reported(false), m_waived(false) {
+  for (auto loc : (locations)) m_locations.push_back(loc);
 }
 
 bool Error::operator==(const Error& rhs) const {
@@ -65,3 +66,5 @@ bool Error::operator<(const Error& rhs) const {
   }
   return false;
 }
+
+Error::~Error() {}

--- a/src/ErrorReporting/Error.h
+++ b/src/ErrorReporting/Error.h
@@ -32,34 +32,32 @@ namespace SURELOG {
 
 class ErrorContainer;
 
-class Error final {
-public:
+class Error {
+ public:
   friend ErrorContainer;
-
-  Error(ErrorDefinition::ErrorType errorId, const Location& loc,
-        const std::vector<Location>* extraLocs = nullptr);
-  Error(ErrorDefinition::ErrorType errorId,
-        const Location& loc, const Location& extra);
-  Error(ErrorDefinition::ErrorType errorId,
-        const std::vector<Location>& locations);
-  Error(const Error& orig) = default;
-
+  Error(ErrorDefinition::ErrorType errorId, Location& loc,
+        std::vector<Location>* extraLocs = NULL);
+  Error(ErrorDefinition::ErrorType errorId, Location& loc, Location& extra);
+  Error(ErrorDefinition::ErrorType errorId, std::vector<Location>& locations);
   bool operator==(const Error& rhs) const;
   bool operator<(const Error& rhs) const;
   struct compare {
     bool operator()(const Error& e1, const Error& e2) const { return e1 < e2; }
   };
 
-  const std::vector<Location>& getLocations() const { return m_locations; }
-  ErrorDefinition::ErrorType getType() const { return m_errorId; }
+  /* Do not create Copy constructor, use default*/
+  // Error(const Error& orig);
+  virtual ~Error();
+  std::vector<Location>& getLocations() { return m_locations; }
+  ErrorDefinition::ErrorType getType() { return m_errorId; }
 
-private:
+ private:
   std::vector<Location> m_locations;
   ErrorDefinition::ErrorType m_errorId;
-  bool m_reported = false;
-  bool m_waived = false;
+  bool m_reported;
+  bool m_waived;
 };
 
-}  // namespace SURELOG
+};  // namespace SURELOG
 
 #endif /* ERROR_H */

--- a/src/ErrorReporting/ErrorContainer.h
+++ b/src/ErrorReporting/ErrorContainer.h
@@ -33,7 +33,7 @@ namespace SURELOG {
 
 class CommandLineParser;
 
-class ErrorContainer final {
+class ErrorContainer {
  public:
   class Stats {
   public:
@@ -56,43 +56,38 @@ class ErrorContainer final {
   };
 
   ErrorContainer(SymbolTable* symbolTable);
-
   void regiterCmdLine(CommandLineParser* clp) { m_clp = clp; }
   void init();
   Error& addError(Error& error, bool showDuplicates = false,
                   bool reentrantPython = true);
-  void appendErrors(const ErrorContainer& other);
-
-  const std::vector<Error>& getErrors() const { return m_errors; }
+  ErrorContainer(const ErrorContainer& orig);
+  virtual ~ErrorContainer();
+  std::vector<Error>& getErrors() { return m_errors; }
   bool printMessages(bool muteStdout = false);
   bool printMessage(Error& error, bool muteStdout = false);
-  bool printStats(const Stats& stats, bool muteStdout = false);
-  bool printToLogFile(const std::string& report);
-  bool hasFatalErrors() const;
-  Stats getErrorStats() const;
-
+  bool printStats(Stats stats, bool muteStdout = false);
+  bool printToLogFile(std::string report);
+  bool hasFatalErrors();
+  Stats getErrorStats();
+  void appendErrors(ErrorContainer&);
+  SymbolTable* getSymbolTable() { return m_symbolTable; }
   std::tuple<std::string, bool, bool> createErrorMessage(
-    const Error& error, bool reentrantPython = true) const;
+      Error& error, bool reentrantPython = true);
   void setPythonInterp(void* interpState) {
     m_interpState = interpState;
   }
 
-  SymbolTable* getSymbolTable() { return m_symbolTable; }
-
  private:
-  ErrorContainer(const ErrorContainer& orig) = delete;
-
   std::pair<std::string, bool> createReport_();
   std::pair<std::string, bool> createReport_(Error& error);
-
   std::vector<Error> m_errors;
   std::set<std::string> m_errorSet;
-  CommandLineParser* m_clp = nullptr;
-  bool m_reportedFatalErrorLogFile = false;
-  SymbolTable* const m_symbolTable;
+  CommandLineParser* m_clp;
+  bool m_reportedFatalErrorLogFile;
+  SymbolTable* m_symbolTable;
   void* m_interpState;
 };
 
-}  // namespace SURELOG
+};  // namespace SURELOG
 
 #endif /* ERRORCONTAINER_H */

--- a/src/ErrorReporting/ErrorDefinition.cpp
+++ b/src/ErrorReporting/ErrorDefinition.cpp
@@ -20,9 +20,8 @@
  *
  * Created on March 5, 2017, 11:25 PM
  */
-#include "ErrorReporting/ErrorDefinition.h"
-
 #include "Utils/StringUtils.h"
+#include "ErrorReporting/ErrorDefinition.h"
 
 using namespace SURELOG;
 
@@ -74,22 +73,46 @@ ErrorDefinition::ErrorSeverity ErrorDefinition::getErrorSeverity(
 
 std::string ErrorDefinition::getCategoryName(
     ErrorDefinition::ErrorCategory category) {
+  std::string cat;
   switch (category) {
-  case ErrorCategory::CMD:   return "CM";
-  case ErrorCategory::PP:    return "PP";
-  case ErrorCategory::PARSE: return "PA";
-  case ErrorCategory::PYTH:  return "PY";
-  case ErrorCategory::LANG:  return "LA";
-  case ErrorCategory::SEMA:  return "SM";
-  case ErrorCategory::COMP:  return "CP";
-  case ErrorCategory::ELAB:  return "EL";
-  case ErrorCategory::LIB:   return "LIB";
-  case ErrorCategory::LINT:  return "LN";
-  case ErrorCategory::USER:  return "US";
-  case ErrorCategory::UHDM:  return "UH";
-    // Deliberately no 'default' so that compiler can warn on new enum value
+    case ErrorDefinition::CMD:
+      cat = "CM";
+      break;
+    case ErrorDefinition::PP:
+      cat = "PP";
+      break;
+    case ErrorDefinition::PARSE:
+      cat = "PA";
+      break;
+    case ErrorDefinition::PYTH:
+      cat = "PY";
+      break;
+    case ErrorDefinition::LANG:
+      cat = "LA";
+      break;
+    case ErrorDefinition::SEMA:
+      cat = "SM";
+      break;
+    case ErrorDefinition::COMP:
+      cat = "CP";
+      break;
+    case ErrorDefinition::ELAB:
+      cat = "EL";
+      break;
+    case ErrorDefinition::LIB:
+      cat = "LIB";
+      break;
+    case ErrorDefinition::LINT:
+      cat = "LN";
+      break;
+    case ErrorDefinition::USER:
+      cat = "US";
+      break;
+    case ErrorDefinition::UHDM:
+      cat = "UH";
+      break;
   }
-  return "";
+  return cat;
 }
 
 ErrorDefinition::ErrorCategory ErrorDefinition::getCategory(std::string cat) {
@@ -200,7 +223,7 @@ bool ErrorDefinition::init() {
   rec(PP_RECURSIVE_MACRO_DEFINITION, ERROR, PP,
       "Recursive macro definition for \"%s\"",
       "%exloc macro used in macro \"%exobj\"");
-  rec(PP_UNTERMINATED_STRING, ERROR, PP, "Illegal unterminated string: >>%s<<",
+  rec(PP_UNTERMINATED_STRING, ERROR, PP, "Illegal unterminated string: >>%s<<", 
       "%exloc macro instance");
   rec(PP_UNESCAPED_CHARACTER_IN_STRING, ERROR, PP,
       "Illegal un-escaped character '%s' in string");
@@ -339,10 +362,10 @@ bool ErrorDefinition::init() {
       "Out of range parameter index: \"%s\"");
   rec(LIB_FILE_MAPS_TO_MULTIPLE_LIBS, ERROR, LIB,
       "File \"%exobj\" maps to multiple libraries: \"%s\"");
-  rec(UHDM_UNSUPPORTED_EXPR, ERROR, UHDM, "Unsupported expression \"%s\"");
-  rec(UHDM_UNSUPPORTED_STMT, ERROR, UHDM, "Unsupported statement \"%s\"");
-  rec(UHDM_UNSUPPORTED_SIGNAL, ERROR, UHDM, "Unsupported signal type \"%s\"");
-  rec(UHDM_WRONG_OBJECT_TYPE, ERROR, UHDM, "Wrong object type added to container \"%s\"");
-  rec(UHDM_WRONG_COVERAGE_LINE, ERROR, UHDM, "UHDM coverage pointing to empty source line");
+  rec(UHDM_UNSUPPORTED_EXPR, ERROR, UHDM, "Unsupported expression \"%s\""); 
+  rec(UHDM_UNSUPPORTED_STMT, ERROR, UHDM, "Unsupported statement \"%s\"");  
+  rec(UHDM_UNSUPPORTED_SIGNAL, ERROR, UHDM, "Unsupported signal type \"%s\"");  
+  rec(UHDM_WRONG_OBJECT_TYPE, ERROR, UHDM, "Wrong object type added to container \"%s\"");  
+  rec(UHDM_WRONG_COVERAGE_LINE, ERROR, UHDM, "UHDM coverage pointing to empty source line"); 
   return true;
 }

--- a/src/ErrorReporting/ErrorDefinition.h
+++ b/src/ErrorReporting/ErrorDefinition.h
@@ -28,7 +28,7 @@
 
 namespace SURELOG {
 
-class ErrorDefinition final {
+class ErrorDefinition {
  public:
   enum ErrorSeverity { FATAL, SYNTAX, ERROR, WARNING, INFO, NOTE };
 
@@ -192,15 +192,12 @@ class ErrorDefinition final {
 
   class ErrorInfo {
    public:
-    ErrorInfo(ErrorSeverity severity, ErrorCategory category,
-              std::string_view s,
-              std::string_view extra)
+    ErrorInfo(ErrorSeverity severity, ErrorCategory category, std::string s,
+              std::string extra)
         : m_severity(severity),
           m_category(category),
           m_errorText(s),
           m_extraText(extra) {}
-    ErrorInfo(const ErrorInfo&) = default;
-
     ErrorSeverity m_severity;
     ErrorCategory m_category;
     std::string m_errorText;
@@ -224,12 +221,12 @@ class ErrorDefinition final {
                   std::string extraText = "");
 
  private:
-  ErrorDefinition() = delete;
-  ErrorDefinition(const ErrorDefinition& orig) = delete;
-
+  ErrorDefinition();
+  ErrorDefinition(const ErrorDefinition& orig);
+  virtual ~ErrorDefinition();
   static std::map<ErrorType, ErrorInfo> m_errorInfoMap;
 };
 
-}  // namespace SURELOG
+};  // namespace SURELOG
 
 #endif /* ERRORDEFINITION_H */

--- a/src/ErrorReporting/Location.cpp
+++ b/src/ErrorReporting/Location.cpp
@@ -20,9 +20,12 @@
  *
  * Created on March 6, 2017, 6:48 PM
  */
+#include <string>
 #include "ErrorReporting/Location.h"
 
 using namespace SURELOG;
+
+Location::~Location() {}
 
 bool Location::operator==(const Location& rhs) const {
   if (m_fileId != rhs.m_fileId) return false;

--- a/src/ErrorReporting/Location.h
+++ b/src/ErrorReporting/Location.h
@@ -28,25 +28,26 @@
 
 namespace SURELOG {
 
-class Location final {
-public:
+class Location {
+ public:
   Location(SymbolId object)
-    : m_fileId(0), m_line(0), m_column(0), m_object(object){};
+      : m_fileId(0), m_line(0), m_column(0), m_object(object){};
   Location(SymbolId fileId, unsigned int line, unsigned short int column,
            SymbolId object = 0)
-    : m_fileId(fileId), m_line(line), m_column(column), m_object(object){};
-  Location(const Location& orig) = default;
-
+      : m_fileId(fileId), m_line(line), m_column(column), m_object(object){};
+  /* Do not create a copy constructor, use default*/
+  // Location(const Location& orig);
   bool operator==(const Location& rhs) const;
   bool operator<(const Location& rhs) const;
-
-public:
+  virtual ~Location();
   SymbolId m_fileId;
   unsigned int m_line;
   unsigned short int m_column;
   SymbolId m_object;
+
+ private:
 };
 
-}  // namespace SURELOG
+};  // namespace SURELOG
 
 #endif /* LOCATION_H */


### PR DESCRIPTION
It cause printing some error messages with '%s' format specifier.
Will look offline what cause this and send an improved redo later.

Signed-off-by: Henner Zeller <h.zeller@acm.org>