### PR TITLE
Append 's' to time outputs.

### DIFF
--- a/src/SourceCompile/ParseFile.cpp
+++ b/src/SourceCompile/ParseFile.cpp
@@ -305,7 +305,7 @@ bool ParseFile::parseOneFile_(std::string fileName, unsigned int lineOffset) {
     if (getCompileSourceFile()->getCommandLineParser()->profile()) {
       m_profileInfo +=
           "SLL Parsing: " + StringUtils::to_string(tmr.elapsed_rounded()) +
-          " " + fileName + "\n";
+          "s " + fileName + "\n";
       tmr.reset();
     }
   } catch (ParseCancellationException& pex) {
@@ -415,8 +415,8 @@ bool ParseFile::parse() {
       }
 
       if (getCompileSourceFile()->getCommandLineParser()->profile()) {
-        m_profileInfo += "Cache saving: " + std::to_string(tmr.elapsed_rounded ()) + "\n";
-        std::cout << "Cache saving: " + std::to_string(tmr.elapsed_rounded ()) + "\n" << std::flush;
+        m_profileInfo += "Cache saving: " + std::to_string(tmr.elapsed_rounded ()) + "s\n";
+        std::cout << "Cache saving: " + std::to_string(tmr.elapsed_rounded ()) + "s\n" << std::flush;
         tmr.reset();
       }
     }

--- a/src/SourceCompile/PreprocessFile.cpp
+++ b/src/SourceCompile/PreprocessFile.cpp
@@ -406,7 +406,7 @@ bool PreprocessFile::preprocess() {
       if (getCompileSourceFile()->getCommandLineParser()->profile()) {
         m_profileInfo +=
                 "PP SSL Parsing: " + StringUtils::to_string(tmr.elapsed_rounded()) +
-                " " + fileName + "\n";
+                "s " + fileName + "\n";
         tmr.reset();
       }
 


### PR DESCRIPTION
This makes it simpler to add time canonicalization similar to
filename canonicalization added in #649: we can confidently
latch on a regular expression to something [0-9]+.[0-9]{3}s or
[0-9]+.[0-9]{6}s.

Signed-off-by: Henner Zeller <h.zeller@acm.org>