### PR TITLE
Elaboration updates VpiParent

### DIFF
--- a/tests/Assignments/Assignments.log
+++ b/tests/Assignments/Assignments.log
@@ -781,12 +781,12 @@ design: (work@dut)
     |vpiName:uvm_packer::get_packed_bits
     |vpiFullName:work@dut.uvm_packer::get_packed_bits
     |vpiIODecl:
-    \_io_decl: (stream)
+    \_io_decl: (stream), parent:uvm_packer::get_packed_bits
       |vpiName:stream
       |vpiDirection:6
       |vpiExpr:
       \_bit_var: , line:5, parent:stream
-        |vpiFullName:stream
+        |vpiFullName:work@dut.uvm_packer::get_packed_bits.stream
     |vpiStmt:
     \_begin: , parent:uvm_packer::get_packed_bits
       |vpiFullName:work@dut.uvm_packer::get_packed_bits
@@ -802,11 +802,12 @@ design: (work@dut)
         \_func_call: (new)
           |vpiName:new
           |vpiArgument:
-          \_operation: , line:6
+          \_operation: , line:6, parent:new
             |vpiOpType:24
             |vpiOperand:
             \_ref_obj: (cover_info.size), line:6
               |vpiName:cover_info.size
+              |vpiFullName:work@dut.uvm_packer::get_packed_bits.new.cover_info.size
             |vpiOperand:
             \_constant: , line:6
               |vpiConstType:7
@@ -814,8 +815,9 @@ design: (work@dut)
               |vpiSize:32
               |INT:1
           |vpiArgument:
-          \_ref_obj: (cover_info), line:6
+          \_ref_obj: (cover_info), line:6, parent:new
             |vpiName:cover_info
+            |vpiFullName:work@dut.uvm_packer::get_packed_bits.new.cover_info
       |vpiStmt:
       \_assignment: , line:7
         |vpiOpType:82
@@ -828,8 +830,9 @@ design: (work@dut)
         \_func_call: (new)
           |vpiName:new
           |vpiArgument:
-          \_ref_obj: (m_pack_iter), line:7
+          \_ref_obj: (m_pack_iter), line:7, parent:new
             |vpiName:m_pack_iter
+            |vpiFullName:work@dut.uvm_packer::get_packed_bits.new.m_pack_iter
       |vpiStmt:
       \_assignment: , line:8
         |vpiOpType:82
@@ -912,6 +915,7 @@ design: (work@dut)
           |vpiOperand:
           \_ref_obj: (i), line:10
             |vpiName:i
+            |vpiFullName:work@dut.uvm_packer::get_packed_bits.i
         |vpiStmt:
         \_assignment: , line:11
           |vpiOpType:82

--- a/tests/BindVarsAndEnum/BindVarsAndEnum.log
+++ b/tests/BindVarsAndEnum/BindVarsAndEnum.log
@@ -519,7 +519,7 @@ design: (work@conditional_Fsm)
   \_enum_typespec: (state), line:7
     |vpiName:state
     |vpiBaseTypespec:
-    \_logic_typespec: , line:7
+    \_logic_typespec: , line:7, parent:state
       |vpiRange:
       \_range: , line:7
         |vpiLeftRange:
@@ -535,15 +535,15 @@ design: (work@conditional_Fsm)
           |vpiSize:32
           |INT:0
     |vpiEnumConst:
-    \_enum_const: (COUNTER), line:7
+    \_enum_const: (COUNTER), line:7, parent:state
       |vpiName:COUNTER
       |INT:1
     |vpiEnumConst:
-    \_enum_const: (COUNTER_DONE), line:7
+    \_enum_const: (COUNTER_DONE), line:7, parent:state
       |vpiName:COUNTER_DONE
       |INT:2
     |vpiEnumConst:
-    \_enum_const: (RESET), line:7
+    \_enum_const: (RESET), line:7, parent:state
       |vpiName:RESET
       |INT:0
 ===================

--- a/tests/BitsOp/BitsOp.log
+++ b/tests/BitsOp/BitsOp.log
@@ -1139,7 +1139,7 @@ design: (work@dut)
   \_bit_typespec: (MyBits), line:93
     |vpiName:MyBits
     |vpiRange:
-    \_range: , line:93
+    \_range: , line:93, parent:MyBits
       |vpiLeftRange:
       \_constant: , line:93
         |vpiDecompile:9
@@ -1154,17 +1154,17 @@ design: (work@dut)
   \_struct_typespec: (MyType), line:88
     |vpiName:MyType
     |vpiTypespecMember:
-    \_typespec_member: (valid), line:89
+    \_typespec_member: (valid), line:89, parent:MyType
       |vpiName:valid
       |vpiTypespec:
-      \_logic_typespec: , line:89
+      \_logic_typespec: , line:89, parent:valid
     |vpiTypespecMember:
-    \_typespec_member: (data), line:90
+    \_typespec_member: (data), line:90, parent:MyType
       |vpiName:data
       |vpiTypespec:
-      \_bit_typespec: , line:90
+      \_bit_typespec: , line:90, parent:data
         |vpiRange:
-        \_range: , line:90, parent:MyType
+        \_range: , line:90
           |vpiLeftRange:
           \_constant: , line:90
             |vpiConstType:7
@@ -1181,20 +1181,20 @@ design: (work@dut)
   \_enum_typespec: (flash_erase_op_e), line:65
     |vpiName:flash_erase_op_e
     |vpiBaseTypespec:
-    \_logic_typespec: , line:62
+    \_logic_typespec: , line:62, parent:flash_erase_op_e
     |vpiEnumConst:
-    \_enum_const: (BankErase), line:64
+    \_enum_const: (BankErase), line:64, parent:flash_erase_op_e
       |vpiName:BankErase
       |INT:1
     |vpiEnumConst:
-    \_enum_const: (PageErase), line:63
+    \_enum_const: (PageErase), line:63, parent:flash_erase_op_e
       |vpiName:PageErase
       |INT:0
   |vpiTypedef:
   \_logic_typespec: (sha_word_t), line:67
     |vpiName:sha_word_t
     |vpiRange:
-    \_range: , line:67
+    \_range: , line:67, parent:sha_word_t
       |vpiLeftRange:
       \_constant: , line:67
         |vpiConstType:7
@@ -1216,9 +1216,10 @@ design: (work@dut)
     |vpiLhs:
     \_parameter: (WordByte), line:74
       |vpiName:WordByte
+      |vpiFullName:work@dut.WordByte
       |vpiLocalParam:1
       |vpiTypespec:
-      \_int_typespec: , line:74
+      \_int_typespec: , line:74, parent:WordByte
   |vpiParamAssign:
   \_param_assign: , line:76
     |vpiRhs:
@@ -1228,9 +1229,10 @@ design: (work@dut)
     |vpiLhs:
     \_parameter: (DataWidth), line:76
       |vpiName:DataWidth
+      |vpiFullName:work@dut.DataWidth
       |vpiLocalParam:1
       |vpiTypespec:
-      \_int_typespec: , line:76
+      \_int_typespec: , line:76, parent:DataWidth
   |vpiParamAssign:
   \_param_assign: , line:77
     |vpiRhs:
@@ -1240,9 +1242,10 @@ design: (work@dut)
     |vpiLhs:
     \_parameter: (DataBitWidth), line:77
       |vpiName:DataBitWidth
+      |vpiFullName:work@dut.DataBitWidth
       |vpiLocalParam:1
       |vpiTypespec:
-      \_int_typespec: , line:77
+      \_int_typespec: , line:77, parent:DataBitWidth
   |vpiParamAssign:
   \_param_assign: , line:78
     |vpiRhs:
@@ -1252,9 +1255,10 @@ design: (work@dut)
     |vpiLhs:
     \_parameter: (EraseBitWidth), line:78
       |vpiName:EraseBitWidth
+      |vpiFullName:work@dut.EraseBitWidth
       |vpiLocalParam:1
       |vpiTypespec:
-      \_int_typespec: , line:78
+      \_int_typespec: , line:78, parent:EraseBitWidth
   |vpiParamAssign:
   \_param_assign: , line:80
     |vpiRhs:
@@ -1264,9 +1268,10 @@ design: (work@dut)
     |vpiLhs:
     \_parameter: (HashWordBits), line:80
       |vpiName:HashWordBits
+      |vpiFullName:work@dut.HashWordBits
       |vpiLocalParam:1
       |vpiTypespec:
-      \_int_typespec: , line:80
+      \_int_typespec: , line:80, parent:HashWordBits
   |vpiParamAssign:
   \_param_assign: , line:82
     |vpiRhs:
@@ -1276,9 +1281,10 @@ design: (work@dut)
     |vpiLhs:
     \_parameter: (REQFIFO_WIDTH), line:82
       |vpiName:REQFIFO_WIDTH
+      |vpiFullName:work@dut.REQFIFO_WIDTH
       |vpiLocalParam:1
       |vpiTypespec:
-      \_int_typespec: , line:82
+      \_int_typespec: , line:82, parent:REQFIFO_WIDTH
   |vpiParameter:
   \_parameter: (WordByte), line:74
   |vpiParameter:
@@ -1351,6 +1357,7 @@ design: (work@dut)
                   |vpiOperand:
                   \_ref_obj: (dmi_tdi), line:117
                     |vpiName:dmi_tdi
+                    |vpiFullName:work@dmi_jtag.p_shift.dmi_tdi
                   |vpiOperand:
                   \_part_select: , line:117, parent:dr_q
                     |vpiConstantSelect:1
@@ -1406,12 +1413,12 @@ design: (work@dut)
         |vpiPacked:1
         |vpiName:dmi_t
         |vpiTypespecMember:
-        \_typespec_member: (address), line:103
+        \_typespec_member: (address), line:103, parent:dmi_t
           |vpiName:address
           |vpiTypespec:
-          \_logic_typespec: , line:103
+          \_logic_typespec: , line:103, parent:address
             |vpiRange:
-            \_range: , line:103, parent:dmi_t
+            \_range: , line:103
               |vpiLeftRange:
               \_constant: , line:103
                 |vpiConstType:7
@@ -1425,12 +1432,12 @@ design: (work@dut)
                 |vpiSize:32
                 |INT:0
         |vpiTypespecMember:
-        \_typespec_member: (data), line:104
+        \_typespec_member: (data), line:104, parent:dmi_t
           |vpiName:data
           |vpiTypespec:
-          \_logic_typespec: , line:104
+          \_logic_typespec: , line:104, parent:data
             |vpiRange:
-            \_range: , line:104, parent:dmi_t
+            \_range: , line:104
               |vpiLeftRange:
               \_constant: , line:104
                 |vpiConstType:7
@@ -1444,12 +1451,12 @@ design: (work@dut)
                 |vpiSize:32
                 |INT:0
         |vpiTypespecMember:
-        \_typespec_member: (op), line:105
+        \_typespec_member: (op), line:105, parent:dmi_t
           |vpiName:op
           |vpiTypespec:
-          \_logic_typespec: , line:105
+          \_logic_typespec: , line:105, parent:op
             |vpiRange:
-            \_range: , line:105, parent:dmi_t
+            \_range: , line:105
               |vpiLeftRange:
               \_constant: , line:105
                 |vpiConstType:7
@@ -1542,12 +1549,12 @@ design: (work@dut)
     |vpiPacked:1
     |vpiName:dmi_t
     |vpiTypespecMember:
-    \_typespec_member: (address), line:103
+    \_typespec_member: (address), line:103, parent:dmi_t
       |vpiName:address
       |vpiTypespec:
-      \_logic_typespec: , line:103
+      \_logic_typespec: , line:103, parent:address
         |vpiRange:
-        \_range: , line:103, parent:dmi_t
+        \_range: , line:103
           |vpiLeftRange:
           \_constant: , line:103
             |vpiConstType:7
@@ -1561,12 +1568,12 @@ design: (work@dut)
             |vpiSize:32
             |INT:0
     |vpiTypespecMember:
-    \_typespec_member: (data), line:104
+    \_typespec_member: (data), line:104, parent:dmi_t
       |vpiName:data
       |vpiTypespec:
-      \_logic_typespec: , line:104
+      \_logic_typespec: , line:104, parent:data
         |vpiRange:
-        \_range: , line:104, parent:dmi_t
+        \_range: , line:104
           |vpiLeftRange:
           \_constant: , line:104
             |vpiConstType:7
@@ -1580,12 +1587,12 @@ design: (work@dut)
             |vpiSize:32
             |INT:0
     |vpiTypespecMember:
-    \_typespec_member: (op), line:105
+    \_typespec_member: (op), line:105, parent:dmi_t
       |vpiName:op
       |vpiTypespec:
-      \_logic_typespec: , line:105
+      \_logic_typespec: , line:105, parent:op
         |vpiRange:
-        \_range: , line:105, parent:dmi_t
+        \_range: , line:105
           |vpiLeftRange:
           \_constant: , line:105
             |vpiConstType:7

--- a/tests/CaseFullElab/CaseFullElab.log
+++ b/tests/CaseFullElab/CaseFullElab.log
@@ -780,6 +780,7 @@ design: (work@FSM)
           |vpiOperand:
           \_ref_obj: (clock), line:17
             |vpiName:clock
+            |vpiFullName:work@FSM.clock
             |vpiActual:
             \_logic_net: (clock), line:3, parent:work@FSM
               |vpiName:clock
@@ -791,6 +792,7 @@ design: (work@FSM)
           |vpiOperand:
           \_ref_obj: (keys), line:17
             |vpiName:keys
+            |vpiFullName:work@FSM.keys
             |vpiActual:
             \_logic_net: (keys), line:3, parent:work@FSM
               |vpiName:keys
@@ -857,6 +859,7 @@ design: (work@FSM)
                     |vpiActual:
                     \_parameter: (Stop), line:9
                       |vpiName:Stop
+                      |vpiFullName:work@FSM.Stop
                   |vpiStmt:
                   \_assignment: , line:23
                     |vpiOpType:82
@@ -873,6 +876,7 @@ design: (work@FSM)
                       |vpiActual:
                       \_parameter: (Slow), line:12
                         |vpiName:Slow
+                        |vpiFullName:work@FSM.Slow
                 |vpiCaseItem:
                 \_case_item: , line:24
                   |vpiExpr:
@@ -882,6 +886,7 @@ design: (work@FSM)
                     |vpiActual:
                     \_parameter: (Move), line:10
                       |vpiName:Move
+                      |vpiFullName:work@FSM.Move
                   |vpiStmt:
                   \_assignment: , line:24
                     |vpiOpType:82
@@ -898,6 +903,7 @@ design: (work@FSM)
                       |vpiActual:
                       \_parameter: (Faster), line:15
                         |vpiName:Faster
+                        |vpiFullName:work@FSM.Faster
                 |vpiCaseItem:
                 \_case_item: , line:25
                   |vpiStmt:
@@ -1088,6 +1094,7 @@ design: (work@FSM)
     |vpiLhs:
     \_parameter: (Turn), line:11
       |vpiName:Turn
+      |vpiFullName:work@FSM.Turn
   |vpiParamAssign:
   \_param_assign: , line:12
     |vpiRhs:
@@ -1109,6 +1116,7 @@ design: (work@FSM)
     |vpiLhs:
     \_parameter: (Medium), line:13
       |vpiName:Medium
+      |vpiFullName:work@FSM.Medium
   |vpiParamAssign:
   \_param_assign: , line:14
     |vpiRhs:
@@ -1120,6 +1128,7 @@ design: (work@FSM)
     |vpiLhs:
     \_parameter: (Fast), line:14
       |vpiName:Fast
+      |vpiFullName:work@FSM.Fast
   |vpiParamAssign:
   \_param_assign: , line:15
     |vpiRhs:

--- a/tests/CaseInside/CaseInside.log
+++ b/tests/CaseInside/CaseInside.log
@@ -365,6 +365,7 @@ design: (work@dm_csrs)
           |vpiOperand:
           \_ref_obj: (dmi_req_i.addr), line:15
             |vpiName:dmi_req_i.addr
+            |vpiFullName:work@dm_csrs.csr_read_write.dmi_req_i.addr
         |vpiCaseItem:
         \_case_item: , line:17
           |vpiExpr:

--- a/tests/ClogCast/ClogCast.log
+++ b/tests/ClogCast/ClogCast.log
@@ -735,14 +735,16 @@ design: (work@debug_rom)
                     \_sys_func_call: ($clog2), line:38
                       |vpiName:$clog2
                       |vpiArgument:
-                      \_ref_obj: (RomSize), line:38
+                      \_ref_obj: (RomSize), line:38, parent:$clog2
                         |vpiName:RomSize
+                        |vpiFullName:addr_i.$clog2.RomSize
                         |vpiActual:
                         \_parameter: (RomSize), line:10
                           |vpiName:RomSize
+                          |vpiFullName:work@debug_rom.RomSize
                           |vpiLocalParam:1
                           |vpiTypespec:
-                          \_int_typespec: , line:10
+                          \_int_typespec: , line:10, parent:RomSize
                     |vpiOperand:
                     \_constant: , line:38
                       |vpiConstType:7

--- a/tests/ConditionalOp/ConditionalOp.log
+++ b/tests/ConditionalOp/ConditionalOp.log
@@ -365,9 +365,10 @@ design: (work@top)
     |vpiLhs:
     \_parameter: (NrHarts2), line:3
       |vpiName:NrHarts2
+      |vpiFullName:work@top.NrHarts2
       |vpiLocalParam:1
       |vpiTypespec:
-      \_int_typespec: , line:3
+      \_int_typespec: , line:3, parent:NrHarts2
   |vpiParamAssign:
   \_param_assign: , line:5
     |vpiRhs:
@@ -379,6 +380,7 @@ design: (work@top)
         |vpiOperand:
         \_ref_obj: (NrHarts), line:5
           |vpiName:NrHarts
+          |vpiFullName:work@top.NrHarts
         |vpiOperand:
         \_constant: , line:5
           |vpiConstType:7
@@ -395,14 +397,16 @@ design: (work@top)
       \_sys_func_call: ($clog2), line:5
         |vpiName:$clog2
         |vpiArgument:
-        \_ref_obj: (NrHarts), line:5
+        \_ref_obj: (NrHarts), line:5, parent:$clog2
           |vpiName:NrHarts
+          |vpiFullName:work@top.$clog2.NrHarts
     |vpiLhs:
     \_parameter: (HartSelLen1), line:5
       |vpiName:HartSelLen1
+      |vpiFullName:work@top.HartSelLen1
       |vpiLocalParam:1
       |vpiTypespec:
-      \_int_typespec: , line:5
+      \_int_typespec: , line:5, parent:HartSelLen1
   |vpiParamAssign:
   \_param_assign: , line:7
     |vpiRhs:
@@ -414,6 +418,7 @@ design: (work@top)
         |vpiOperand:
         \_ref_obj: (NrHarts), line:7
           |vpiName:NrHarts
+          |vpiFullName:work@top.NrHarts
         |vpiOperand:
         \_constant: , line:7
           |vpiConstType:7
@@ -435,9 +440,10 @@ design: (work@top)
     |vpiLhs:
     \_parameter: (HartSelLen2), line:7
       |vpiName:HartSelLen2
+      |vpiFullName:work@top.HartSelLen2
       |vpiLocalParam:1
       |vpiTypespec:
-      \_int_typespec: , line:7
+      \_int_typespec: , line:7, parent:HartSelLen2
   |vpiParamAssign:
   \_param_assign: , line:9
     |vpiRhs:
@@ -449,6 +455,7 @@ design: (work@top)
         |vpiOperand:
         \_ref_obj: (NrHarts), line:9
           |vpiName:NrHarts
+          |vpiFullName:work@top.NrHarts
         |vpiOperand:
         \_constant: , line:9
           |vpiConstType:7
@@ -468,9 +475,10 @@ design: (work@top)
     |vpiLhs:
     \_parameter: (HartSelLen3), line:9
       |vpiName:HartSelLen3
+      |vpiFullName:work@top.HartSelLen3
       |vpiLocalParam:1
       |vpiTypespec:
-      \_int_typespec: , line:9
+      \_int_typespec: , line:9, parent:HartSelLen3
   |vpiParameter:
   \_parameter: (NrHarts2), line:3
   |vpiParameter:

--- a/tests/DollarRoot/DollarRoot.log
+++ b/tests/DollarRoot/DollarRoot.log
@@ -9402,7 +9402,7 @@ design: (work@top)
             |vpiName:read_command_queue_master.pop_front
             |vpiFullName:work@test_program.read_command_queue_master.pop_front
             |vpiIndex:
-            \_constant: , line:254
+            \_constant: , line:254, parent:read_command_queue_master.pop_front
               |vpiConstType:7
               |vpiDecompile:0
               |vpiSize:32
@@ -9430,17 +9430,20 @@ design: (work@top)
           \_func_call: (get_expected_read_response), line:256
             |vpiName:get_expected_read_response
             |vpiArgument:
-            \_ref_obj: (cmd), line:256
+            \_ref_obj: (cmd), line:256, parent:get_expected_read_response
               |vpiName:cmd
+              |vpiFullName:work@test_program.get_expected_read_response.cmd
         |vpiStmt:
         \_func_call: (verify_response), line:257
           |vpiName:verify_response
           |vpiArgument:
-          \_ref_obj: (actual_rsp), line:257
+          \_ref_obj: (actual_rsp), line:257, parent:verify_response
             |vpiName:actual_rsp
+            |vpiFullName:work@test_program.verify_response.actual_rsp
           |vpiArgument:
-          \_ref_obj: (exp_rsp), line:257
+          \_ref_obj: (exp_rsp), line:257, parent:verify_response
             |vpiName:exp_rsp
+            |vpiFullName:work@test_program.verify_response.exp_rsp
   |vpiProcess:
   \_always: , line:261
     |vpiAlwaysType:1
@@ -9510,6 +9513,7 @@ design: (work@top)
               |vpiActual:
               \_parameter: (MAX_BURST), line:20
                 |vpiName:MAX_BURST
+                |vpiFullName:work@test_program.MAX_BURST
                 |vpiLocalParam:1
           |vpiForInitStmt:
           \_assign_stmt: 
@@ -9529,6 +9533,7 @@ design: (work@top)
             |vpiOperand:
             \_ref_obj: (i), line:290
               |vpiName:i
+              |vpiFullName:work@test_program.i
           |vpiStmt:
           \_begin: , line:290
             |vpiFullName:work@test_program
@@ -9544,27 +9549,31 @@ design: (work@top)
               \_sys_func_call: ($urandom_range), line:291
                 |vpiName:$urandom_range
                 |vpiArgument:
-                \_constant: , line:291
+                \_constant: , line:291, parent:$urandom_range
                   |vpiConstType:7
                   |vpiDecompile:0
                   |vpiSize:32
                   |INT:0
                 |vpiArgument:
-                \_ref_obj: (MAX_COMMAND_BACKPRESSURE), line:291
+                \_ref_obj: (MAX_COMMAND_BACKPRESSURE), line:291, parent:$urandom_range
                   |vpiName:MAX_COMMAND_BACKPRESSURE
+                  |vpiFullName:work@test_program.$urandom_range.MAX_COMMAND_BACKPRESSURE
                   |vpiActual:
                   \_parameter: (MAX_COMMAND_BACKPRESSURE), line:25
                     |vpiName:MAX_COMMAND_BACKPRESSURE
+                    |vpiFullName:work@test_program.MAX_COMMAND_BACKPRESSURE
                     |vpiLocalParam:1
             |vpiStmt:
             \_func_call: ($root.tb.dut.slave_0.set_interface_wait_time), line:292
               |vpiName:$root.tb.dut.slave_0.set_interface_wait_time
               |vpiArgument:
-              \_ref_obj: (backpressure_cycles), line:292
+              \_ref_obj: (backpressure_cycles), line:292, parent:$root.tb.dut.slave_0.set_interface_wait_time
                 |vpiName:backpressure_cycles
+                |vpiFullName:work@test_program.$root.tb.dut.slave_0.set_interface_wait_time.backpressure_cycles
               |vpiArgument:
-              \_ref_obj: (i), line:292
+              \_ref_obj: (i), line:292, parent:$root.tb.dut.slave_0.set_interface_wait_time
                 |vpiName:i
+                |vpiFullName:work@test_program.$root.tb.dut.slave_0.set_interface_wait_time.i
         |vpiStmt:
         \_assignment: , line:295
           |vpiOpType:82
@@ -9588,10 +9597,11 @@ design: (work@top)
           \_func_call: (get_expected_command_for_slave), line:296
             |vpiName:get_expected_command_for_slave
             |vpiArgument:
-            \_ref_obj: (actual_cmd), line:296
+            \_ref_obj: (actual_cmd), line:296, parent:get_expected_command_for_slave
               |vpiName:actual_cmd
+              |vpiFullName:work@test_program.get_expected_command_for_slave.actual_cmd
             |vpiArgument:
-            \_constant: , line:296
+            \_constant: , line:296, parent:get_expected_command_for_slave
               |vpiConstType:7
               |vpiDecompile:0
               |vpiSize:32
@@ -9600,11 +9610,13 @@ design: (work@top)
         \_func_call: (verify_command), line:297
           |vpiName:verify_command
           |vpiArgument:
-          \_ref_obj: (actual_cmd), line:297
+          \_ref_obj: (actual_cmd), line:297, parent:verify_command
             |vpiName:actual_cmd
+            |vpiFullName:work@test_program.verify_command.actual_cmd
           |vpiArgument:
-          \_ref_obj: (exp_cmd), line:297
+          \_ref_obj: (exp_cmd), line:297, parent:verify_command
             |vpiName:exp_cmd
+            |vpiFullName:work@test_program.verify_command.exp_cmd
         |vpiStmt:
         \_if_stmt: , line:300
           |vpiCondition:
@@ -9637,20 +9649,23 @@ design: (work@top)
               \_func_call: (create_response), line:301
                 |vpiName:create_response
                 |vpiArgument:
-                \_ref_obj: (actual_cmd.burstcount), line:301
+                \_ref_obj: (actual_cmd.burstcount), line:301, parent:create_response
                   |vpiName:actual_cmd.burstcount
+                  |vpiFullName:work@test_program.create_response.actual_cmd.burstcount
             |vpiStmt:
             \_func_call: (configure_and_push_response_to_slave_0), line:302
               |vpiName:configure_and_push_response_to_slave_0
               |vpiArgument:
-              \_ref_obj: (rsp), line:302
+              \_ref_obj: (rsp), line:302, parent:configure_and_push_response_to_slave_0
                 |vpiName:rsp
+                |vpiFullName:work@test_program.configure_and_push_response_to_slave_0.rsp
             |vpiStmt:
             \_func_call: (read_response_queue_slave.push_back), line:303
               |vpiName:read_response_queue_slave.push_back
               |vpiArgument:
-              \_ref_obj: (rsp), line:303
+              \_ref_obj: (rsp), line:303, parent:read_response_queue_slave.push_back
                 |vpiName:rsp
+                |vpiFullName:work@test_program.read_response_queue_slave.push_back.rsp
   |vpiProcess:
   \_always: , line:333
     |vpiAlwaysType:1
@@ -9662,6 +9677,7 @@ design: (work@top)
         |vpiOperand:
         \_ref_obj: ($root.tb.dut.clk_clk), line:333
           |vpiName:$root.tb.dut.clk_clk
+          |vpiFullName:work@test_program.$root.tb.dut.clk_clk
       |vpiStmt:
       \_begin: , line:333
         |vpiFullName:work@test_program
@@ -9739,7 +9755,7 @@ design: (work@top)
             |vpiName:read_command_queue_master.pop_front
             |vpiFullName:work@test_program.read_command_queue_master.pop_front
             |vpiIndex:
-            \_constant: , line:397
+            \_constant: , line:397, parent:read_command_queue_master.pop_front
               |vpiConstType:7
               |vpiDecompile:1
               |vpiSize:32
@@ -9767,17 +9783,20 @@ design: (work@top)
           \_func_call: (get_expected_read_response), line:399
             |vpiName:get_expected_read_response
             |vpiArgument:
-            \_ref_obj: (cmd), line:399
+            \_ref_obj: (cmd), line:399, parent:get_expected_read_response
               |vpiName:cmd
+              |vpiFullName:work@test_program.get_expected_read_response.cmd
         |vpiStmt:
         \_func_call: (verify_response), line:400
           |vpiName:verify_response
           |vpiArgument:
-          \_ref_obj: (actual_rsp), line:400
+          \_ref_obj: (actual_rsp), line:400, parent:verify_response
             |vpiName:actual_rsp
+            |vpiFullName:work@test_program.verify_response.actual_rsp
           |vpiArgument:
-          \_ref_obj: (exp_rsp), line:400
+          \_ref_obj: (exp_rsp), line:400, parent:verify_response
             |vpiName:exp_rsp
+            |vpiFullName:work@test_program.verify_response.exp_rsp
   |vpiProcess:
   \_always: , line:404
     |vpiAlwaysType:1
@@ -9864,6 +9883,7 @@ design: (work@top)
             |vpiOperand:
             \_ref_obj: (i), line:433
               |vpiName:i
+              |vpiFullName:work@test_program.i
           |vpiStmt:
           \_begin: , line:433
             |vpiFullName:work@test_program
@@ -9879,25 +9899,28 @@ design: (work@top)
               \_sys_func_call: ($urandom_range), line:434
                 |vpiName:$urandom_range
                 |vpiArgument:
-                \_constant: , line:434
+                \_constant: , line:434, parent:$urandom_range
                   |vpiConstType:7
                   |vpiDecompile:0
                   |vpiSize:32
                   |INT:0
                 |vpiArgument:
-                \_ref_obj: (MAX_COMMAND_BACKPRESSURE), line:434
+                \_ref_obj: (MAX_COMMAND_BACKPRESSURE), line:434, parent:$urandom_range
                   |vpiName:MAX_COMMAND_BACKPRESSURE
+                  |vpiFullName:work@test_program.$urandom_range.MAX_COMMAND_BACKPRESSURE
                   |vpiActual:
                   \_parameter: (MAX_COMMAND_BACKPRESSURE), line:25
             |vpiStmt:
             \_func_call: ($root.tb.dut.slave_1.set_interface_wait_time), line:435
               |vpiName:$root.tb.dut.slave_1.set_interface_wait_time
               |vpiArgument:
-              \_ref_obj: (backpressure_cycles), line:435
+              \_ref_obj: (backpressure_cycles), line:435, parent:$root.tb.dut.slave_1.set_interface_wait_time
                 |vpiName:backpressure_cycles
+                |vpiFullName:work@test_program.$root.tb.dut.slave_1.set_interface_wait_time.backpressure_cycles
               |vpiArgument:
-              \_ref_obj: (i), line:435
+              \_ref_obj: (i), line:435, parent:$root.tb.dut.slave_1.set_interface_wait_time
                 |vpiName:i
+                |vpiFullName:work@test_program.$root.tb.dut.slave_1.set_interface_wait_time.i
         |vpiStmt:
         \_assignment: , line:438
           |vpiOpType:82
@@ -9921,10 +9944,11 @@ design: (work@top)
           \_func_call: (get_expected_command_for_slave), line:439
             |vpiName:get_expected_command_for_slave
             |vpiArgument:
-            \_ref_obj: (actual_cmd), line:439
+            \_ref_obj: (actual_cmd), line:439, parent:get_expected_command_for_slave
               |vpiName:actual_cmd
+              |vpiFullName:work@test_program.get_expected_command_for_slave.actual_cmd
             |vpiArgument:
-            \_constant: , line:439
+            \_constant: , line:439, parent:get_expected_command_for_slave
               |vpiConstType:7
               |vpiDecompile:1
               |vpiSize:32
@@ -9933,11 +9957,13 @@ design: (work@top)
         \_func_call: (verify_command), line:440
           |vpiName:verify_command
           |vpiArgument:
-          \_ref_obj: (actual_cmd), line:440
+          \_ref_obj: (actual_cmd), line:440, parent:verify_command
             |vpiName:actual_cmd
+            |vpiFullName:work@test_program.verify_command.actual_cmd
           |vpiArgument:
-          \_ref_obj: (exp_cmd), line:440
+          \_ref_obj: (exp_cmd), line:440, parent:verify_command
             |vpiName:exp_cmd
+            |vpiFullName:work@test_program.verify_command.exp_cmd
         |vpiStmt:
         \_if_stmt: , line:443
           |vpiCondition:
@@ -9968,20 +9994,23 @@ design: (work@top)
               \_func_call: (create_response), line:444
                 |vpiName:create_response
                 |vpiArgument:
-                \_ref_obj: (actual_cmd.burstcount), line:444
+                \_ref_obj: (actual_cmd.burstcount), line:444, parent:create_response
                   |vpiName:actual_cmd.burstcount
+                  |vpiFullName:work@test_program.create_response.actual_cmd.burstcount
             |vpiStmt:
             \_func_call: (configure_and_push_response_to_slave_1), line:445
               |vpiName:configure_and_push_response_to_slave_1
               |vpiArgument:
-              \_ref_obj: (rsp), line:445
+              \_ref_obj: (rsp), line:445, parent:configure_and_push_response_to_slave_1
                 |vpiName:rsp
+                |vpiFullName:work@test_program.configure_and_push_response_to_slave_1.rsp
             |vpiStmt:
             \_func_call: (read_response_queue_slave.push_back), line:446
               |vpiName:read_response_queue_slave.push_back
               |vpiArgument:
-              \_ref_obj: (rsp), line:446
+              \_ref_obj: (rsp), line:446, parent:read_response_queue_slave.push_back
                 |vpiName:rsp
+                |vpiFullName:work@test_program.read_response_queue_slave.push_back.rsp
   |vpiProcess:
   \_always: , line:476
     |vpiAlwaysType:1
@@ -9993,6 +10022,7 @@ design: (work@top)
         |vpiOperand:
         \_ref_obj: ($root.tb.dut.clk_clk), line:476
           |vpiName:$root.tb.dut.clk_clk
+          |vpiFullName:work@test_program.$root.tb.dut.clk_clk
       |vpiStmt:
       \_begin: , line:476
         |vpiFullName:work@test_program
@@ -10036,8 +10066,9 @@ design: (work@top)
       \_func_call: (set_verbosity), line:525
         |vpiName:set_verbosity
         |vpiArgument:
-        \_ref_obj: (VERBOSITY_INFO), line:525
+        \_ref_obj: (VERBOSITY_INFO), line:525, parent:set_verbosity
           |vpiName:VERBOSITY_INFO
+          |vpiFullName:work@test_program.set_verbosity.VERBOSITY_INFO
       |vpiStmt:
       \_wait_stmt: , line:526
         |vpiCondition:
@@ -10057,7 +10088,7 @@ design: (work@top)
       \_sys_func_call: ($display), line:527
         |vpiName:$display
         |vpiArgument:
-        \_constant: , line:527
+        \_constant: , line:527, parent:$display
           |vpiConstType:6
           |vpiDecompile:"Starting master test program"
           |vpiSize:30
@@ -10066,7 +10097,7 @@ design: (work@top)
       \_sys_func_call: ($display), line:529
         |vpiName:$display
         |vpiArgument:
-        \_constant: , line:529
+        \_constant: , line:529, parent:$display
           |vpiConstType:6
           |vpiDecompile:"Master sending out non bursting write commands"
           |vpiSize:48
@@ -10075,21 +10106,23 @@ design: (work@top)
       \_func_call: (master_send_commands), line:530
         |vpiName:master_send_commands
         |vpiArgument:
-        \_constant: , line:530
+        \_constant: , line:530, parent:master_send_commands
           |vpiConstType:7
           |vpiDecompile:10
           |vpiSize:32
           |INT:10
         |vpiArgument:
-        \_ref_obj: (WRITE), line:530
+        \_ref_obj: (WRITE), line:530, parent:master_send_commands
           |vpiName:WRITE
+          |vpiFullName:work@test_program.master_send_commands.WRITE
           |vpiActual:
           \_enum_const: (WRITE), line:35
             |vpiName:WRITE
             |INT:0
         |vpiArgument:
-        \_ref_obj: (NOBURST), line:530
+        \_ref_obj: (NOBURST), line:530, parent:master_send_commands
           |vpiName:NOBURST
+          |vpiFullName:work@test_program.master_send_commands.NOBURST
           |vpiActual:
           \_enum_const: (NOBURST), line:41
             |vpiName:NOBURST
@@ -10098,7 +10131,7 @@ design: (work@top)
       \_sys_func_call: ($display), line:532
         |vpiName:$display
         |vpiArgument:
-        \_constant: , line:532
+        \_constant: , line:532, parent:$display
           |vpiConstType:6
           |vpiDecompile:"Master sending out non bursting read commands"
           |vpiSize:47
@@ -10107,26 +10140,28 @@ design: (work@top)
       \_func_call: (master_send_commands), line:533
         |vpiName:master_send_commands
         |vpiArgument:
-        \_constant: , line:533
+        \_constant: , line:533, parent:master_send_commands
           |vpiConstType:7
           |vpiDecompile:10
           |vpiSize:32
           |INT:10
         |vpiArgument:
-        \_ref_obj: (READ), line:533
+        \_ref_obj: (READ), line:533, parent:master_send_commands
           |vpiName:READ
+          |vpiFullName:work@test_program.master_send_commands.READ
           |vpiActual:
           \_enum_const: (READ), line:36
         |vpiArgument:
-        \_ref_obj: (NOBURST), line:533
+        \_ref_obj: (NOBURST), line:533, parent:master_send_commands
           |vpiName:NOBURST
+          |vpiFullName:work@test_program.master_send_commands.NOBURST
           |vpiActual:
           \_enum_const: (NOBURST), line:41
       |vpiStmt:
       \_sys_func_call: ($display), line:535
         |vpiName:$display
         |vpiArgument:
-        \_constant: , line:535
+        \_constant: , line:535, parent:$display
           |vpiConstType:6
           |vpiDecompile:"Master sending out burst write commands"
           |vpiSize:41
@@ -10135,19 +10170,21 @@ design: (work@top)
       \_func_call: (master_send_commands), line:536
         |vpiName:master_send_commands
         |vpiArgument:
-        \_constant: , line:536
+        \_constant: , line:536, parent:master_send_commands
           |vpiConstType:7
           |vpiDecompile:10
           |vpiSize:32
           |INT:10
         |vpiArgument:
-        \_ref_obj: (WRITE), line:536
+        \_ref_obj: (WRITE), line:536, parent:master_send_commands
           |vpiName:WRITE
+          |vpiFullName:work@test_program.master_send_commands.WRITE
           |vpiActual:
           \_enum_const: (WRITE), line:35
         |vpiArgument:
-        \_ref_obj: (BURST), line:536
+        \_ref_obj: (BURST), line:536, parent:master_send_commands
           |vpiName:BURST
+          |vpiFullName:work@test_program.master_send_commands.BURST
           |vpiActual:
           \_enum_const: (BURST), line:42
             |vpiName:BURST
@@ -10156,7 +10193,7 @@ design: (work@top)
       \_sys_func_call: ($display), line:538
         |vpiName:$display
         |vpiArgument:
-        \_constant: , line:538
+        \_constant: , line:538, parent:$display
           |vpiConstType:6
           |vpiDecompile:"Master sending out burst read commands"
           |vpiSize:40
@@ -10165,26 +10202,28 @@ design: (work@top)
       \_func_call: (master_send_commands), line:539
         |vpiName:master_send_commands
         |vpiArgument:
-        \_constant: , line:539
+        \_constant: , line:539, parent:master_send_commands
           |vpiConstType:7
           |vpiDecompile:10
           |vpiSize:32
           |INT:10
         |vpiArgument:
-        \_ref_obj: (READ), line:539
+        \_ref_obj: (READ), line:539, parent:master_send_commands
           |vpiName:READ
+          |vpiFullName:work@test_program.master_send_commands.READ
           |vpiActual:
           \_enum_const: (READ), line:36
         |vpiArgument:
-        \_ref_obj: (BURST), line:539
+        \_ref_obj: (BURST), line:539, parent:master_send_commands
           |vpiName:BURST
+          |vpiFullName:work@test_program.master_send_commands.BURST
           |vpiActual:
           \_enum_const: (BURST), line:42
       |vpiStmt:
       \_sys_func_call: ($display), line:541
         |vpiName:$display
         |vpiArgument:
-        \_constant: , line:541
+        \_constant: , line:541, parent:$display
           |vpiConstType:6
           |vpiDecompile:"Master has sent out all commands"
           |vpiSize:34
@@ -10201,8 +10240,9 @@ design: (work@top)
     |vpiName:get_read_response_from_master_0
     |vpiFullName:work@test_program.get_read_response_from_master_0
     |vpiReturn:
-    \_chandle_var: (Response), line:266
+    \_chandle_var: (Response), line:266, parent:get_read_response_from_master_0
       |vpiName:Response
+      |vpiFullName:work@test_program.get_read_response_from_master_0.Response
     |vpiStmt:
     \_begin: , parent:get_read_response_from_master_0
       |vpiFullName:work@test_program.get_read_response_from_master_0
@@ -10259,6 +10299,7 @@ design: (work@top)
           |vpiOperand:
           \_ref_obj: (i), line:272
             |vpiName:i
+            |vpiFullName:work@test_program.get_read_response_from_master_0.i
         |vpiStmt:
         \_begin: , line:272
           |vpiFullName:work@test_program.get_read_response_from_master_0
@@ -10290,8 +10331,9 @@ design: (work@top)
     |vpiName:get_command_from_slave_0
     |vpiFullName:work@test_program.get_command_from_slave_0
     |vpiReturn:
-    \_chandle_var: (Command), line:309
+    \_chandle_var: (Command), line:309, parent:get_command_from_slave_0
       |vpiName:Command
+      |vpiFullName:work@test_program.get_command_from_slave_0.Command
     |vpiStmt:
     \_begin: , parent:get_command_from_slave_0
       |vpiFullName:work@test_program.get_command_from_slave_0
@@ -10390,6 +10432,7 @@ design: (work@top)
               |vpiOperand:
               \_ref_obj: (i), line:319
                 |vpiName:i
+                |vpiFullName:work@test_program.get_command_from_slave_0.i
             |vpiStmt:
             \_begin: , line:319
               |vpiFullName:work@test_program.get_command_from_slave_0
@@ -10466,8 +10509,9 @@ design: (work@top)
     |vpiName:get_read_response_from_master_1
     |vpiFullName:work@test_program.get_read_response_from_master_1
     |vpiReturn:
-    \_chandle_var: (Response), line:409
+    \_chandle_var: (Response), line:409, parent:get_read_response_from_master_1
       |vpiName:Response
+      |vpiFullName:work@test_program.get_read_response_from_master_1.Response
     |vpiStmt:
     \_begin: , parent:get_read_response_from_master_1
       |vpiFullName:work@test_program.get_read_response_from_master_1
@@ -10524,6 +10568,7 @@ design: (work@top)
           |vpiOperand:
           \_ref_obj: (i), line:415
             |vpiName:i
+            |vpiFullName:work@test_program.get_read_response_from_master_1.i
         |vpiStmt:
         \_begin: , line:415
           |vpiFullName:work@test_program.get_read_response_from_master_1
@@ -10555,8 +10600,9 @@ design: (work@top)
     |vpiName:get_command_from_slave_1
     |vpiFullName:work@test_program.get_command_from_slave_1
     |vpiReturn:
-    \_chandle_var: (Command), line:452
+    \_chandle_var: (Command), line:452, parent:get_command_from_slave_1
       |vpiName:Command
+      |vpiFullName:work@test_program.get_command_from_slave_1.Command
     |vpiStmt:
     \_begin: , parent:get_command_from_slave_1
       |vpiFullName:work@test_program.get_command_from_slave_1
@@ -10655,6 +10701,7 @@ design: (work@top)
               |vpiOperand:
               \_ref_obj: (i), line:462
                 |vpiName:i
+                |vpiFullName:work@test_program.get_command_from_slave_1.i
             |vpiStmt:
             \_begin: , line:462
               |vpiFullName:work@test_program.get_command_from_slave_1
@@ -10731,31 +10778,32 @@ design: (work@top)
     |vpiName:create_command
     |vpiFullName:work@test_program.create_command
     |vpiReturn:
-    \_chandle_var: (Command), line:570
+    \_chandle_var: (Command), line:570, parent:create_command
       |vpiName:Command
+      |vpiFullName:work@test_program.create_command.Command
     |vpiIODecl:
-    \_io_decl: (trans)
+    \_io_decl: (trans), parent:create_command
       |vpiName:trans
       |vpiDirection:5
       |vpiExpr:
       \_chandle_var: (Transaction), line:571, parent:trans
         |vpiName:Transaction
-        |vpiFullName:trans.Transaction
+        |vpiFullName:work@test_program.create_command.trans.Transaction
     |vpiIODecl:
-    \_io_decl: (burstmode)
+    \_io_decl: (burstmode), parent:create_command
       |vpiName:burstmode
       |vpiDirection:5
       |vpiExpr:
       \_chandle_var: (Burstmode), line:572, parent:burstmode
         |vpiName:Burstmode
-        |vpiFullName:burstmode.Burstmode
+        |vpiFullName:work@test_program.create_command.burstmode.Burstmode
     |vpiIODecl:
-    \_io_decl: (slave_id)
+    \_io_decl: (slave_id), parent:create_command
       |vpiName:slave_id
       |vpiDirection:5
       |vpiExpr:
       \_int_var: , line:573, parent:slave_id
-        |vpiFullName:slave_id
+        |vpiFullName:work@test_program.create_command.slave_id
     |vpiStmt:
     \_begin: , parent:create_command
       |vpiFullName:work@test_program.create_command
@@ -10835,8 +10883,9 @@ design: (work@top)
         \_func_call: (generate_random_aligned_address), line:585
           |vpiName:generate_random_aligned_address
           |vpiArgument:
-          \_ref_obj: (slave_id), line:585
+          \_ref_obj: (slave_id), line:585, parent:generate_random_aligned_address
             |vpiName:slave_id
+            |vpiFullName:work@test_program.create_command.generate_random_aligned_address.slave_id
       |vpiStmt:
       \_assignment: , line:586
         |vpiOpType:82
@@ -10849,17 +10898,19 @@ design: (work@top)
         \_sys_func_call: ($urandom_range), line:586
           |vpiName:$urandom_range
           |vpiArgument:
-          \_constant: , line:586
+          \_constant: , line:586, parent:$urandom_range
             |vpiConstType:7
             |vpiDecompile:0
             |vpiSize:32
             |INT:0
           |vpiArgument:
-          \_ref_obj: (MAX_COMMAND_IDLE), line:586
+          \_ref_obj: (MAX_COMMAND_IDLE), line:586, parent:$urandom_range
             |vpiName:MAX_COMMAND_IDLE
+            |vpiFullName:work@test_program.create_command.$urandom_range.MAX_COMMAND_IDLE
             |vpiActual:
             \_parameter: (MAX_COMMAND_IDLE), line:24
               |vpiName:MAX_COMMAND_IDLE
+              |vpiFullName:work@test_program.MAX_COMMAND_IDLE
               |vpiLocalParam:1
       |vpiStmt:
       \_if_else: , line:588
@@ -10911,6 +10962,7 @@ design: (work@top)
               |vpiOperand:
               \_ref_obj: (i), line:589
                 |vpiName:i
+                |vpiFullName:work@test_program.create_command.i
             |vpiStmt:
             \_begin: , line:589
               |vpiFullName:work@test_program.create_command
@@ -10947,9 +10999,11 @@ design: (work@top)
                   |vpiOperand:
                   \_ref_obj: (NUM_SYMBOLS), line:591
                     |vpiName:NUM_SYMBOLS
+                    |vpiFullName:work@test_program.create_command.NUM_SYMBOLS
                     |vpiActual:
                     \_parameter: (NUM_SYMBOLS), line:16
                       |vpiName:NUM_SYMBOLS
+                      |vpiFullName:work@test_program.NUM_SYMBOLS
                       |vpiLocalParam:1
                   |vpiOperand:
                   \_operation: 
@@ -10976,17 +11030,19 @@ design: (work@top)
                 \_sys_func_call: ($urandom_range), line:592
                   |vpiName:$urandom_range
                   |vpiArgument:
-                  \_constant: , line:592
+                  \_constant: , line:592, parent:$urandom_range
                     |vpiConstType:7
                     |vpiDecompile:0
                     |vpiSize:32
                     |INT:0
                   |vpiArgument:
-                  \_ref_obj: (MAX_DATA_IDLE), line:592
+                  \_ref_obj: (MAX_DATA_IDLE), line:592, parent:$urandom_range
                     |vpiName:MAX_DATA_IDLE
+                    |vpiFullName:work@test_program.create_command.$urandom_range.MAX_DATA_IDLE
                     |vpiActual:
                     \_parameter: (MAX_DATA_IDLE), line:26
                       |vpiName:MAX_DATA_IDLE
+                      |vpiFullName:work@test_program.MAX_DATA_IDLE
                       |vpiLocalParam:1
         |vpiElseStmt:
         \_begin: , line:594
@@ -11009,14 +11065,15 @@ design: (work@top)
             \_sys_func_call: ($urandom_range), line:595
               |vpiName:$urandom_range
               |vpiArgument:
-              \_constant: , line:595
+              \_constant: , line:595, parent:$urandom_range
                 |vpiConstType:7
                 |vpiDecompile:0
                 |vpiSize:32
                 |INT:0
               |vpiArgument:
-              \_ref_obj: (MAX_DATA_IDLE), line:595
+              \_ref_obj: (MAX_DATA_IDLE), line:595, parent:$urandom_range
                 |vpiName:MAX_DATA_IDLE
+                |vpiFullName:work@test_program.create_command.$urandom_range.MAX_DATA_IDLE
                 |vpiActual:
                 \_parameter: (MAX_DATA_IDLE), line:26
       |vpiStmt:
@@ -11031,8 +11088,9 @@ design: (work@top)
     |vpiName:randomize_burstcount
     |vpiFullName:work@test_program.randomize_burstcount
     |vpiReturn:
-    \_chandle_var: (Burstcount), line:601
+    \_chandle_var: (Burstcount), line:601, parent:randomize_burstcount
       |vpiName:Burstcount
+      |vpiFullName:work@test_program.randomize_burstcount.Burstcount
     |vpiStmt:
     \_begin: , parent:randomize_burstcount
       |vpiFullName:work@test_program.randomize_burstcount
@@ -11054,14 +11112,15 @@ design: (work@top)
         \_sys_func_call: ($urandom_range), line:605
           |vpiName:$urandom_range
           |vpiArgument:
-          \_constant: , line:605
+          \_constant: , line:605, parent:$urandom_range
             |vpiConstType:7
             |vpiDecompile:1
             |vpiSize:32
             |INT:1
           |vpiArgument:
-          \_ref_obj: (MAX_BURST), line:605
+          \_ref_obj: (MAX_BURST), line:605, parent:$urandom_range
             |vpiName:MAX_BURST
+            |vpiFullName:work@test_program.randomize_burstcount.$urandom_range.MAX_BURST
             |vpiActual:
             \_parameter: (MAX_BURST), line:20
       |vpiStmt:
@@ -11076,7 +11135,8 @@ design: (work@top)
     |vpiName:generate_random_aligned_address
     |vpiFullName:work@test_program.generate_random_aligned_address
     |vpiReturn:
-    \_logic_var: , line:609
+    \_logic_var: , line:609, parent:generate_random_aligned_address
+      |vpiFullName:work@test_program.generate_random_aligned_address
       |vpiRange:
       \_range: , line:609
         |vpiLeftRange:
@@ -11085,9 +11145,11 @@ design: (work@top)
           |vpiOperand:
           \_ref_obj: (ADDR_W), line:609
             |vpiName:ADDR_W
+            |vpiFullName:work@test_program.generate_random_aligned_address.ADDR_W
             |vpiActual:
             \_parameter: (ADDR_W), line:13
               |vpiName:ADDR_W
+              |vpiFullName:work@test_program.ADDR_W
               |vpiLocalParam:1
           |vpiOperand:
           \_constant: , line:609
@@ -11102,12 +11164,12 @@ design: (work@top)
           |vpiSize:32
           |INT:0
     |vpiIODecl:
-    \_io_decl: (slave_id)
+    \_io_decl: (slave_id), parent:generate_random_aligned_address
       |vpiName:slave_id
       |vpiDirection:5
       |vpiExpr:
       \_int_var: , line:610, parent:slave_id
-        |vpiFullName:slave_id
+        |vpiFullName:work@test_program.generate_random_aligned_address.slave_id
     |vpiStmt:
     \_begin: , parent:generate_random_aligned_address
       |vpiFullName:work@test_program.generate_random_aligned_address
@@ -11118,13 +11180,14 @@ design: (work@top)
           |vpiName:base_addr
           |vpiFullName:work@test_program.generate_random_aligned_address.base_addr
           |vpiRange:
-          \_range: , line:612
+          \_range: , line:612, parent:base_addr
             |vpiLeftRange:
             \_operation: , line:612
               |vpiOpType:11
               |vpiOperand:
               \_ref_obj: (ADDR_W), line:612
                 |vpiName:ADDR_W
+                |vpiFullName:work@test_program.generate_random_aligned_address.base_addr.ADDR_W
                 |vpiActual:
                 \_parameter: (ADDR_W), line:13
               |vpiOperand:
@@ -11146,13 +11209,14 @@ design: (work@top)
           |vpiName:addr
           |vpiFullName:work@test_program.generate_random_aligned_address.addr
           |vpiRange:
-          \_range: , line:612
+          \_range: , line:612, parent:addr
             |vpiLeftRange:
             \_operation: , line:612
               |vpiOpType:11
               |vpiOperand:
               \_ref_obj: (ADDR_W), line:612
                 |vpiName:ADDR_W
+                |vpiFullName:work@test_program.generate_random_aligned_address.addr.ADDR_W
                 |vpiActual:
                 \_parameter: (ADDR_W), line:13
               |vpiOperand:
@@ -11189,6 +11253,7 @@ design: (work@top)
             |vpiActual:
             \_parameter: (SLAVE_SPAN), line:22
               |vpiName:SLAVE_SPAN
+              |vpiFullName:work@test_program.SLAVE_SPAN
               |vpiLocalParam:1
       |vpiStmt:
       \_assignment: , line:615
@@ -11265,7 +11330,8 @@ design: (work@top)
     |vpiName:translate_master_to_slave_address
     |vpiFullName:work@test_program.translate_master_to_slave_address
     |vpiReturn:
-    \_logic_var: , line:658
+    \_logic_var: , line:658, parent:translate_master_to_slave_address
+      |vpiFullName:work@test_program.translate_master_to_slave_address
       |vpiRange:
       \_range: , line:658
         |vpiLeftRange:
@@ -11274,6 +11340,7 @@ design: (work@top)
           |vpiOperand:
           \_ref_obj: (ADDR_W), line:658
             |vpiName:ADDR_W
+            |vpiFullName:work@test_program.translate_master_to_slave_address.ADDR_W
             |vpiActual:
             \_parameter: (ADDR_W), line:13
           |vpiOperand:
@@ -11289,12 +11356,12 @@ design: (work@top)
           |vpiSize:32
           |INT:0
     |vpiIODecl:
-    \_io_decl: (addr)
+    \_io_decl: (addr), parent:translate_master_to_slave_address
       |vpiName:addr
       |vpiDirection:5
       |vpiExpr:
       \_logic_var: , line:659, parent:addr
-        |vpiFullName:addr
+        |vpiFullName:work@test_program.translate_master_to_slave_address.addr
         |vpiRange:
         \_range: , line:659
           |vpiLeftRange:
@@ -11303,6 +11370,7 @@ design: (work@top)
             |vpiOperand:
             \_ref_obj: (ADDR_W), line:659
               |vpiName:ADDR_W
+              |vpiFullName:work@test_program.translate_master_to_slave_address.addr.ADDR_W
               |vpiActual:
               \_parameter: (ADDR_W), line:13
             |vpiOperand:
@@ -11346,13 +11414,14 @@ design: (work@top)
           |vpiName:base_addr
           |vpiFullName:work@test_program.translate_master_to_slave_address.base_addr
           |vpiRange:
-          \_range: , line:662
+          \_range: , line:662, parent:base_addr
             |vpiLeftRange:
             \_operation: , line:662
               |vpiOpType:11
               |vpiOperand:
               \_ref_obj: (ADDR_W), line:662
                 |vpiName:ADDR_W
+                |vpiFullName:work@test_program.translate_master_to_slave_address.base_addr.ADDR_W
                 |vpiActual:
                 \_parameter: (ADDR_W), line:13
               |vpiOperand:
@@ -11374,13 +11443,14 @@ design: (work@top)
           |vpiName:offset
           |vpiFullName:work@test_program.translate_master_to_slave_address.offset
           |vpiRange:
-          \_range: , line:662
+          \_range: , line:662, parent:offset
             |vpiLeftRange:
             \_operation: , line:662
               |vpiOpType:11
               |vpiOperand:
               \_ref_obj: (ADDR_W), line:662
                 |vpiName:ADDR_W
+                |vpiFullName:work@test_program.translate_master_to_slave_address.offset.ADDR_W
                 |vpiActual:
                 \_parameter: (ADDR_W), line:13
               |vpiOperand:
@@ -11462,23 +11532,24 @@ design: (work@top)
     |vpiName:get_expected_command_for_slave
     |vpiFullName:work@test_program.get_expected_command_for_slave
     |vpiReturn:
-    \_chandle_var: (Command), line:682
+    \_chandle_var: (Command), line:682, parent:get_expected_command_for_slave
       |vpiName:Command
+      |vpiFullName:work@test_program.get_expected_command_for_slave.Command
     |vpiIODecl:
-    \_io_decl: (cmd)
+    \_io_decl: (cmd), parent:get_expected_command_for_slave
       |vpiName:cmd
       |vpiDirection:5
       |vpiExpr:
       \_chandle_var: (Command), line:683, parent:cmd
         |vpiName:Command
-        |vpiFullName:cmd.Command
+        |vpiFullName:work@test_program.get_expected_command_for_slave.cmd.Command
     |vpiIODecl:
-    \_io_decl: (slave_id)
+    \_io_decl: (slave_id), parent:get_expected_command_for_slave
       |vpiName:slave_id
       |vpiDirection:5
       |vpiExpr:
       \_int_var: , line:684, parent:slave_id
-        |vpiFullName:slave_id
+        |vpiFullName:work@test_program.get_expected_command_for_slave.slave_id
     |vpiStmt:
     \_begin: , parent:get_expected_command_for_slave
       |vpiFullName:work@test_program.get_expected_command_for_slave
@@ -11568,8 +11639,9 @@ design: (work@top)
                   \_func_call: (write_command_queue_slave.delete), line:694
                     |vpiName:write_command_queue_slave.delete
                     |vpiArgument:
-                    \_ref_obj: (i), line:694
+                    \_ref_obj: (i), line:694, parent:write_command_queue_slave.delete
                       |vpiName:i
+                      |vpiFullName:work@test_program.get_expected_command_for_slave.write_command_queue_slave.delete.i
                   |vpiStmt:
                   \_assignment: , line:695
                     |vpiOpType:82
@@ -11617,8 +11689,9 @@ design: (work@top)
                   |vpiName:write_command_queue_slave.pop_front
                   |vpiFullName:work@test_program.get_expected_command_for_slave.write_command_queue_slave.pop_front
                   |vpiIndex:
-                  \_ref_obj: (slave_id), line:700
+                  \_ref_obj: (slave_id), line:700, parent:write_command_queue_slave.pop_front
                     |vpiName:slave_id
+                    |vpiFullName:work@test_program.get_expected_command_for_slave.write_command_queue_slave.pop_front.slave_id
         |vpiElseStmt:
         \_begin: , line:702
           |vpiFullName:work@test_program.get_expected_command_for_slave
@@ -11672,8 +11745,9 @@ design: (work@top)
                   \_func_call: (read_command_queue_slave.delete), line:706
                     |vpiName:read_command_queue_slave.delete
                     |vpiArgument:
-                    \_ref_obj: (i), line:706
+                    \_ref_obj: (i), line:706, parent:read_command_queue_slave.delete
                       |vpiName:i
+                      |vpiFullName:work@test_program.get_expected_command_for_slave.read_command_queue_slave.delete.i
                   |vpiStmt:
                   \_assignment: , line:707
                     |vpiOpType:82
@@ -11721,8 +11795,9 @@ design: (work@top)
                   |vpiName:read_command_queue_slave.pop_front
                   |vpiFullName:work@test_program.get_expected_command_for_slave.read_command_queue_slave.pop_front
                   |vpiIndex:
-                  \_ref_obj: (slave_id), line:712
+                  \_ref_obj: (slave_id), line:712, parent:read_command_queue_slave.pop_front
                     |vpiName:slave_id
+                    |vpiFullName:work@test_program.get_expected_command_for_slave.read_command_queue_slave.pop_front.slave_id
       |vpiStmt:
       \_return_stmt: , line:716
         |vpiCondition:
@@ -11747,16 +11822,17 @@ design: (work@top)
     |vpiName:create_response
     |vpiFullName:work@test_program.create_response
     |vpiReturn:
-    \_chandle_var: (Response), line:759
+    \_chandle_var: (Response), line:759, parent:create_response
       |vpiName:Response
+      |vpiFullName:work@test_program.create_response.Response
     |vpiIODecl:
-    \_io_decl: (burstcount)
+    \_io_decl: (burstcount), parent:create_response
       |vpiName:burstcount
       |vpiDirection:5
       |vpiExpr:
       \_chandle_var: (Burstcount), line:760, parent:burstcount
         |vpiName:Burstcount
-        |vpiFullName:burstcount.Burstcount
+        |vpiFullName:work@test_program.create_response.burstcount.Burstcount
     |vpiStmt:
     \_begin: , parent:create_response
       |vpiFullName:work@test_program.create_response
@@ -11810,6 +11886,7 @@ design: (work@top)
           |vpiOperand:
           \_ref_obj: (i), line:766
             |vpiName:i
+            |vpiFullName:work@test_program.create_response.i
         |vpiStmt:
         \_begin: , line:766
           |vpiFullName:work@test_program.create_response
@@ -11844,14 +11921,15 @@ design: (work@top)
             \_sys_func_call: ($urandom_range), line:768
               |vpiName:$urandom_range
               |vpiArgument:
-              \_constant: , line:768
+              \_constant: , line:768, parent:$urandom_range
                 |vpiConstType:7
                 |vpiDecompile:0
                 |vpiSize:32
                 |INT:0
               |vpiArgument:
-              \_ref_obj: (MAX_DATA_IDLE), line:768
+              \_ref_obj: (MAX_DATA_IDLE), line:768, parent:$urandom_range
                 |vpiName:MAX_DATA_IDLE
+                |vpiFullName:work@test_program.create_response.$urandom_range.MAX_DATA_IDLE
                 |vpiActual:
                 \_parameter: (MAX_DATA_IDLE), line:26
       |vpiStmt:
@@ -11866,16 +11944,17 @@ design: (work@top)
     |vpiName:get_expected_read_response
     |vpiFullName:work@test_program.get_expected_read_response
     |vpiReturn:
-    \_chandle_var: (Response), line:774
+    \_chandle_var: (Response), line:774, parent:get_expected_read_response
       |vpiName:Response
+      |vpiFullName:work@test_program.get_expected_read_response.Response
     |vpiIODecl:
-    \_io_decl: (cmd)
+    \_io_decl: (cmd), parent:get_expected_read_response
       |vpiName:cmd
       |vpiDirection:5
       |vpiExpr:
       \_chandle_var: (Command), line:775, parent:cmd
         |vpiName:Command
-        |vpiFullName:cmd.Command
+        |vpiFullName:work@test_program.get_expected_read_response.cmd.Command
     |vpiStmt:
     \_begin: , parent:get_expected_read_response
       |vpiFullName:work@test_program.get_expected_read_response
@@ -11917,8 +11996,9 @@ design: (work@top)
           |vpiName:read_response_queue_slave.pop_front
           |vpiFullName:work@test_program.get_expected_read_response.read_response_queue_slave.pop_front
           |vpiIndex:
-          \_ref_obj: (slave_id), line:781
+          \_ref_obj: (slave_id), line:781, parent:read_response_queue_slave.pop_front
             |vpiName:slave_id
+            |vpiFullName:work@test_program.get_expected_read_response.read_response_queue_slave.pop_front.slave_id
       |vpiStmt:
       \_return_stmt: , line:783
         |vpiCondition:
@@ -12309,7 +12389,7 @@ design: (work@top)
   \_logic_typespec: (Burstcount), line:31
     |vpiName:Burstcount
     |vpiRange:
-    \_range: , line:31
+    \_range: , line:31, parent:Burstcount
       |vpiLeftRange:
       \_constant: , line:31
         |vpiDecompile:3
@@ -12324,42 +12404,42 @@ design: (work@top)
   \_enum_typespec: (Burstmode), line:43
     |vpiName:Burstmode
     |vpiBaseTypespec:
-    \_bit_typespec: , line:39
+    \_bit_typespec: , line:39, parent:Burstmode
     |vpiEnumConst:
-    \_enum_const: (BURST), line:42
+    \_enum_const: (BURST), line:42, parent:Burstmode
       |vpiName:BURST
       |INT:1
     |vpiEnumConst:
-    \_enum_const: (NOBURST), line:41
+    \_enum_const: (NOBURST), line:41, parent:Burstmode
       |vpiName:NOBURST
       |INT:0
   |vpiTypedef:
   \_struct_typespec: (Command), line:45
     |vpiName:Command
     |vpiTypespecMember:
-    \_typespec_member: (trans), line:47
+    \_typespec_member: (trans), line:47, parent:Command
       |vpiName:trans
       |vpiTypespec:
-      \_enum_typespec: (Transaction), line:37
+      \_enum_typespec: (Transaction), line:37, parent:trans
         |vpiName:Transaction
         |vpiBaseTypespec:
-        \_bit_typespec: , line:33
+        \_bit_typespec: , line:33, parent:Transaction
         |vpiEnumConst:
-        \_enum_const: (READ), line:36
+        \_enum_const: (READ), line:36, parent:Transaction
           |vpiName:READ
           |INT:1
         |vpiEnumConst:
-        \_enum_const: (WRITE), line:35
+        \_enum_const: (WRITE), line:35, parent:Transaction
           |vpiName:WRITE
           |INT:0
     |vpiTypespecMember:
-    \_typespec_member: (burstcount), line:48
+    \_typespec_member: (burstcount), line:48, parent:Command
       |vpiName:burstcount
       |vpiTypespec:
-      \_logic_typespec: (Burstcount), line:31
+      \_logic_typespec: (Burstcount), line:31, parent:burstcount
         |vpiName:Burstcount
         |vpiRange:
-        \_range: , line:31
+        \_range: , line:31, parent:Burstcount
           |vpiLeftRange:
           \_constant: , line:31
             |vpiDecompile:3
@@ -12371,12 +12451,12 @@ design: (work@top)
             |vpiSize:32
             |INT:0
     |vpiTypespecMember:
-    \_typespec_member: (addr), line:49
+    \_typespec_member: (addr), line:49, parent:Command
       |vpiName:addr
       |vpiTypespec:
-      \_logic_typespec: , line:49
+      \_logic_typespec: , line:49, parent:addr
         |vpiRange:
-        \_range: , line:49, parent:Command
+        \_range: , line:49
           |vpiLeftRange:
           \_constant: , line:49
             |vpiDecompile:12
@@ -12388,12 +12468,12 @@ design: (work@top)
             |vpiSize:32
             |INT:0
     |vpiTypespecMember:
-    \_typespec_member: (data), line:50
+    \_typespec_member: (data), line:50, parent:Command
       |vpiName:data
       |vpiTypespec:
-      \_logic_typespec: , line:50
+      \_logic_typespec: , line:50, parent:data
         |vpiRange:
-        \_range: , line:50, parent:Command
+        \_range: , line:50
           |vpiLeftRange:
           \_constant: , line:50
             |vpiDecompile:31
@@ -12405,12 +12485,12 @@ design: (work@top)
             |vpiSize:32
             |INT:0
     |vpiTypespecMember:
-    \_typespec_member: (byteenable), line:51
+    \_typespec_member: (byteenable), line:51, parent:Command
       |vpiName:byteenable
       |vpiTypespec:
-      \_logic_typespec: , line:51
+      \_logic_typespec: , line:51, parent:byteenable
         |vpiRange:
-        \_range: , line:51, parent:Command
+        \_range: , line:51
           |vpiLeftRange:
           \_constant: , line:51
             |vpiDecompile:3
@@ -12422,12 +12502,12 @@ design: (work@top)
             |vpiSize:32
             |INT:0
     |vpiTypespecMember:
-    \_typespec_member: (cmd_delay), line:52
+    \_typespec_member: (cmd_delay), line:52, parent:Command
       |vpiName:cmd_delay
       |vpiTypespec:
-      \_bit_typespec: , line:52
+      \_bit_typespec: , line:52, parent:cmd_delay
         |vpiRange:
-        \_range: , line:52, parent:Command
+        \_range: , line:52
           |vpiLeftRange:
           \_constant: , line:52
             |vpiConstType:7
@@ -12441,12 +12521,12 @@ design: (work@top)
             |vpiSize:32
             |INT:0
     |vpiTypespecMember:
-    \_typespec_member: (data_idles), line:53
+    \_typespec_member: (data_idles), line:53, parent:Command
       |vpiName:data_idles
       |vpiTypespec:
-      \_bit_typespec: , line:53
+      \_bit_typespec: , line:53, parent:data_idles
         |vpiRange:
-        \_range: , line:53, parent:Command
+        \_range: , line:53
           |vpiLeftRange:
           \_constant: , line:53
             |vpiConstType:7
@@ -12463,13 +12543,13 @@ design: (work@top)
   \_struct_typespec: (Response), line:56
     |vpiName:Response
     |vpiTypespecMember:
-    \_typespec_member: (burstcount), line:58
+    \_typespec_member: (burstcount), line:58, parent:Response
       |vpiName:burstcount
       |vpiTypespec:
-      \_logic_typespec: (Burstcount), line:31
+      \_logic_typespec: (Burstcount), line:31, parent:burstcount
         |vpiName:Burstcount
         |vpiRange:
-        \_range: , line:31
+        \_range: , line:31, parent:Burstcount
           |vpiLeftRange:
           \_constant: , line:31
             |vpiDecompile:3
@@ -12481,12 +12561,12 @@ design: (work@top)
             |vpiSize:32
             |INT:0
     |vpiTypespecMember:
-    \_typespec_member: (data), line:59
+    \_typespec_member: (data), line:59, parent:Response
       |vpiName:data
       |vpiTypespec:
-      \_logic_typespec: , line:59
+      \_logic_typespec: , line:59, parent:data
         |vpiRange:
-        \_range: , line:59, parent:Response
+        \_range: , line:59
           |vpiLeftRange:
           \_constant: , line:59
             |vpiDecompile:31
@@ -12498,12 +12578,12 @@ design: (work@top)
             |vpiSize:32
             |INT:0
     |vpiTypespecMember:
-    \_typespec_member: (latency), line:60
+    \_typespec_member: (latency), line:60, parent:Response
       |vpiName:latency
       |vpiTypespec:
-      \_bit_typespec: , line:60
+      \_bit_typespec: , line:60, parent:latency
         |vpiRange:
-        \_range: , line:60, parent:Response
+        \_range: , line:60
           |vpiLeftRange:
           \_constant: , line:60
             |vpiConstType:7
@@ -12520,13 +12600,13 @@ design: (work@top)
   \_enum_typespec: (Transaction), line:37
     |vpiName:Transaction
     |vpiBaseTypespec:
-    \_bit_typespec: , line:33
+    \_bit_typespec: , line:33, parent:Transaction
     |vpiEnumConst:
-    \_enum_const: (READ), line:36
+    \_enum_const: (READ), line:36, parent:Transaction
       |vpiName:READ
       |INT:1
     |vpiEnumConst:
-    \_enum_const: (WRITE), line:35
+    \_enum_const: (WRITE), line:35, parent:Transaction
       |vpiName:WRITE
       |INT:0
   |vpiParamAssign:
@@ -12550,6 +12630,7 @@ design: (work@top)
     |vpiLhs:
     \_parameter: (SYMBOL_W), line:15
       |vpiName:SYMBOL_W
+      |vpiFullName:work@test_program.SYMBOL_W
       |vpiLocalParam:1
   |vpiParamAssign:
   \_param_assign: , line:16
@@ -12570,6 +12651,7 @@ design: (work@top)
     |vpiLhs:
     \_parameter: (DATA_W), line:17
       |vpiName:DATA_W
+      |vpiFullName:work@test_program.DATA_W
       |vpiLocalParam:1
   |vpiParamAssign:
   \_param_assign: , line:19
@@ -12582,6 +12664,7 @@ design: (work@top)
     |vpiLhs:
     \_parameter: (BURST_W), line:19
       |vpiName:BURST_W
+      |vpiFullName:work@test_program.BURST_W
       |vpiLocalParam:1
   |vpiParamAssign:
   \_param_assign: , line:20
@@ -12673,7 +12756,7 @@ design: (work@top)
         \_func_call: ($root.tb.dut.master_0[3].pop_response), line:803
           |vpiName:$root.tb.dut.master_0[3].pop_response
           |vpiArgument:
-          \_constant: , line:803
+          \_constant: , line:803, parent:$root.tb.dut.master_0[3].pop_response
             |vpiConstType:6
             |vpiDecompile:"blah"
             |vpiSize:6

--- a/tests/FSM2Always/FSM2Always.log
+++ b/tests/FSM2Always/FSM2Always.log
@@ -1600,6 +1600,7 @@ design: (work@fsm_using_always)
           |vpiOperand:
           \_ref_obj: (state), line:29
             |vpiName:state
+            |vpiFullName:work@fsm_using_always.state
             |vpiActual:
             \_logic_net: (state), line:26, parent:work@fsm_using_always
               |vpiName:state
@@ -1622,6 +1623,7 @@ design: (work@fsm_using_always)
           |vpiOperand:
           \_ref_obj: (req_0), line:29
             |vpiName:req_0
+            |vpiFullName:work@fsm_using_always.req_0
             |vpiActual:
             \_logic_net: (req_0), line:19, parent:work@fsm_using_always
               |vpiName:req_0
@@ -1630,6 +1632,7 @@ design: (work@fsm_using_always)
         |vpiOperand:
         \_ref_obj: (req_1), line:29
           |vpiName:req_1
+          |vpiFullName:work@fsm_using_always.req_1
           |vpiActual:
           \_logic_net: (req_1), line:19, parent:work@fsm_using_always
             |vpiName:req_1
@@ -1690,6 +1693,7 @@ design: (work@fsm_using_always)
               |vpiActual:
               \_parameter: (IDLE), line:24
                 |vpiName:IDLE
+                |vpiFullName:work@fsm_using_always.IDLE
             |vpiStmt:
             \_if_else: , line:33
               |vpiCondition:
@@ -1727,6 +1731,7 @@ design: (work@fsm_using_always)
                     |vpiActual:
                     \_parameter: (GNT0), line:24
                       |vpiName:GNT0
+                      |vpiFullName:work@fsm_using_always.GNT0
               |vpiElseStmt:
               \_if_else: , line:35
                 |vpiCondition:
@@ -1764,6 +1769,7 @@ design: (work@fsm_using_always)
                       |vpiActual:
                       \_parameter: (GNT1), line:24
                         |vpiName:GNT1
+                        |vpiFullName:work@fsm_using_always.GNT1
                 |vpiElseStmt:
                 \_begin: , line:37
                   |vpiFullName:work@fsm_using_always.FSM_COMBO
@@ -2359,6 +2365,7 @@ design: (work@fsm_using_always)
     |vpiLhs:
     \_parameter: (SIZE), line:23
       |vpiName:SIZE
+      |vpiFullName:work@fsm_using_always.SIZE
   |vpiParamAssign:
   \_param_assign: , line:24
     |vpiRhs:

--- a/tests/FSMBsp13/FSMBsp13.log
+++ b/tests/FSMBsp13/FSMBsp13.log
@@ -12124,14 +12124,15 @@ design: (work@top)
       \_sys_func_call: ($vtDumpvars), line:121
         |vpiName:$vtDumpvars
         |vpiArgument:
-        \_constant: , line:121
+        \_constant: , line:121, parent:$vtDumpvars
           |vpiConstType:7
           |vpiDecompile:1
           |vpiSize:32
           |INT:1
         |vpiArgument:
-        \_ref_obj: (top.F2), line:121
+        \_ref_obj: (top.F2), line:121, parent:$vtDumpvars
           |vpiName:top.F2
+          |vpiFullName:work@top.$vtDumpvars.top.F2
       |vpiStmt:
       \_delay_control: , line:126
         |#3000000
@@ -12331,6 +12332,7 @@ design: (work@top)
                 |vpiActual:
                 \_parameter: (ST_Read), line:7
                   |vpiName:ST_Read
+                  |vpiFullName:work@FSM1.ST_Read
             |vpiElseStmt:
             \_assignment: , line:18
               |vpiOpType:82
@@ -12478,6 +12480,7 @@ design: (work@top)
                 |vpiActual:
                 \_parameter: (ST_Trx), line:8
                   |vpiName:ST_Trx
+                  |vpiFullName:work@FSM1.ST_Trx
               |vpiStmt:
               \_begin: , line:31
                 |vpiFullName:work@FSM1.COMB
@@ -12591,6 +12594,7 @@ design: (work@top)
                       |vpiActual:
                       \_parameter: (ST_Hold), line:8
                         |vpiName:ST_Hold
+                        |vpiFullName:work@FSM1.ST_Hold
                   |vpiElseStmt:
                   \_if_else: , line:37
                     |vpiCondition:
@@ -12625,6 +12629,7 @@ design: (work@top)
                         |vpiActual:
                         \_parameter: (ST_Block), line:8
                           |vpiName:ST_Block
+                          |vpiFullName:work@FSM1.ST_Block
                     |vpiElseStmt:
                     \_if_else: , line:38
                       |vpiCondition:
@@ -12661,6 +12666,7 @@ design: (work@top)
                           |vpiActual:
                           \_parameter: (ST_Wait), line:9
                             |vpiName:ST_Wait
+                            |vpiFullName:work@FSM1.ST_Wait
                       |vpiElseStmt:
                       \_if_else: , line:39
                         |vpiCondition:
@@ -12695,6 +12701,7 @@ design: (work@top)
                             |vpiActual:
                             \_parameter: (ST_Turn), line:9
                               |vpiName:ST_Turn
+                              |vpiFullName:work@FSM1.ST_Turn
                         |vpiElseStmt:
                         \_if_else: , line:40
                           |vpiCondition:
@@ -12729,6 +12736,7 @@ design: (work@top)
                               |vpiActual:
                               \_parameter: (ST_Quit), line:9
                                 |vpiName:ST_Quit
+                                |vpiFullName:work@FSM1.ST_Quit
                           |vpiElseStmt:
                           \_assignment: , line:41
                             |vpiOpType:82
@@ -13233,6 +13241,7 @@ design: (work@top)
                             |vpiActual:
                             \_parameter: (ST_Done), line:10
                               |vpiName:ST_Done
+                              |vpiFullName:work@FSM1.ST_Done
                         |vpiElseStmt:
                         \_if_else: , line:66
                           |vpiCondition:
@@ -13267,6 +13276,7 @@ design: (work@top)
                               |vpiActual:
                               \_parameter: (ST_Exit), line:10
                                 |vpiName:ST_Exit
+                                |vpiFullName:work@FSM1.ST_Exit
                           |vpiElseStmt:
                           \_assignment: , line:67
                             |vpiOpType:82
@@ -13573,6 +13583,7 @@ design: (work@top)
                       |vpiActual:
                       \_parameter: (ST_Write), line:7
                         |vpiName:ST_Write
+                        |vpiFullName:work@FSM1.ST_Write
                   |vpiElseStmt:
                   \_if_else: , line:86
                     |vpiCondition:
@@ -14332,6 +14343,7 @@ design: (work@top)
                       |vpiActual:
                       \_parameter: (ST_Delay), line:7
                         |vpiName:ST_Delay
+                        |vpiFullName:work@FSM1.ST_Delay
                   |vpiElseStmt:
                   \_assignment: , line:136
                     |vpiOpType:82
@@ -14913,6 +14925,7 @@ design: (work@top)
           |vpiOperand:
           \_ref_obj: (control), line:36
             |vpiName:control
+            |vpiFullName:work@FSM2.control
             |vpiActual:
             \_logic_net: (control), line:1, parent:F2
               |vpiName:control
@@ -14920,6 +14933,7 @@ design: (work@top)
           |vpiOperand:
           \_ref_obj: (CurrentState), line:36
             |vpiName:CurrentState
+            |vpiFullName:work@FSM2.CurrentState
             |vpiActual:
             \_logic_net: (CurrentState), line:8, parent:F2
               |vpiName:CurrentState
@@ -14977,6 +14991,7 @@ design: (work@top)
               |vpiActual:
               \_parameter: (ST0), line:6
                 |vpiName:ST0
+                |vpiFullName:work@FSM2.ST0
           |vpiStmt:
           \_case_stmt: , line:38, parent:COMB
             |vpiCaseType:1
@@ -15014,16 +15029,17 @@ design: (work@top)
                     |vpiActual:
                     \_parameter: (ST1), line:6
                       |vpiName:ST1
+                      |vpiFullName:work@FSM2.ST1
                 |vpiStmt:
                 \_task_call: (SwitchCtrl), line:41
                   |vpiName:SwitchCtrl
                   |vpiTask:
-                  \_task: (SwitchCtrl), line:23
+                  \_task: (SwitchCtrl), line:23, parent:SwitchCtrl
                     |vpiName:SwitchCtrl
-                    |vpiFullName:work@FSM2.SwitchCtrl
+                    |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl
                     |vpiStmt:
                     \_begin: , line:24, parent:SwitchCtrl
-                      |vpiFullName:work@FSM2.SwitchCtrl
+                      |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl
                       |vpiStmt:
                       \_assignment: , line:25
                         |vpiOpType:82
@@ -15031,7 +15047,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl1), line:25
                           |vpiName:Ctrl1
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl1
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl1
                           |vpiActual:
                           \_logic_net: (Ctrl1), line:10, parent:F2
                         |vpiRhs:
@@ -15040,7 +15056,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl1), line:25
                             |vpiName:Ctrl1
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl1
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl1
                             |vpiActual:
                             \_logic_net: (Ctrl1), line:10, parent:F2
                       |vpiStmt:
@@ -15050,7 +15066,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl2), line:26
                           |vpiName:Ctrl2
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl2
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl2
                           |vpiActual:
                           \_logic_net: (Ctrl2), line:10, parent:F2
                         |vpiRhs:
@@ -15059,7 +15075,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl2), line:26
                             |vpiName:Ctrl2
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl2
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl2
                             |vpiActual:
                             \_logic_net: (Ctrl2), line:10, parent:F2
                       |vpiStmt:
@@ -15069,7 +15085,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl3), line:27
                           |vpiName:Ctrl3
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl3
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl3
                           |vpiActual:
                           \_logic_net: (Ctrl3), line:10, parent:F2
                         |vpiRhs:
@@ -15078,7 +15094,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl3), line:27
                             |vpiName:Ctrl3
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl3
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl3
                             |vpiActual:
                             \_logic_net: (Ctrl3), line:10, parent:F2
                       |vpiStmt:
@@ -15088,7 +15104,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl4), line:28
                           |vpiName:Ctrl4
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl4
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl4
                           |vpiActual:
                           \_logic_net: (Ctrl4), line:10, parent:F2
                         |vpiRhs:
@@ -15097,7 +15113,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl4), line:28
                             |vpiName:Ctrl4
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl4
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl4
                             |vpiActual:
                             \_logic_net: (Ctrl4), line:10, parent:F2
                       |vpiStmt:
@@ -15107,7 +15123,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl5), line:29
                           |vpiName:Ctrl5
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl5
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl5
                           |vpiActual:
                           \_logic_net: (Ctrl5), line:10, parent:F2
                         |vpiRhs:
@@ -15116,7 +15132,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl5), line:29
                             |vpiName:Ctrl5
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl5
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl5
                             |vpiActual:
                             \_logic_net: (Ctrl5), line:10, parent:F2
                       |vpiStmt:
@@ -15126,7 +15142,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl6), line:30
                           |vpiName:Ctrl6
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl6
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl6
                           |vpiActual:
                           \_logic_net: (Ctrl6), line:10, parent:F2
                         |vpiRhs:
@@ -15135,7 +15151,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl6), line:30
                             |vpiName:Ctrl6
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl6
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl6
                             |vpiActual:
                             \_logic_net: (Ctrl6), line:10, parent:F2
                       |vpiStmt:
@@ -15145,7 +15161,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl7), line:31
                           |vpiName:Ctrl7
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl7
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl7
                           |vpiActual:
                           \_logic_net: (Ctrl7), line:10, parent:F2
                         |vpiRhs:
@@ -15154,7 +15170,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl7), line:31
                             |vpiName:Ctrl7
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl7
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl7
                             |vpiActual:
                             \_logic_net: (Ctrl7), line:10, parent:F2
             |vpiCaseItem:
@@ -15193,6 +15209,7 @@ design: (work@top)
                       |vpiActual:
                       \_parameter: (ST2), line:6
                         |vpiName:ST2
+                        |vpiFullName:work@FSM2.ST2
                   |vpiElseStmt:
                   \_assignment: , line:48
                     |vpiOpType:82
@@ -15210,16 +15227,17 @@ design: (work@top)
                       |vpiActual:
                       \_parameter: (ST3), line:6
                         |vpiName:ST3
+                        |vpiFullName:work@FSM2.ST3
                 |vpiStmt:
                 \_task_call: (SwitchCtrl), line:49
                   |vpiName:SwitchCtrl
                   |vpiTask:
-                  \_task: (SwitchCtrl), line:23
+                  \_task: (SwitchCtrl), line:23, parent:SwitchCtrl
                     |vpiName:SwitchCtrl
-                    |vpiFullName:work@FSM2.SwitchCtrl
+                    |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl
                     |vpiStmt:
                     \_begin: , line:24, parent:SwitchCtrl
-                      |vpiFullName:work@FSM2.SwitchCtrl
+                      |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl
                       |vpiStmt:
                       \_assignment: , line:25
                         |vpiOpType:82
@@ -15227,7 +15245,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl1), line:25
                           |vpiName:Ctrl1
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl1
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl1
                           |vpiActual:
                           \_logic_net: (Ctrl1), line:10, parent:F2
                         |vpiRhs:
@@ -15236,7 +15254,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl1), line:25
                             |vpiName:Ctrl1
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl1
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl1
                             |vpiActual:
                             \_logic_net: (Ctrl1), line:10, parent:F2
                       |vpiStmt:
@@ -15246,7 +15264,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl2), line:26
                           |vpiName:Ctrl2
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl2
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl2
                           |vpiActual:
                           \_logic_net: (Ctrl2), line:10, parent:F2
                         |vpiRhs:
@@ -15255,7 +15273,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl2), line:26
                             |vpiName:Ctrl2
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl2
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl2
                             |vpiActual:
                             \_logic_net: (Ctrl2), line:10, parent:F2
                       |vpiStmt:
@@ -15265,7 +15283,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl3), line:27
                           |vpiName:Ctrl3
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl3
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl3
                           |vpiActual:
                           \_logic_net: (Ctrl3), line:10, parent:F2
                         |vpiRhs:
@@ -15274,7 +15292,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl3), line:27
                             |vpiName:Ctrl3
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl3
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl3
                             |vpiActual:
                             \_logic_net: (Ctrl3), line:10, parent:F2
                       |vpiStmt:
@@ -15284,7 +15302,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl4), line:28
                           |vpiName:Ctrl4
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl4
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl4
                           |vpiActual:
                           \_logic_net: (Ctrl4), line:10, parent:F2
                         |vpiRhs:
@@ -15293,7 +15311,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl4), line:28
                             |vpiName:Ctrl4
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl4
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl4
                             |vpiActual:
                             \_logic_net: (Ctrl4), line:10, parent:F2
                       |vpiStmt:
@@ -15303,7 +15321,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl5), line:29
                           |vpiName:Ctrl5
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl5
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl5
                           |vpiActual:
                           \_logic_net: (Ctrl5), line:10, parent:F2
                         |vpiRhs:
@@ -15312,7 +15330,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl5), line:29
                             |vpiName:Ctrl5
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl5
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl5
                             |vpiActual:
                             \_logic_net: (Ctrl5), line:10, parent:F2
                       |vpiStmt:
@@ -15322,7 +15340,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl6), line:30
                           |vpiName:Ctrl6
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl6
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl6
                           |vpiActual:
                           \_logic_net: (Ctrl6), line:10, parent:F2
                         |vpiRhs:
@@ -15331,7 +15349,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl6), line:30
                             |vpiName:Ctrl6
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl6
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl6
                             |vpiActual:
                             \_logic_net: (Ctrl6), line:10, parent:F2
                       |vpiStmt:
@@ -15341,7 +15359,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl7), line:31
                           |vpiName:Ctrl7
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl7
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl7
                           |vpiActual:
                           \_logic_net: (Ctrl7), line:10, parent:F2
                         |vpiRhs:
@@ -15350,7 +15368,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl7), line:31
                             |vpiName:Ctrl7
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl7
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl7
                             |vpiActual:
                             \_logic_net: (Ctrl7), line:10, parent:F2
             |vpiCaseItem:
@@ -15384,12 +15402,12 @@ design: (work@top)
                 \_task_call: (SwitchCtrl), line:54
                   |vpiName:SwitchCtrl
                   |vpiTask:
-                  \_task: (SwitchCtrl), line:23
+                  \_task: (SwitchCtrl), line:23, parent:SwitchCtrl
                     |vpiName:SwitchCtrl
-                    |vpiFullName:work@FSM2.SwitchCtrl
+                    |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl
                     |vpiStmt:
                     \_begin: , line:24, parent:SwitchCtrl
-                      |vpiFullName:work@FSM2.SwitchCtrl
+                      |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl
                       |vpiStmt:
                       \_assignment: , line:25
                         |vpiOpType:82
@@ -15397,7 +15415,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl1), line:25
                           |vpiName:Ctrl1
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl1
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl1
                           |vpiActual:
                           \_logic_net: (Ctrl1), line:10, parent:F2
                         |vpiRhs:
@@ -15406,7 +15424,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl1), line:25
                             |vpiName:Ctrl1
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl1
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl1
                             |vpiActual:
                             \_logic_net: (Ctrl1), line:10, parent:F2
                       |vpiStmt:
@@ -15416,7 +15434,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl2), line:26
                           |vpiName:Ctrl2
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl2
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl2
                           |vpiActual:
                           \_logic_net: (Ctrl2), line:10, parent:F2
                         |vpiRhs:
@@ -15425,7 +15443,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl2), line:26
                             |vpiName:Ctrl2
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl2
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl2
                             |vpiActual:
                             \_logic_net: (Ctrl2), line:10, parent:F2
                       |vpiStmt:
@@ -15435,7 +15453,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl3), line:27
                           |vpiName:Ctrl3
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl3
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl3
                           |vpiActual:
                           \_logic_net: (Ctrl3), line:10, parent:F2
                         |vpiRhs:
@@ -15444,7 +15462,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl3), line:27
                             |vpiName:Ctrl3
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl3
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl3
                             |vpiActual:
                             \_logic_net: (Ctrl3), line:10, parent:F2
                       |vpiStmt:
@@ -15454,7 +15472,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl4), line:28
                           |vpiName:Ctrl4
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl4
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl4
                           |vpiActual:
                           \_logic_net: (Ctrl4), line:10, parent:F2
                         |vpiRhs:
@@ -15463,7 +15481,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl4), line:28
                             |vpiName:Ctrl4
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl4
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl4
                             |vpiActual:
                             \_logic_net: (Ctrl4), line:10, parent:F2
                       |vpiStmt:
@@ -15473,7 +15491,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl5), line:29
                           |vpiName:Ctrl5
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl5
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl5
                           |vpiActual:
                           \_logic_net: (Ctrl5), line:10, parent:F2
                         |vpiRhs:
@@ -15482,7 +15500,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl5), line:29
                             |vpiName:Ctrl5
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl5
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl5
                             |vpiActual:
                             \_logic_net: (Ctrl5), line:10, parent:F2
                       |vpiStmt:
@@ -15492,7 +15510,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl6), line:30
                           |vpiName:Ctrl6
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl6
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl6
                           |vpiActual:
                           \_logic_net: (Ctrl6), line:10, parent:F2
                         |vpiRhs:
@@ -15501,7 +15519,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl6), line:30
                             |vpiName:Ctrl6
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl6
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl6
                             |vpiActual:
                             \_logic_net: (Ctrl6), line:10, parent:F2
                       |vpiStmt:
@@ -15511,7 +15529,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl7), line:31
                           |vpiName:Ctrl7
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl7
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl7
                           |vpiActual:
                           \_logic_net: (Ctrl7), line:10, parent:F2
                         |vpiRhs:
@@ -15520,7 +15538,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl7), line:31
                             |vpiName:Ctrl7
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl7
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl7
                             |vpiActual:
                             \_logic_net: (Ctrl7), line:10, parent:F2
             |vpiCaseItem:
@@ -15559,6 +15577,7 @@ design: (work@top)
                 |vpiActual:
                 \_parameter: (ST4), line:6
                   |vpiName:ST4
+                  |vpiFullName:work@FSM2.ST4
               |vpiStmt:
               \_begin: , line:61
                 |vpiFullName:work@FSM2.COMB
@@ -15566,12 +15585,12 @@ design: (work@top)
                 \_task_call: (SwitchCtrl), line:62
                   |vpiName:SwitchCtrl
                   |vpiTask:
-                  \_task: (SwitchCtrl), line:23
+                  \_task: (SwitchCtrl), line:23, parent:SwitchCtrl
                     |vpiName:SwitchCtrl
-                    |vpiFullName:work@FSM2.SwitchCtrl
+                    |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl
                     |vpiStmt:
                     \_begin: , line:24, parent:SwitchCtrl
-                      |vpiFullName:work@FSM2.SwitchCtrl
+                      |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl
                       |vpiStmt:
                       \_assignment: , line:25
                         |vpiOpType:82
@@ -15579,7 +15598,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl1), line:25
                           |vpiName:Ctrl1
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl1
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl1
                           |vpiActual:
                           \_logic_net: (Ctrl1), line:10, parent:F2
                         |vpiRhs:
@@ -15588,7 +15607,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl1), line:25
                             |vpiName:Ctrl1
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl1
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl1
                             |vpiActual:
                             \_logic_net: (Ctrl1), line:10, parent:F2
                       |vpiStmt:
@@ -15598,7 +15617,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl2), line:26
                           |vpiName:Ctrl2
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl2
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl2
                           |vpiActual:
                           \_logic_net: (Ctrl2), line:10, parent:F2
                         |vpiRhs:
@@ -15607,7 +15626,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl2), line:26
                             |vpiName:Ctrl2
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl2
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl2
                             |vpiActual:
                             \_logic_net: (Ctrl2), line:10, parent:F2
                       |vpiStmt:
@@ -15617,7 +15636,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl3), line:27
                           |vpiName:Ctrl3
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl3
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl3
                           |vpiActual:
                           \_logic_net: (Ctrl3), line:10, parent:F2
                         |vpiRhs:
@@ -15626,7 +15645,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl3), line:27
                             |vpiName:Ctrl3
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl3
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl3
                             |vpiActual:
                             \_logic_net: (Ctrl3), line:10, parent:F2
                       |vpiStmt:
@@ -15636,7 +15655,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl4), line:28
                           |vpiName:Ctrl4
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl4
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl4
                           |vpiActual:
                           \_logic_net: (Ctrl4), line:10, parent:F2
                         |vpiRhs:
@@ -15645,7 +15664,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl4), line:28
                             |vpiName:Ctrl4
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl4
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl4
                             |vpiActual:
                             \_logic_net: (Ctrl4), line:10, parent:F2
                       |vpiStmt:
@@ -15655,7 +15674,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl5), line:29
                           |vpiName:Ctrl5
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl5
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl5
                           |vpiActual:
                           \_logic_net: (Ctrl5), line:10, parent:F2
                         |vpiRhs:
@@ -15664,7 +15683,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl5), line:29
                             |vpiName:Ctrl5
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl5
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl5
                             |vpiActual:
                             \_logic_net: (Ctrl5), line:10, parent:F2
                       |vpiStmt:
@@ -15674,7 +15693,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl6), line:30
                           |vpiName:Ctrl6
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl6
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl6
                           |vpiActual:
                           \_logic_net: (Ctrl6), line:10, parent:F2
                         |vpiRhs:
@@ -15683,7 +15702,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl6), line:30
                             |vpiName:Ctrl6
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl6
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl6
                             |vpiActual:
                             \_logic_net: (Ctrl6), line:10, parent:F2
                       |vpiStmt:
@@ -15693,7 +15712,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl7), line:31
                           |vpiName:Ctrl7
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl7
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl7
                           |vpiActual:
                           \_logic_net: (Ctrl7), line:10, parent:F2
                         |vpiRhs:
@@ -15702,7 +15721,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl7), line:31
                             |vpiName:Ctrl7
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl7
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl7
                             |vpiActual:
                             \_logic_net: (Ctrl7), line:10, parent:F2
                 |vpiStmt:
@@ -15722,6 +15741,7 @@ design: (work@top)
                     |vpiActual:
                     \_parameter: (ST5), line:6
                       |vpiName:ST5
+                      |vpiFullName:work@FSM2.ST5
             |vpiCaseItem:
             \_case_item: , line:66
               |vpiExpr:
@@ -15750,16 +15770,17 @@ design: (work@top)
                     |vpiActual:
                     \_parameter: (ST10), line:7
                       |vpiName:ST10
+                      |vpiFullName:work@FSM2.ST10
                 |vpiStmt:
                 \_task_call: (SwitchCtrl), line:68
                   |vpiName:SwitchCtrl
                   |vpiTask:
-                  \_task: (SwitchCtrl), line:23
+                  \_task: (SwitchCtrl), line:23, parent:SwitchCtrl
                     |vpiName:SwitchCtrl
-                    |vpiFullName:work@FSM2.SwitchCtrl
+                    |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl
                     |vpiStmt:
                     \_begin: , line:24, parent:SwitchCtrl
-                      |vpiFullName:work@FSM2.SwitchCtrl
+                      |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl
                       |vpiStmt:
                       \_assignment: , line:25
                         |vpiOpType:82
@@ -15767,7 +15788,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl1), line:25
                           |vpiName:Ctrl1
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl1
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl1
                           |vpiActual:
                           \_logic_net: (Ctrl1), line:10, parent:F2
                         |vpiRhs:
@@ -15776,7 +15797,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl1), line:25
                             |vpiName:Ctrl1
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl1
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl1
                             |vpiActual:
                             \_logic_net: (Ctrl1), line:10, parent:F2
                       |vpiStmt:
@@ -15786,7 +15807,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl2), line:26
                           |vpiName:Ctrl2
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl2
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl2
                           |vpiActual:
                           \_logic_net: (Ctrl2), line:10, parent:F2
                         |vpiRhs:
@@ -15795,7 +15816,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl2), line:26
                             |vpiName:Ctrl2
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl2
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl2
                             |vpiActual:
                             \_logic_net: (Ctrl2), line:10, parent:F2
                       |vpiStmt:
@@ -15805,7 +15826,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl3), line:27
                           |vpiName:Ctrl3
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl3
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl3
                           |vpiActual:
                           \_logic_net: (Ctrl3), line:10, parent:F2
                         |vpiRhs:
@@ -15814,7 +15835,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl3), line:27
                             |vpiName:Ctrl3
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl3
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl3
                             |vpiActual:
                             \_logic_net: (Ctrl3), line:10, parent:F2
                       |vpiStmt:
@@ -15824,7 +15845,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl4), line:28
                           |vpiName:Ctrl4
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl4
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl4
                           |vpiActual:
                           \_logic_net: (Ctrl4), line:10, parent:F2
                         |vpiRhs:
@@ -15833,7 +15854,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl4), line:28
                             |vpiName:Ctrl4
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl4
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl4
                             |vpiActual:
                             \_logic_net: (Ctrl4), line:10, parent:F2
                       |vpiStmt:
@@ -15843,7 +15864,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl5), line:29
                           |vpiName:Ctrl5
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl5
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl5
                           |vpiActual:
                           \_logic_net: (Ctrl5), line:10, parent:F2
                         |vpiRhs:
@@ -15852,7 +15873,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl5), line:29
                             |vpiName:Ctrl5
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl5
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl5
                             |vpiActual:
                             \_logic_net: (Ctrl5), line:10, parent:F2
                       |vpiStmt:
@@ -15862,7 +15883,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl6), line:30
                           |vpiName:Ctrl6
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl6
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl6
                           |vpiActual:
                           \_logic_net: (Ctrl6), line:10, parent:F2
                         |vpiRhs:
@@ -15871,7 +15892,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl6), line:30
                             |vpiName:Ctrl6
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl6
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl6
                             |vpiActual:
                             \_logic_net: (Ctrl6), line:10, parent:F2
                       |vpiStmt:
@@ -15881,7 +15902,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl7), line:31
                           |vpiName:Ctrl7
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl7
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl7
                           |vpiActual:
                           \_logic_net: (Ctrl7), line:10, parent:F2
                         |vpiRhs:
@@ -15890,7 +15911,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl7), line:31
                             |vpiName:Ctrl7
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl7
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl7
                             |vpiActual:
                             \_logic_net: (Ctrl7), line:10, parent:F2
             |vpiCaseItem:
@@ -15902,6 +15923,7 @@ design: (work@top)
                 |vpiActual:
                 \_parameter: (ST6), line:6
                   |vpiName:ST6
+                  |vpiFullName:work@FSM2.ST6
               |vpiStmt:
               \_begin: , line:71
                 |vpiFullName:work@FSM2.COMB
@@ -15909,12 +15931,12 @@ design: (work@top)
                 \_task_call: (SwitchCtrl), line:72
                   |vpiName:SwitchCtrl
                   |vpiTask:
-                  \_task: (SwitchCtrl), line:23
+                  \_task: (SwitchCtrl), line:23, parent:SwitchCtrl
                     |vpiName:SwitchCtrl
-                    |vpiFullName:work@FSM2.SwitchCtrl
+                    |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl
                     |vpiStmt:
                     \_begin: , line:24, parent:SwitchCtrl
-                      |vpiFullName:work@FSM2.SwitchCtrl
+                      |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl
                       |vpiStmt:
                       \_assignment: , line:25
                         |vpiOpType:82
@@ -15922,7 +15944,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl1), line:25
                           |vpiName:Ctrl1
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl1
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl1
                           |vpiActual:
                           \_logic_net: (Ctrl1), line:10, parent:F2
                         |vpiRhs:
@@ -15931,7 +15953,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl1), line:25
                             |vpiName:Ctrl1
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl1
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl1
                             |vpiActual:
                             \_logic_net: (Ctrl1), line:10, parent:F2
                       |vpiStmt:
@@ -15941,7 +15963,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl2), line:26
                           |vpiName:Ctrl2
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl2
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl2
                           |vpiActual:
                           \_logic_net: (Ctrl2), line:10, parent:F2
                         |vpiRhs:
@@ -15950,7 +15972,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl2), line:26
                             |vpiName:Ctrl2
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl2
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl2
                             |vpiActual:
                             \_logic_net: (Ctrl2), line:10, parent:F2
                       |vpiStmt:
@@ -15960,7 +15982,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl3), line:27
                           |vpiName:Ctrl3
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl3
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl3
                           |vpiActual:
                           \_logic_net: (Ctrl3), line:10, parent:F2
                         |vpiRhs:
@@ -15969,7 +15991,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl3), line:27
                             |vpiName:Ctrl3
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl3
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl3
                             |vpiActual:
                             \_logic_net: (Ctrl3), line:10, parent:F2
                       |vpiStmt:
@@ -15979,7 +16001,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl4), line:28
                           |vpiName:Ctrl4
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl4
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl4
                           |vpiActual:
                           \_logic_net: (Ctrl4), line:10, parent:F2
                         |vpiRhs:
@@ -15988,7 +16010,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl4), line:28
                             |vpiName:Ctrl4
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl4
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl4
                             |vpiActual:
                             \_logic_net: (Ctrl4), line:10, parent:F2
                       |vpiStmt:
@@ -15998,7 +16020,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl5), line:29
                           |vpiName:Ctrl5
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl5
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl5
                           |vpiActual:
                           \_logic_net: (Ctrl5), line:10, parent:F2
                         |vpiRhs:
@@ -16007,7 +16029,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl5), line:29
                             |vpiName:Ctrl5
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl5
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl5
                             |vpiActual:
                             \_logic_net: (Ctrl5), line:10, parent:F2
                       |vpiStmt:
@@ -16017,7 +16039,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl6), line:30
                           |vpiName:Ctrl6
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl6
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl6
                           |vpiActual:
                           \_logic_net: (Ctrl6), line:10, parent:F2
                         |vpiRhs:
@@ -16026,7 +16048,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl6), line:30
                             |vpiName:Ctrl6
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl6
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl6
                             |vpiActual:
                             \_logic_net: (Ctrl6), line:10, parent:F2
                       |vpiStmt:
@@ -16036,7 +16058,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl7), line:31
                           |vpiName:Ctrl7
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl7
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl7
                           |vpiActual:
                           \_logic_net: (Ctrl7), line:10, parent:F2
                         |vpiRhs:
@@ -16045,7 +16067,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl7), line:31
                             |vpiName:Ctrl7
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl7
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl7
                             |vpiActual:
                             \_logic_net: (Ctrl7), line:10, parent:F2
                 |vpiStmt:
@@ -16073,6 +16095,7 @@ design: (work@top)
                 |vpiActual:
                 \_parameter: (ST7), line:6
                   |vpiName:ST7
+                  |vpiFullName:work@FSM2.ST7
               |vpiStmt:
               \_begin: , line:76
                 |vpiFullName:work@FSM2.COMB
@@ -16080,12 +16103,12 @@ design: (work@top)
                 \_task_call: (SwitchCtrl), line:77
                   |vpiName:SwitchCtrl
                   |vpiTask:
-                  \_task: (SwitchCtrl), line:23
+                  \_task: (SwitchCtrl), line:23, parent:SwitchCtrl
                     |vpiName:SwitchCtrl
-                    |vpiFullName:work@FSM2.SwitchCtrl
+                    |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl
                     |vpiStmt:
                     \_begin: , line:24, parent:SwitchCtrl
-                      |vpiFullName:work@FSM2.SwitchCtrl
+                      |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl
                       |vpiStmt:
                       \_assignment: , line:25
                         |vpiOpType:82
@@ -16093,7 +16116,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl1), line:25
                           |vpiName:Ctrl1
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl1
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl1
                           |vpiActual:
                           \_logic_net: (Ctrl1), line:10, parent:F2
                         |vpiRhs:
@@ -16102,7 +16125,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl1), line:25
                             |vpiName:Ctrl1
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl1
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl1
                             |vpiActual:
                             \_logic_net: (Ctrl1), line:10, parent:F2
                       |vpiStmt:
@@ -16112,7 +16135,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl2), line:26
                           |vpiName:Ctrl2
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl2
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl2
                           |vpiActual:
                           \_logic_net: (Ctrl2), line:10, parent:F2
                         |vpiRhs:
@@ -16121,7 +16144,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl2), line:26
                             |vpiName:Ctrl2
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl2
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl2
                             |vpiActual:
                             \_logic_net: (Ctrl2), line:10, parent:F2
                       |vpiStmt:
@@ -16131,7 +16154,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl3), line:27
                           |vpiName:Ctrl3
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl3
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl3
                           |vpiActual:
                           \_logic_net: (Ctrl3), line:10, parent:F2
                         |vpiRhs:
@@ -16140,7 +16163,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl3), line:27
                             |vpiName:Ctrl3
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl3
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl3
                             |vpiActual:
                             \_logic_net: (Ctrl3), line:10, parent:F2
                       |vpiStmt:
@@ -16150,7 +16173,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl4), line:28
                           |vpiName:Ctrl4
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl4
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl4
                           |vpiActual:
                           \_logic_net: (Ctrl4), line:10, parent:F2
                         |vpiRhs:
@@ -16159,7 +16182,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl4), line:28
                             |vpiName:Ctrl4
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl4
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl4
                             |vpiActual:
                             \_logic_net: (Ctrl4), line:10, parent:F2
                       |vpiStmt:
@@ -16169,7 +16192,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl5), line:29
                           |vpiName:Ctrl5
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl5
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl5
                           |vpiActual:
                           \_logic_net: (Ctrl5), line:10, parent:F2
                         |vpiRhs:
@@ -16178,7 +16201,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl5), line:29
                             |vpiName:Ctrl5
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl5
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl5
                             |vpiActual:
                             \_logic_net: (Ctrl5), line:10, parent:F2
                       |vpiStmt:
@@ -16188,7 +16211,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl6), line:30
                           |vpiName:Ctrl6
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl6
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl6
                           |vpiActual:
                           \_logic_net: (Ctrl6), line:10, parent:F2
                         |vpiRhs:
@@ -16197,7 +16220,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl6), line:30
                             |vpiName:Ctrl6
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl6
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl6
                             |vpiActual:
                             \_logic_net: (Ctrl6), line:10, parent:F2
                       |vpiStmt:
@@ -16207,7 +16230,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl7), line:31
                           |vpiName:Ctrl7
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl7
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl7
                           |vpiActual:
                           \_logic_net: (Ctrl7), line:10, parent:F2
                         |vpiRhs:
@@ -16216,7 +16239,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl7), line:31
                             |vpiName:Ctrl7
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl7
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl7
                             |vpiActual:
                             \_logic_net: (Ctrl7), line:10, parent:F2
                 |vpiStmt:
@@ -16244,6 +16267,7 @@ design: (work@top)
                       |vpiActual:
                       \_parameter: (ST8), line:7
                         |vpiName:ST8
+                        |vpiFullName:work@FSM2.ST8
                   |vpiElseStmt:
                   \_if_else: , line:79
                     |vpiCondition:
@@ -16419,12 +16443,12 @@ design: (work@top)
                 \_task_call: (SwitchCtrl), line:89
                   |vpiName:SwitchCtrl
                   |vpiTask:
-                  \_task: (SwitchCtrl), line:23
+                  \_task: (SwitchCtrl), line:23, parent:SwitchCtrl
                     |vpiName:SwitchCtrl
-                    |vpiFullName:work@FSM2.SwitchCtrl
+                    |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl
                     |vpiStmt:
                     \_begin: , line:24, parent:SwitchCtrl
-                      |vpiFullName:work@FSM2.SwitchCtrl
+                      |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl
                       |vpiStmt:
                       \_assignment: , line:25
                         |vpiOpType:82
@@ -16432,7 +16456,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl1), line:25
                           |vpiName:Ctrl1
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl1
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl1
                           |vpiActual:
                           \_logic_net: (Ctrl1), line:10, parent:F2
                         |vpiRhs:
@@ -16441,7 +16465,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl1), line:25
                             |vpiName:Ctrl1
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl1
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl1
                             |vpiActual:
                             \_logic_net: (Ctrl1), line:10, parent:F2
                       |vpiStmt:
@@ -16451,7 +16475,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl2), line:26
                           |vpiName:Ctrl2
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl2
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl2
                           |vpiActual:
                           \_logic_net: (Ctrl2), line:10, parent:F2
                         |vpiRhs:
@@ -16460,7 +16484,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl2), line:26
                             |vpiName:Ctrl2
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl2
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl2
                             |vpiActual:
                             \_logic_net: (Ctrl2), line:10, parent:F2
                       |vpiStmt:
@@ -16470,7 +16494,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl3), line:27
                           |vpiName:Ctrl3
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl3
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl3
                           |vpiActual:
                           \_logic_net: (Ctrl3), line:10, parent:F2
                         |vpiRhs:
@@ -16479,7 +16503,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl3), line:27
                             |vpiName:Ctrl3
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl3
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl3
                             |vpiActual:
                             \_logic_net: (Ctrl3), line:10, parent:F2
                       |vpiStmt:
@@ -16489,7 +16513,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl4), line:28
                           |vpiName:Ctrl4
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl4
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl4
                           |vpiActual:
                           \_logic_net: (Ctrl4), line:10, parent:F2
                         |vpiRhs:
@@ -16498,7 +16522,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl4), line:28
                             |vpiName:Ctrl4
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl4
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl4
                             |vpiActual:
                             \_logic_net: (Ctrl4), line:10, parent:F2
                       |vpiStmt:
@@ -16508,7 +16532,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl5), line:29
                           |vpiName:Ctrl5
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl5
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl5
                           |vpiActual:
                           \_logic_net: (Ctrl5), line:10, parent:F2
                         |vpiRhs:
@@ -16517,7 +16541,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl5), line:29
                             |vpiName:Ctrl5
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl5
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl5
                             |vpiActual:
                             \_logic_net: (Ctrl5), line:10, parent:F2
                       |vpiStmt:
@@ -16527,7 +16551,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl6), line:30
                           |vpiName:Ctrl6
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl6
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl6
                           |vpiActual:
                           \_logic_net: (Ctrl6), line:10, parent:F2
                         |vpiRhs:
@@ -16536,7 +16560,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl6), line:30
                             |vpiName:Ctrl6
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl6
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl6
                             |vpiActual:
                             \_logic_net: (Ctrl6), line:10, parent:F2
                       |vpiStmt:
@@ -16546,7 +16570,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl7), line:31
                           |vpiName:Ctrl7
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl7
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl7
                           |vpiActual:
                           \_logic_net: (Ctrl7), line:10, parent:F2
                         |vpiRhs:
@@ -16555,7 +16579,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl7), line:31
                             |vpiName:Ctrl7
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl7
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl7
                             |vpiActual:
                             \_logic_net: (Ctrl7), line:10, parent:F2
                 |vpiStmt:
@@ -16760,6 +16784,7 @@ design: (work@top)
                 |vpiActual:
                 \_parameter: (ST9), line:7
                   |vpiName:ST9
+                  |vpiFullName:work@FSM2.ST9
               |vpiStmt:
               \_begin: , line:100
                 |vpiFullName:work@FSM2.COMB
@@ -16767,12 +16792,12 @@ design: (work@top)
                 \_task_call: (SwitchCtrl), line:101
                   |vpiName:SwitchCtrl
                   |vpiTask:
-                  \_task: (SwitchCtrl), line:23
+                  \_task: (SwitchCtrl), line:23, parent:SwitchCtrl
                     |vpiName:SwitchCtrl
-                    |vpiFullName:work@FSM2.SwitchCtrl
+                    |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl
                     |vpiStmt:
                     \_begin: , line:24, parent:SwitchCtrl
-                      |vpiFullName:work@FSM2.SwitchCtrl
+                      |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl
                       |vpiStmt:
                       \_assignment: , line:25
                         |vpiOpType:82
@@ -16780,7 +16805,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl1), line:25
                           |vpiName:Ctrl1
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl1
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl1
                           |vpiActual:
                           \_logic_net: (Ctrl1), line:10, parent:F2
                         |vpiRhs:
@@ -16789,7 +16814,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl1), line:25
                             |vpiName:Ctrl1
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl1
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl1
                             |vpiActual:
                             \_logic_net: (Ctrl1), line:10, parent:F2
                       |vpiStmt:
@@ -16799,7 +16824,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl2), line:26
                           |vpiName:Ctrl2
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl2
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl2
                           |vpiActual:
                           \_logic_net: (Ctrl2), line:10, parent:F2
                         |vpiRhs:
@@ -16808,7 +16833,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl2), line:26
                             |vpiName:Ctrl2
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl2
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl2
                             |vpiActual:
                             \_logic_net: (Ctrl2), line:10, parent:F2
                       |vpiStmt:
@@ -16818,7 +16843,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl3), line:27
                           |vpiName:Ctrl3
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl3
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl3
                           |vpiActual:
                           \_logic_net: (Ctrl3), line:10, parent:F2
                         |vpiRhs:
@@ -16827,7 +16852,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl3), line:27
                             |vpiName:Ctrl3
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl3
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl3
                             |vpiActual:
                             \_logic_net: (Ctrl3), line:10, parent:F2
                       |vpiStmt:
@@ -16837,7 +16862,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl4), line:28
                           |vpiName:Ctrl4
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl4
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl4
                           |vpiActual:
                           \_logic_net: (Ctrl4), line:10, parent:F2
                         |vpiRhs:
@@ -16846,7 +16871,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl4), line:28
                             |vpiName:Ctrl4
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl4
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl4
                             |vpiActual:
                             \_logic_net: (Ctrl4), line:10, parent:F2
                       |vpiStmt:
@@ -16856,7 +16881,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl5), line:29
                           |vpiName:Ctrl5
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl5
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl5
                           |vpiActual:
                           \_logic_net: (Ctrl5), line:10, parent:F2
                         |vpiRhs:
@@ -16865,7 +16890,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl5), line:29
                             |vpiName:Ctrl5
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl5
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl5
                             |vpiActual:
                             \_logic_net: (Ctrl5), line:10, parent:F2
                       |vpiStmt:
@@ -16875,7 +16900,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl6), line:30
                           |vpiName:Ctrl6
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl6
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl6
                           |vpiActual:
                           \_logic_net: (Ctrl6), line:10, parent:F2
                         |vpiRhs:
@@ -16884,7 +16909,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl6), line:30
                             |vpiName:Ctrl6
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl6
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl6
                             |vpiActual:
                             \_logic_net: (Ctrl6), line:10, parent:F2
                       |vpiStmt:
@@ -16894,7 +16919,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl7), line:31
                           |vpiName:Ctrl7
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl7
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl7
                           |vpiActual:
                           \_logic_net: (Ctrl7), line:10, parent:F2
                         |vpiRhs:
@@ -16903,7 +16928,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl7), line:31
                             |vpiName:Ctrl7
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl7
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl7
                             |vpiActual:
                             \_logic_net: (Ctrl7), line:10, parent:F2
                 |vpiStmt:
@@ -16961,12 +16986,12 @@ design: (work@top)
                 \_task_call: (SwitchCtrl), line:107
                   |vpiName:SwitchCtrl
                   |vpiTask:
-                  \_task: (SwitchCtrl), line:23
+                  \_task: (SwitchCtrl), line:23, parent:SwitchCtrl
                     |vpiName:SwitchCtrl
-                    |vpiFullName:work@FSM2.SwitchCtrl
+                    |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl
                     |vpiStmt:
                     \_begin: , line:24, parent:SwitchCtrl
-                      |vpiFullName:work@FSM2.SwitchCtrl
+                      |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl
                       |vpiStmt:
                       \_assignment: , line:25
                         |vpiOpType:82
@@ -16974,7 +16999,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl1), line:25
                           |vpiName:Ctrl1
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl1
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl1
                           |vpiActual:
                           \_logic_net: (Ctrl1), line:10, parent:F2
                         |vpiRhs:
@@ -16983,7 +17008,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl1), line:25
                             |vpiName:Ctrl1
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl1
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl1
                             |vpiActual:
                             \_logic_net: (Ctrl1), line:10, parent:F2
                       |vpiStmt:
@@ -16993,7 +17018,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl2), line:26
                           |vpiName:Ctrl2
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl2
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl2
                           |vpiActual:
                           \_logic_net: (Ctrl2), line:10, parent:F2
                         |vpiRhs:
@@ -17002,7 +17027,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl2), line:26
                             |vpiName:Ctrl2
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl2
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl2
                             |vpiActual:
                             \_logic_net: (Ctrl2), line:10, parent:F2
                       |vpiStmt:
@@ -17012,7 +17037,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl3), line:27
                           |vpiName:Ctrl3
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl3
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl3
                           |vpiActual:
                           \_logic_net: (Ctrl3), line:10, parent:F2
                         |vpiRhs:
@@ -17021,7 +17046,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl3), line:27
                             |vpiName:Ctrl3
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl3
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl3
                             |vpiActual:
                             \_logic_net: (Ctrl3), line:10, parent:F2
                       |vpiStmt:
@@ -17031,7 +17056,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl4), line:28
                           |vpiName:Ctrl4
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl4
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl4
                           |vpiActual:
                           \_logic_net: (Ctrl4), line:10, parent:F2
                         |vpiRhs:
@@ -17040,7 +17065,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl4), line:28
                             |vpiName:Ctrl4
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl4
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl4
                             |vpiActual:
                             \_logic_net: (Ctrl4), line:10, parent:F2
                       |vpiStmt:
@@ -17050,7 +17075,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl5), line:29
                           |vpiName:Ctrl5
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl5
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl5
                           |vpiActual:
                           \_logic_net: (Ctrl5), line:10, parent:F2
                         |vpiRhs:
@@ -17059,7 +17084,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl5), line:29
                             |vpiName:Ctrl5
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl5
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl5
                             |vpiActual:
                             \_logic_net: (Ctrl5), line:10, parent:F2
                       |vpiStmt:
@@ -17069,7 +17094,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl6), line:30
                           |vpiName:Ctrl6
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl6
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl6
                           |vpiActual:
                           \_logic_net: (Ctrl6), line:10, parent:F2
                         |vpiRhs:
@@ -17078,7 +17103,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl6), line:30
                             |vpiName:Ctrl6
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl6
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl6
                             |vpiActual:
                             \_logic_net: (Ctrl6), line:10, parent:F2
                       |vpiStmt:
@@ -17088,7 +17113,7 @@ design: (work@top)
                         |vpiLhs:
                         \_ref_obj: (Ctrl7), line:31
                           |vpiName:Ctrl7
-                          |vpiFullName:work@FSM2.SwitchCtrl.Ctrl7
+                          |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl7
                           |vpiActual:
                           \_logic_net: (Ctrl7), line:10, parent:F2
                         |vpiRhs:
@@ -17097,7 +17122,7 @@ design: (work@top)
                           |vpiOperand:
                           \_ref_obj: (Ctrl7), line:31
                             |vpiName:Ctrl7
-                            |vpiFullName:work@FSM2.SwitchCtrl.Ctrl7
+                            |vpiFullName:work@FSM2.COMB.SwitchCtrl.SwitchCtrl.Ctrl7
                             |vpiActual:
                             \_logic_net: (Ctrl7), line:10, parent:F2
                 |vpiStmt:
@@ -17154,6 +17179,7 @@ design: (work@top)
             |vpiOperand:
             \_ref_obj: (clock), line:116
               |vpiName:clock
+              |vpiFullName:work@FSM2.clock
               |vpiActual:
               \_logic_net: (clock), line:1, parent:F2
                 |vpiName:clock
@@ -17164,6 +17190,7 @@ design: (work@top)
             |vpiOperand:
             \_ref_obj: (reset), line:116
               |vpiName:reset
+              |vpiFullName:work@FSM2.reset
               |vpiActual:
               \_logic_net: (reset), line:1, parent:F2
                 |vpiName:reset
@@ -17817,6 +17844,7 @@ design: (work@top)
             |vpiOperand:
             \_ref_obj: (clock), line:22
               |vpiName:clock
+              |vpiFullName:work@FSM3.clock
               |vpiActual:
               \_logic_net: (clock), line:1, parent:F3
                 |vpiName:clock
@@ -17827,6 +17855,7 @@ design: (work@top)
             |vpiOperand:
             \_ref_obj: (keys), line:22
               |vpiName:keys
+              |vpiFullName:work@FSM3.keys
               |vpiActual:
               \_logic_net: (keys), line:1, parent:F3
                 |vpiName:keys
@@ -17880,6 +17909,7 @@ design: (work@top)
                 |vpiActual:
                 \_parameter: (Stop), line:8
                   |vpiName:Stop
+                  |vpiFullName:work@FSM3.Stop
             |vpiElseStmt:
             \_if_else: , line:25
               |vpiCondition:
@@ -17924,6 +17954,7 @@ design: (work@top)
                       |vpiActual:
                       \_parameter: (Slow), line:11
                         |vpiName:Slow
+                        |vpiFullName:work@FSM3.Slow
                 |vpiCaseItem:
                 \_case_item: , line:28
                   |vpiExpr:
@@ -17933,6 +17964,7 @@ design: (work@top)
                     |vpiActual:
                     \_parameter: (Move), line:9
                       |vpiName:Move
+                      |vpiFullName:work@FSM3.Move
                   |vpiStmt:
                   \_assignment: , line:28
                     |vpiOpType:82
@@ -17950,6 +17982,7 @@ design: (work@top)
                       |vpiActual:
                       \_parameter: (Faster), line:14
                         |vpiName:Faster
+                        |vpiFullName:work@FSM3.Faster
                 |vpiCaseItem:
                 \_case_item: , line:29
                   |vpiExpr:
@@ -17959,6 +17992,7 @@ design: (work@top)
                     |vpiActual:
                     \_parameter: (Turn), line:10
                       |vpiName:Turn
+                      |vpiFullName:work@FSM3.Turn
                   |vpiStmt:
                   \_assignment: , line:29
                     |vpiOpType:82
@@ -18000,6 +18034,7 @@ design: (work@top)
                       |vpiActual:
                       \_parameter: (Medium), line:12
                         |vpiName:Medium
+                        |vpiFullName:work@FSM3.Medium
                 |vpiCaseItem:
                 \_case_item: , line:31
                   |vpiExpr:
@@ -18025,6 +18060,7 @@ design: (work@top)
                       |vpiActual:
                       \_parameter: (Fast), line:13
                         |vpiName:Fast
+                        |vpiFullName:work@FSM3.Fast
                 |vpiCaseItem:
                 \_case_item: , line:32
                   |vpiExpr:

--- a/tests/FSMFunction/FSMFunction.log
+++ b/tests/FSMFunction/FSMFunction.log
@@ -1734,6 +1734,7 @@ design: (work@fsm_using_function)
                 |vpiActual:
                 \_parameter: (IDLE), line:24
                   |vpiName:IDLE
+                  |vpiFullName:work@fsm_using_function.IDLE
           |vpiElseStmt:
           \_begin: , line:61
             |vpiFullName:work@fsm_using_function.FSM_SEQ
@@ -1920,6 +1921,7 @@ design: (work@fsm_using_function)
                   |vpiActual:
                   \_parameter: (GNT0), line:24
                     |vpiName:GNT0
+                    |vpiFullName:work@fsm_using_function.GNT0
                 |vpiStmt:
                 \_begin: , line:78
                   |vpiFullName:work@fsm_using_function.OUTPUT_LOGIC
@@ -1968,6 +1970,7 @@ design: (work@fsm_using_function)
                   |vpiActual:
                   \_parameter: (GNT1), line:24
                     |vpiName:GNT1
+                    |vpiFullName:work@fsm_using_function.GNT1
                 |vpiStmt:
                 \_begin: , line:82
                   |vpiFullName:work@fsm_using_function.OUTPUT_LOGIC
@@ -2108,18 +2111,21 @@ design: (work@fsm_using_function)
     \_func_call: (fsm_function), line:29
       |vpiName:fsm_function
       |vpiArgument:
-      \_ref_obj: (state), line:29
+      \_ref_obj: (state), line:29, parent:fsm_function
         |vpiName:state
+        |vpiFullName:work@fsm_using_function.fsm_function.state
         |vpiActual:
         \_logic_net: (state), line:26, parent:work@fsm_using_function
       |vpiArgument:
-      \_ref_obj: (req_0), line:29
+      \_ref_obj: (req_0), line:29, parent:fsm_function
         |vpiName:req_0
+        |vpiFullName:work@fsm_using_function.fsm_function.req_0
         |vpiActual:
         \_logic_net: (req_0), line:19, parent:work@fsm_using_function
       |vpiArgument:
-      \_ref_obj: (req_1), line:29
+      \_ref_obj: (req_1), line:29, parent:fsm_function
         |vpiName:req_1
+        |vpiFullName:work@fsm_using_function.fsm_function.req_1
         |vpiActual:
         \_logic_net: (req_1), line:19, parent:work@fsm_using_function
     |vpiLhs:
@@ -2133,7 +2139,8 @@ design: (work@fsm_using_function)
     |vpiName:fsm_function
     |vpiFullName:work@fsm_using_function.fsm_function
     |vpiReturn:
-    \_logic_var: , line:31
+    \_logic_var: , line:31, parent:fsm_function
+      |vpiFullName:work@fsm_using_function.fsm_function
       |vpiRange:
       \_range: , line:31
         |vpiLeftRange:
@@ -2142,9 +2149,11 @@ design: (work@fsm_using_function)
           |vpiOperand:
           \_ref_obj: (SIZE), line:31
             |vpiName:SIZE
+            |vpiFullName:work@fsm_using_function.fsm_function.SIZE
             |vpiActual:
             \_parameter: (SIZE), line:23
               |vpiName:SIZE
+              |vpiFullName:work@fsm_using_function.SIZE
           |vpiOperand:
           \_constant: , line:31
             |vpiConstType:7
@@ -2162,7 +2171,7 @@ design: (work@fsm_using_function)
       |vpiName:state
       |vpiDirection:1
       |vpiRange:
-      \_range: , line:32
+      \_range: , line:32, parent:state
         |vpiLeftRange:
         \_constant: , line:32
           |vpiDecompile:2

--- a/tests/FSMSingleAlways/FSMSingleAlways.log
+++ b/tests/FSMSingleAlways/FSMSingleAlways.log
@@ -1227,6 +1227,7 @@ design: (work@fsm_using_single_always)
                 |vpiActual:
                 \_parameter: (IDLE), line:25
                   |vpiName:IDLE
+                  |vpiFullName:work@fsm_using_single_always.IDLE
             |vpiStmt:
             \_assignment: , line:34
               |vpiOpType:82
@@ -1322,6 +1323,7 @@ design: (work@fsm_using_single_always)
                       |vpiActual:
                       \_parameter: (GNT0), line:25
                         |vpiName:GNT0
+                        |vpiFullName:work@fsm_using_single_always.GNT0
                   |vpiStmt:
                   \_assignment: , line:40
                     |vpiOpType:82
@@ -1394,6 +1396,7 @@ design: (work@fsm_using_single_always)
                         |vpiActual:
                         \_parameter: (GNT1), line:25
                           |vpiName:GNT1
+                          |vpiFullName:work@fsm_using_single_always.GNT1
                   |vpiElseStmt:
                   \_begin: , line:44
                     |vpiFullName:work@fsm_using_single_always.FSM
@@ -1691,6 +1694,7 @@ design: (work@fsm_using_single_always)
     |vpiLhs:
     \_parameter: (SIZE), line:24
       |vpiName:SIZE
+      |vpiFullName:work@fsm_using_single_always.SIZE
   |vpiParamAssign:
   \_param_assign: , line:25
     |vpiRhs:

--- a/tests/PackageFuncCall/PackageFuncCall.log
+++ b/tests/PackageFuncCall/PackageFuncCall.log
@@ -1321,8 +1321,8 @@ design: (work@top)
                 |vpiSize:32
                 |INT:1
           |vpiOperand:
-          \_var_select: , line:33, parent:PRINCE_ROUND_CONST
-            |vpiFullName:prim_cipher_pkg::PRINCE_ROUND_CONST
+          \_var_select: , line:33
+            |vpiFullName:work@top.p_post_round_xor
             |vpiIndex:
             \_constant: , line:34
               |vpiConstType:7
@@ -1340,7 +1340,7 @@ design: (work@top)
                 |vpiOperand:
                 \_ref_obj: (DataWidth), line:35
                   |vpiName:DataWidth
-                  |vpiFullName:work@top.p_post_round_xor.DataWidth
+                  |vpiFullName:prim_cipher_pkg::PRINCE_ROUND_CONST::DataWidth
                 |vpiOperand:
                 \_constant: , line:35
                   |vpiConstType:7
@@ -1383,12 +1383,13 @@ design: (work@top)
     \_func_call: (prim_cipher_pkg::sbox4_64bit), line:28
       |vpiName:prim_cipher_pkg::sbox4_64bit
       |vpiFunction:
-      \_function: (sbox4_64bit), line:8
+      \_function: (sbox4_64bit), line:8, parent:prim_cipher_pkg::sbox4_64bit
         |vpiAutomatic:1
         |vpiName:sbox4_64bit
-        |vpiFullName:prim_cipher_pkg::sbox4_64bit
+        |vpiFullName:work@top.prim_cipher_pkg::sbox4_64bit.sbox4_64bit
         |vpiReturn:
-        \_logic_var: , line:8
+        \_logic_var: , line:8, parent:sbox4_64bit
+          |vpiFullName:work@top.prim_cipher_pkg::sbox4_64bit.sbox4_64bit
           |vpiRange:
           \_range: , line:8
             |vpiLeftRange:
@@ -1404,12 +1405,12 @@ design: (work@top)
               |vpiSize:32
               |INT:0
         |vpiIODecl:
-        \_io_decl: (state_in)
+        \_io_decl: (state_in), parent:sbox4_64bit
           |vpiName:state_in
           |vpiDirection:5
           |vpiExpr:
           \_logic_var: , line:8, parent:state_in
-            |vpiFullName:state_in
+            |vpiFullName:work@top.prim_cipher_pkg::sbox4_64bit.sbox4_64bit.state_in
             |vpiRange:
             \_range: , line:8
               |vpiLeftRange:
@@ -1425,12 +1426,12 @@ design: (work@top)
                 |vpiSize:32
                 |INT:0
         |vpiIODecl:
-        \_io_decl: (sbox4)
+        \_io_decl: (sbox4), parent:sbox4_64bit
           |vpiName:sbox4
           |vpiDirection:5
           |vpiExpr:
           \_logic_var: , line:8, parent:sbox4
-            |vpiFullName:sbox4
+            |vpiFullName:work@top.prim_cipher_pkg::sbox4_64bit.sbox4_64bit.sbox4
             |vpiRange:
             \_range: , line:8
               |vpiLeftRange:
@@ -1447,15 +1448,15 @@ design: (work@top)
                 |INT:0
         |vpiStmt:
         \_begin: , parent:sbox4_64bit
-          |vpiFullName:prim_cipher_pkg::sbox4_64bit
+          |vpiFullName:work@top.prim_cipher_pkg::sbox4_64bit.sbox4_64bit
           |vpiStmt:
           \_assign_stmt: 
             |vpiLhs:
             \_logic_var: (state_out), line:9
               |vpiName:state_out
-              |vpiFullName:prim_cipher_pkg::sbox4_64bit::state_out
+              |vpiFullName:work@top.prim_cipher_pkg::sbox4_64bit.sbox4_64bit.state_out
               |vpiRange:
-              \_range: , line:9
+              \_range: , line:9, parent:state_out
                 |vpiLeftRange:
                 \_constant: , line:9
                   |vpiConstType:7
@@ -1470,14 +1471,14 @@ design: (work@top)
                   |INT:0
           |vpiStmt:
           \_for_stmt: , line:11
-            |vpiFullName:prim_cipher_pkg::sbox4_64bit
+            |vpiFullName:work@top.prim_cipher_pkg::sbox4_64bit.sbox4_64bit
             |vpiCondition:
             \_operation: , line:11
               |vpiOpType:20
               |vpiOperand:
               \_ref_obj: (k), line:11
                 |vpiName:k
-                |vpiFullName:prim_cipher_pkg::sbox4_64bit::k
+                |vpiFullName:work@top.prim_cipher_pkg::sbox4_64bit.sbox4_64bit.k
               |vpiOperand:
               \_operation: , line:11
                 |vpiOpType:12
@@ -1504,22 +1505,23 @@ design: (work@top)
               |vpiLhs:
               \_int_var: (k), line:11
                 |vpiName:k
-                |vpiFullName:prim_cipher_pkg::sbox4_64bit::k
+                |vpiFullName:work@top.prim_cipher_pkg::sbox4_64bit.sbox4_64bit.k
             |vpiForIncStmt:
             \_operation: , line:11
               |vpiOpType:62
               |vpiOperand:
               \_ref_obj: (k), line:11
                 |vpiName:k
+                |vpiFullName:work@top.prim_cipher_pkg::sbox4_64bit.sbox4_64bit.k
             |vpiStmt:
             \_begin: , line:11
-              |vpiFullName:prim_cipher_pkg::sbox4_64bit
+              |vpiFullName:work@top.prim_cipher_pkg::sbox4_64bit.sbox4_64bit
               |vpiStmt:
               \_assignment: , line:12
                 |vpiOpType:82
                 |vpiBlocking:1
                 |vpiLhs:
-                \_indexed_part_select: , line:12, parent:state_out
+                \_indexed_part_select: , line:12
                   |vpiConstantSelect:1
                   |vpiIndexedPartSelectType:1
                   |vpiBaseExpr:
@@ -1528,6 +1530,7 @@ design: (work@top)
                     |vpiOperand:
                     \_ref_obj: (k), line:12
                       |vpiName:k
+                      |vpiFullName:work@top.prim_cipher_pkg::sbox4_64bit.sbox4_64bit.k
                     |vpiOperand:
                     \_constant: , line:12
                       |vpiConstType:7
@@ -1543,7 +1546,7 @@ design: (work@top)
                 |vpiRhs:
                 \_bit_select: (sbox4), line:12
                   |vpiName:sbox4
-                  |vpiFullName:prim_cipher_pkg::sbox4_64bit::sbox4
+                  |vpiFullName:work@top.prim_cipher_pkg::sbox4_64bit.sbox4_64bit.sbox4
                   |vpiIndex:
                   \_indexed_part_select: , line:12, parent:sbox4
                     |vpiConstantSelect:1
@@ -1554,6 +1557,7 @@ design: (work@top)
                       |vpiOperand:
                       \_ref_obj: (k), line:12
                         |vpiName:k
+                        |vpiFullName:work@top.prim_cipher_pkg::sbox4_64bit.sbox4_64bit.sbox4.k
                       |vpiOperand:
                       \_constant: , line:12
                         |vpiConstType:7
@@ -1571,16 +1575,17 @@ design: (work@top)
             |vpiCondition:
             \_ref_obj: (state_out), line:14
               |vpiName:state_out
-              |vpiFullName:prim_cipher_pkg::sbox4_64bit::state_out
+              |vpiFullName:work@top.prim_cipher_pkg::sbox4_64bit.sbox4_64bit.state_out
       |vpiArgument:
-      \_ref_obj: (data_state_xor), line:28
+      \_ref_obj: (data_state_xor), line:28, parent:prim_cipher_pkg::sbox4_64bit
         |vpiName:data_state_xor
+        |vpiFullName:work@top.prim_cipher_pkg::sbox4_64bit.data_state_xor
       |vpiArgument:
-      \_parameter: (PRESENT_SBOX4), line:29
+      \_parameter: (PRESENT_SBOX4), line:29, parent:prim_cipher_pkg::sbox4_64bit
         |vpiName:PRESENT_SBOX4
-        |vpiFullName:prim_cipher_pkg::PRESENT_SBOX4
+        |vpiFullName:work@top.prim_cipher_pkg::sbox4_64bit.PRESENT_SBOX4
         |vpiTypespec:
-        \_logic_typespec: , line:3
+        \_logic_typespec: , line:3, parent:PRESENT_SBOX4
           |vpiRange:
           \_range: , line:3
             |vpiLeftRange:

--- a/tests/PreprocUhdmCov/PreprocUhdmCov.log
+++ b/tests/PreprocUhdmCov/PreprocUhdmCov.log
@@ -532,7 +532,8 @@ design: (work@top)
     |vpiName:prince_shiftrows_32bit
     |vpiFullName:work@top.prince_shiftrows_32bit
     |vpiReturn:
-    \_logic_var: , line:45
+    \_logic_var: , line:45, parent:prince_shiftrows_32bit
+      |vpiFullName:work@top.prince_shiftrows_32bit
       |vpiRange:
       \_range: , line:45
         |vpiLeftRange:
@@ -548,12 +549,12 @@ design: (work@top)
           |vpiSize:32
           |INT:0
     |vpiIODecl:
-    \_io_decl: (state_in)
+    \_io_decl: (state_in), parent:prince_shiftrows_32bit
       |vpiName:state_in
       |vpiDirection:5
       |vpiExpr:
       \_logic_var: , line:45, parent:state_in
-        |vpiFullName:state_in
+        |vpiFullName:work@top.prince_shiftrows_32bit.state_in
         |vpiRange:
         \_range: , line:45
           |vpiLeftRange:
@@ -569,12 +570,12 @@ design: (work@top)
             |vpiSize:32
             |INT:0
     |vpiIODecl:
-    \_io_decl: (shifts)
+    \_io_decl: (shifts), parent:prince_shiftrows_32bit
       |vpiName:shifts
       |vpiDirection:5
       |vpiExpr:
       \_logic_var: , line:46, parent:shifts
-        |vpiFullName:shifts
+        |vpiFullName:work@top.prince_shiftrows_32bit.shifts
         |vpiRange:
         \_range: , line:46
           |vpiLeftRange:
@@ -601,16 +602,16 @@ design: (work@top)
     |vpiPacked:1
     |vpiName:spi_device_reg2hw_intr_enable_reg_t
     |vpiTypespecMember:
-    \_typespec_member: (txunderflow), line:42
+    \_typespec_member: (txunderflow), line:42, parent:spi_device_reg2hw_intr_enable_reg_t
       |vpiName:txunderflow
       |vpiTypespec:
-      \_struct_typespec: , line:40
+      \_struct_typespec: , line:40, parent:txunderflow
         |vpiPacked:1
         |vpiTypespecMember:
         \_typespec_member: (q), line:41
           |vpiName:q
           |vpiTypespec:
-          \_logic_typespec: , line:41
+          \_logic_typespec: , line:41, parent:q
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/ProcForLoop/ProcForLoop.log
+++ b/tests/ProcForLoop/ProcForLoop.log
@@ -385,10 +385,11 @@ design: (work@top)
           \_func_call: (f2), line:4
             |vpiName:f2
             |vpiArgument:
-            \_ref_obj: (i), line:4
+            \_ref_obj: (i), line:4, parent:f2
               |vpiName:i
+              |vpiFullName:work@top.foo.f2.i
             |vpiArgument:
-            \_constant: , line:4
+            \_constant: , line:4, parent:f2
               |vpiConstType:7
               |vpiDecompile:0
               |vpiSize:32
@@ -427,6 +428,7 @@ design: (work@top)
           |vpiOperand:
           \_ref_obj: (j), line:6
             |vpiName:j
+            |vpiFullName:work@top.foo.j
         |vpiStmt:
         \_begin: , line:6
           |vpiFullName:work@top.foo
@@ -434,10 +436,11 @@ design: (work@top)
           \_func_call: (f2), line:7
             |vpiName:f2
             |vpiArgument:
-            \_ref_obj: (j), line:7
+            \_ref_obj: (j), line:7, parent:f2
               |vpiName:j
+              |vpiFullName:work@top.foo.f2.j
             |vpiArgument:
-            \_constant: , line:7
+            \_constant: , line:7, parent:f2
               |vpiConstType:7
               |vpiDecompile:0
               |vpiSize:32

--- a/tests/Rom/Rom.log
+++ b/tests/Rom/Rom.log
@@ -456,6 +456,7 @@ design: (work@top)
     |vpiLhs:
     \_parameter: (RhoOffset), line:13
       |vpiName:RhoOffset
+      |vpiFullName:work@top.RhoOffset
       |vpiLocalParam:1
       |vpiSize:25
       |vpiRange:
@@ -487,7 +488,7 @@ design: (work@top)
           |vpiSize:32
           |INT:4
       |vpiTypespec:
-      \_int_typespec: , line:13
+      \_int_typespec: , line:13, parent:RhoOffset
   |vpiParameter:
   \_parameter: (RhoOffset), line:13
 ===================

--- a/tests/StructVar/StructVar.log
+++ b/tests/StructVar/StructVar.log
@@ -320,8 +320,9 @@ design: (work@test)
     \_sys_func_call: ($vpi_decompiler), line:75
       |vpiName:$vpi_decompiler
       |vpiArgument:
-      \_ref_obj: (test), line:75
+      \_ref_obj: (test), line:75, parent:$vpi_decompiler
         |vpiName:test
+        |vpiFullName:work@test.$vpi_decompiler.test
   |vpiModule:
   \_module: work@dut1 (u1), file:dut.sv, line:70, parent:work@test
     |vpiDefName:work@dut1
@@ -620,12 +621,12 @@ design: (work@test)
     \_struct_typespec: (intf), line:13
       |vpiName:intf
       |vpiTypespecMember:
-      \_typespec_member: (addr), line:14
+      \_typespec_member: (addr), line:14, parent:intf
         |vpiName:addr
         |vpiTypespec:
-        \_logic_typespec: , line:14
+        \_logic_typespec: , line:14, parent:addr
           |vpiRange:
-          \_range: , line:14, parent:intf
+          \_range: , line:14
             |vpiLeftRange:
             \_constant: , line:14
               |vpiConstType:7
@@ -639,12 +640,12 @@ design: (work@test)
               |vpiSize:32
               |INT:0
       |vpiTypespecMember:
-      \_typespec_member: (data), line:15
+      \_typespec_member: (data), line:15, parent:intf
         |vpiName:data
         |vpiTypespec:
-        \_logic_typespec: , line:15
+        \_logic_typespec: , line:15, parent:data
           |vpiRange:
-          \_range: , line:15, parent:intf
+          \_range: , line:15
             |vpiLeftRange:
             \_constant: , line:15
               |vpiConstType:7
@@ -658,21 +659,21 @@ design: (work@test)
               |vpiSize:32
               |INT:0
       |vpiTypespecMember:
-      \_typespec_member: (wr), line:16
+      \_typespec_member: (wr), line:16, parent:intf
         |vpiName:wr
         |vpiTypespec:
-        \_logic_typespec: , line:16
+        \_logic_typespec: , line:16, parent:wr
     |vpiTypedef:
     \_struct_typespec: (mem_s), line:3
       |vpiPacked:1
       |vpiName:mem_s
       |vpiTypespecMember:
-      \_typespec_member: (addr), line:4
+      \_typespec_member: (addr), line:4, parent:mem_s
         |vpiName:addr
         |vpiTypespec:
-        \_bit_typespec: , line:4
+        \_bit_typespec: , line:4, parent:addr
           |vpiRange:
-          \_range: , line:4, parent:mem_s
+          \_range: , line:4
             |vpiLeftRange:
             \_constant: , line:4
               |vpiConstType:7
@@ -686,12 +687,12 @@ design: (work@test)
               |vpiSize:32
               |INT:0
       |vpiTypespecMember:
-      \_typespec_member: (data), line:5
+      \_typespec_member: (data), line:5, parent:mem_s
         |vpiName:data
         |vpiTypespec:
-        \_bit_typespec: , line:5
+        \_bit_typespec: , line:5, parent:data
           |vpiRange:
-          \_range: , line:5, parent:mem_s
+          \_range: , line:5
             |vpiLeftRange:
             \_constant: , line:5
               |vpiConstType:7
@@ -705,10 +706,10 @@ design: (work@test)
               |vpiSize:32
               |INT:0
       |vpiTypespecMember:
-      \_typespec_member: (wr), line:6
+      \_typespec_member: (wr), line:6, parent:mem_s
         |vpiName:wr
         |vpiTypespec:
-        \_bit_typespec: , line:6
+        \_bit_typespec: , line:6, parent:wr
   |vpiModule:
   \_module: work@dut2 (u2), file:dut.sv, line:71, parent:work@test
     |vpiDefName:work@dut2
@@ -835,12 +836,12 @@ design: (work@test)
       |vpiPacked:1
       |vpiName:mem_s
       |vpiTypespecMember:
-      \_typespec_member: (addr), line:37
+      \_typespec_member: (addr), line:37, parent:mem_s
         |vpiName:addr
         |vpiTypespec:
-        \_bit_typespec: , line:37
+        \_bit_typespec: , line:37, parent:addr
           |vpiRange:
-          \_range: , line:37, parent:mem_s
+          \_range: , line:37
             |vpiLeftRange:
             \_constant: , line:37
               |vpiConstType:7
@@ -854,12 +855,12 @@ design: (work@test)
               |vpiSize:32
               |INT:0
       |vpiTypespecMember:
-      \_typespec_member: (data), line:38
+      \_typespec_member: (data), line:38, parent:mem_s
         |vpiName:data
         |vpiTypespec:
-        \_bit_typespec: , line:38
+        \_bit_typespec: , line:38, parent:data
           |vpiRange:
-          \_range: , line:38, parent:mem_s
+          \_range: , line:38
             |vpiLeftRange:
             \_constant: , line:38
               |vpiConstType:7
@@ -1053,7 +1054,7 @@ design: (work@test)
     \_enum_typespec: (pmp_cfg_mode_e), line:51
       |vpiName:pmp_cfg_mode_e
       |vpiBaseTypespec:
-      \_logic_typespec: , line:49
+      \_logic_typespec: , line:49, parent:pmp_cfg_mode_e
         |vpiRange:
         \_range: , line:49
           |vpiLeftRange:
@@ -1069,7 +1070,7 @@ design: (work@test)
             |vpiSize:32
             |INT:0
       |vpiEnumConst:
-      \_enum_const: (PMP_MODE_TOR), line:50
+      \_enum_const: (PMP_MODE_TOR), line:50, parent:pmp_cfg_mode_e
         |vpiName:PMP_MODE_TOR
         |INT:1
     |vpiTypedef:
@@ -1077,18 +1078,18 @@ design: (work@test)
       |vpiPacked:1
       |vpiName:pmp_cfg_t
       |vpiTypespecMember:
-      \_typespec_member: (lock), line:53
+      \_typespec_member: (lock), line:53, parent:pmp_cfg_t
         |vpiName:lock
         |vpiTypespec:
-        \_logic_typespec: , line:53
+        \_logic_typespec: , line:53, parent:lock
       |vpiTypespecMember:
-      \_typespec_member: (mode), line:54
+      \_typespec_member: (mode), line:54, parent:pmp_cfg_t
         |vpiName:mode
         |vpiTypespec:
-        \_enum_typespec: (pmp_cfg_mode_e), line:51
+        \_enum_typespec: (pmp_cfg_mode_e), line:51, parent:mode
           |vpiName:pmp_cfg_mode_e
           |vpiBaseTypespec:
-          \_logic_typespec: , line:49
+          \_logic_typespec: , line:49, parent:pmp_cfg_mode_e
             |vpiRange:
             \_range: , line:49
               |vpiLeftRange:
@@ -1104,7 +1105,7 @@ design: (work@test)
                 |vpiSize:32
                 |INT:0
           |vpiEnumConst:
-          \_enum_const: (PMP_MODE_TOR), line:50
+          \_enum_const: (PMP_MODE_TOR), line:50, parent:pmp_cfg_mode_e
             |vpiName:PMP_MODE_TOR
             |INT:1
 ===================

--- a/tests/TaggedPattern/TaggedPattern.log
+++ b/tests/TaggedPattern/TaggedPattern.log
@@ -267,7 +267,7 @@ design: (work@top)
         \_tagged_pattern: (v2), line:9
           |vpiName:v2
           |vpiPattern:
-          \_constant: , line:9
+          \_constant: , line:9, parent:v2
             |vpiConstType:7
             |vpiDecompile:10
             |vpiSize:32
@@ -286,7 +286,7 @@ design: (work@top)
         \_tagged_pattern: (v1), line:10
           |vpiName:v1
           |vpiPattern:
-          \_constant: , line:10
+          \_constant: , line:10, parent:v1
             |vpiConstType:7
             |vpiDecompile:85
             |vpiSize:32
@@ -295,14 +295,15 @@ design: (work@top)
       \_sys_func_call: ($display), line:11
         |vpiName:$display
         |vpiArgument:
-        \_constant: , line:11
+        \_constant: , line:11, parent:$display
           |vpiConstType:6
           |vpiDecompile:":assert: ('%b' == 'v1:1010101'"
           |vpiSize:32
           |STRING:":assert: ('%b' == 'v1:1010101'"
         |vpiArgument:
-        \_ref_obj: (un), line:11
+        \_ref_obj: (un), line:11, parent:$display
           |vpiName:un
+          |vpiFullName:work@top.$display.un
           |vpiActual:
           \_logic_net: (un), line:6, parent:work@top
   |vpiNet:

--- a/tests/Ternary/Ternary.log
+++ b/tests/Ternary/Ternary.log
@@ -1609,6 +1609,7 @@ design: (work@test)
           |vpiOperand:
           \_ref_obj: (RAMRST), line:37
             |vpiName:RAMRST
+            |vpiFullName:work@test.RAMRST
             |vpiActual:
             \_logic_net: (RAMRST), line:12, parent:work@test
               |vpiName:RAMRST
@@ -1620,6 +1621,7 @@ design: (work@test)
           |vpiOperand:
           \_ref_obj: (CLK), line:37
             |vpiName:CLK
+            |vpiFullName:work@test.CLK
             |vpiActual:
             \_logic_net: (CLK), line:6, parent:work@test
               |vpiName:CLK
@@ -1680,6 +1682,7 @@ design: (work@test)
                 |vpiActual:
                 \_parameter: (USER_DELAY_INIT), line:24
                   |vpiName:USER_DELAY_INIT
+                  |vpiFullName:work@test.USER_DELAY_INIT
                   |vpiLocalParam:1
             |vpiStmt:
             \_assignment: , line:40
@@ -1956,6 +1959,7 @@ design: (work@test)
                           |vpiActual:
                           \_parameter: (USER_CHECK_STATE), line:30
                             |vpiName:USER_CHECK_STATE
+                            |vpiFullName:work@test.USER_CHECK_STATE
                             |vpiLocalParam:1
               |vpiCaseItem:
               \_case_item: , line:57
@@ -2093,6 +2097,7 @@ design: (work@test)
                               |vpiActual:
                               \_parameter: (USER_CHECK_SPACE), line:31
                                 |vpiName:USER_CHECK_SPACE
+                                |vpiFullName:work@test.USER_CHECK_SPACE
                                 |vpiLocalParam:1
                         |vpiElseStmt:
                         \_begin: , line:65
@@ -2131,6 +2136,7 @@ design: (work@test)
                                 |vpiActual:
                                 \_parameter: (USER_READ_LENGTH), line:33
                                   |vpiName:USER_READ_LENGTH
+                                  |vpiFullName:work@test.USER_READ_LENGTH
                                   |vpiLocalParam:1
                               |vpiOperand:
                               \_ref_obj: (USER_READ_DATA), line:67
@@ -2139,6 +2145,7 @@ design: (work@test)
                                 |vpiActual:
                                 \_parameter: (USER_READ_DATA), line:34
                                   |vpiName:USER_READ_DATA
+                                  |vpiFullName:work@test.USER_READ_DATA
                                   |vpiLocalParam:1
               |vpiCaseItem:
               \_case_item: , line:72
@@ -2180,6 +2187,7 @@ design: (work@test)
                         |vpiActual:
                         \_parameter: (ESTABLISHED), line:10
                           |vpiName:ESTABLISHED
+                          |vpiFullName:work@test.ESTABLISHED
                           |vpiLocalParam:1
                     |vpiStmt:
                     \_begin: , line:73
@@ -2200,6 +2208,7 @@ design: (work@test)
                           |vpiActual:
                           \_parameter: (USER_IDLE), line:29
                             |vpiName:USER_IDLE
+                            |vpiFullName:work@test.USER_IDLE
                             |vpiLocalParam:1
                     |vpiElseStmt:
                     \_begin: , line:75
@@ -2220,6 +2229,7 @@ design: (work@test)
                           |vpiActual:
                           \_parameter: (USER_WRITE_DATA), line:32
                             |vpiName:USER_WRITE_DATA
+                            |vpiFullName:work@test.USER_WRITE_DATA
                             |vpiLocalParam:1
   |vpiPort:
   \_port: (CLK), line:6, parent:work@test
@@ -2279,6 +2289,7 @@ design: (work@test)
     |vpiLhs:
     \_parameter: (FRAME_LENGTH), line:9
       |vpiName:FRAME_LENGTH
+      |vpiFullName:work@test.FRAME_LENGTH
       |vpiLocalParam:1
   |vpiParamAssign:
   \_param_assign: , line:10
@@ -2311,6 +2322,7 @@ design: (work@test)
     |vpiLhs:
     \_parameter: (USER_CLEAN), line:25
       |vpiName:USER_CLEAN
+      |vpiFullName:work@test.USER_CLEAN
       |vpiLocalParam:1
   |vpiParamAssign:
   \_param_assign: , line:26
@@ -2323,6 +2335,7 @@ design: (work@test)
     |vpiLhs:
     \_parameter: (USER_CLEAN_CHECK), line:26
       |vpiName:USER_CLEAN_CHECK
+      |vpiFullName:work@test.USER_CLEAN_CHECK
       |vpiLocalParam:1
   |vpiParamAssign:
   \_param_assign: , line:27
@@ -2335,6 +2348,7 @@ design: (work@test)
     |vpiLhs:
     \_parameter: (USER_CLEAR_INTS), line:27
       |vpiName:USER_CLEAR_INTS
+      |vpiFullName:work@test.USER_CLEAR_INTS
       |vpiLocalParam:1
   |vpiParamAssign:
   \_param_assign: , line:28
@@ -2347,6 +2361,7 @@ design: (work@test)
     |vpiLhs:
     \_parameter: (USER_INIT), line:28
       |vpiName:USER_INIT
+      |vpiFullName:work@test.USER_INIT
       |vpiLocalParam:1
   |vpiParamAssign:
   \_param_assign: , line:29

--- a/tests/TypeDefScope/TypeDefScope.log
+++ b/tests/TypeDefScope/TypeDefScope.log
@@ -276,41 +276,41 @@ design: (work@dut)
     |vpiName:UVMC_set_config_object
     |vpiFullName:work@dut.UVMC_set_config_object
     |vpiIODecl:
-    \_io_decl: (type_name)
+    \_io_decl: (type_name), parent:UVMC_set_config_object
       |vpiName:type_name
       |vpiDirection:5
       |vpiExpr:
       \_string_var: , line:3, parent:type_name
-        |vpiFullName:type_name
+        |vpiFullName:work@dut.UVMC_set_config_object.type_name
     |vpiIODecl:
-    \_io_decl: (contxt)
+    \_io_decl: (contxt), parent:UVMC_set_config_object
       |vpiName:contxt
       |vpiDirection:5
       |vpiExpr:
       \_string_var: , line:4, parent:contxt
-        |vpiFullName:contxt
+        |vpiFullName:work@dut.UVMC_set_config_object.contxt
     |vpiIODecl:
-    \_io_decl: (inst_name)
+    \_io_decl: (inst_name), parent:UVMC_set_config_object
       |vpiName:inst_name
       |vpiDirection:5
       |vpiExpr:
       \_string_var: , line:5, parent:inst_name
-        |vpiFullName:inst_name
+        |vpiFullName:work@dut.UVMC_set_config_object.inst_name
     |vpiIODecl:
-    \_io_decl: (field_name)
+    \_io_decl: (field_name), parent:UVMC_set_config_object
       |vpiName:field_name
       |vpiDirection:5
       |vpiExpr:
       \_string_var: , line:6, parent:field_name
-        |vpiFullName:field_name
+        |vpiFullName:work@dut.UVMC_set_config_object.field_name
     |vpiIODecl:
-    \_io_decl: (value)
+    \_io_decl: (value), parent:UVMC_set_config_object
       |vpiName:value
       |vpiDirection:5
       |vpiExpr:
       \_chandle_var: (bits_t), line:7, parent:value
         |vpiName:bits_t
-        |vpiFullName:value.bits_t
+        |vpiFullName:work@dut.UVMC_set_config_object.value.bits_t
     |vpiStmt:
     \_begin: , parent:UVMC_set_config_object
       |vpiFullName:work@dut.UVMC_set_config_object

--- a/tests/Typename/Typename.log
+++ b/tests/Typename/Typename.log
@@ -202,43 +202,44 @@ design: (work@top)
       \_sys_func_call: ($display), line:4
         |vpiName:$display
         |vpiArgument:
-        \_constant: , line:4
+        \_constant: , line:4, parent:$display
           |vpiConstType:6
           |vpiDecompile:":assert: ('%s' == 'logic')"
           |vpiSize:28
           |STRING:":assert: ('%s' == 'logic')"
         |vpiArgument:
-        \_constant: , line:4
+        \_constant: , line:4, parent:$display
           |vpiDecompile:logic
           |STRING:logic
       |vpiStmt:
       \_sys_func_call: ($display), line:5
         |vpiName:$display
         |vpiArgument:
-        \_constant: , line:5
+        \_constant: , line:5, parent:$display
           |vpiConstType:6
           |vpiDecompile:":assert: ('%s' == 'logic')"
           |vpiSize:28
           |STRING:":assert: ('%s' == 'logic')"
         |vpiArgument:
-        \_constant: , line:5
+        \_constant: , line:5, parent:$display
           |vpiDecompile:int
           |STRING:int
       |vpiStmt:
       \_sys_func_call: ($display), line:6
         |vpiName:$display
         |vpiArgument:
-        \_constant: , line:6
+        \_constant: , line:6, parent:$display
           |vpiConstType:6
           |vpiDecompile:":assert: ('%s' == 'logic')"
           |vpiSize:28
           |STRING:":assert: ('%s' == 'logic')"
         |vpiArgument:
-        \_sys_func_call: ($typename), line:6
+        \_sys_func_call: ($typename), line:6, parent:$display
           |vpiName:$typename
           |vpiArgument:
-          \_ref_obj: (a), line:6
+          \_ref_obj: (a), line:6, parent:$typename
             |vpiName:a
+            |vpiFullName:work@top.$display.$typename.a
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/UnitPackage/UnitPackage.log
+++ b/tests/UnitPackage/UnitPackage.log
@@ -1453,27 +1453,27 @@ design: (work@simple_package)
       \_task_call: (msgPkg::initMsgPkg), line:20
         |vpiName:msgPkg::initMsgPkg
         |vpiTask:
-        \_task: (initMsgPkg), line:12
+        \_task: (initMsgPkg), line:12, parent:msgPkg::initMsgPkg
           |vpiName:initMsgPkg
-          |vpiFullName:msgPkg::initMsgPkg
+          |vpiFullName:work@simple_package.msgPkg::initMsgPkg.initMsgPkg
           |vpiIODecl:
-          \_io_decl: (mName)
+          \_io_decl: (mName), parent:initMsgPkg
             |vpiName:mName
             |vpiDirection:5
             |vpiExpr:
             \_string_var: , line:12, parent:mName
-              |vpiFullName:mName
+              |vpiFullName:work@simple_package.msgPkg::initMsgPkg.initMsgPkg.mName
           |vpiIODecl:
-          \_io_decl: (term)
+          \_io_decl: (term), parent:initMsgPkg
             |vpiName:term
             |vpiDirection:5
             |vpiExpr:
             \_chandle_var: (bit), line:12, parent:term
               |vpiName:bit
-              |vpiFullName:term.bit
+              |vpiFullName:work@simple_package.msgPkg::initMsgPkg.initMsgPkg.term.bit
           |vpiStmt:
           \_begin: , parent:initMsgPkg
-            |vpiFullName:msgPkg::initMsgPkg
+            |vpiFullName:work@simple_package.msgPkg::initMsgPkg.initMsgPkg
             |vpiStmt:
             \_assignment: , line:13
               |vpiOpType:82
@@ -1481,11 +1481,11 @@ design: (work@simple_package)
               |vpiLhs:
               \_ref_obj: (terminate_on_error), line:13
                 |vpiName:terminate_on_error
-                |vpiFullName:msgPkg::initMsgPkg::terminate_on_error
+                |vpiFullName:work@simple_package.msgPkg::initMsgPkg.initMsgPkg.terminate_on_error
               |vpiRhs:
               \_ref_obj: (term), line:13
                 |vpiName:term
-                |vpiFullName:msgPkg::initMsgPkg::term
+                |vpiFullName:work@simple_package.msgPkg::initMsgPkg.initMsgPkg.term
             |vpiStmt:
             \_assignment: , line:14
               |vpiOpType:82
@@ -1493,19 +1493,19 @@ design: (work@simple_package)
               |vpiLhs:
               \_ref_obj: (msgName), line:14
                 |vpiName:msgName
-                |vpiFullName:msgPkg::initMsgPkg::msgName
+                |vpiFullName:work@simple_package.msgPkg::initMsgPkg.initMsgPkg.msgName
               |vpiRhs:
               \_ref_obj: (mName), line:14
                 |vpiName:mName
-                |vpiFullName:msgPkg::initMsgPkg::mName
+                |vpiFullName:work@simple_package.msgPkg::initMsgPkg.initMsgPkg.mName
         |vpiArgument:
-        \_constant: , line:20
+        \_constant: , line:20, parent:msgPkg::initMsgPkg
           |vpiConstType:6
           |vpiDecompile:"PACKAGES"
           |vpiSize:10
           |STRING:"PACKAGES"
         |vpiArgument:
-        \_constant: , line:20
+        \_constant: , line:20, parent:msgPkg::initMsgPkg
           |vpiConstType:7
           |vpiDecompile:0
           |vpiSize:32
@@ -1514,36 +1514,38 @@ design: (work@simple_package)
       \_task_call: (msgPkg::msg_info), line:21
         |vpiName:msgPkg::msg_info
         |vpiTask:
-        \_task: (msg_info), line:19
+        \_task: (msg_info), line:19, parent:msgPkg::msg_info
           |vpiName:msg_info
-          |vpiFullName:msgPkg::msg_info
+          |vpiFullName:work@simple_package.msgPkg::msg_info.msg_info
           |vpiIODecl:
-          \_io_decl: (msg)
+          \_io_decl: (msg), parent:msg_info
             |vpiName:msg
             |vpiDirection:5
             |vpiExpr:
             \_string_var: , line:19, parent:msg
-              |vpiFullName:msg
+              |vpiFullName:work@simple_package.msgPkg::msg_info.msg_info.msg
           |vpiStmt:
           \_sys_func_call: ($display), line:20, parent:msg_info
             |vpiName:$display
             |vpiArgument:
-            \_constant: , line:20
+            \_constant: , line:20, parent:$display
               |vpiConstType:6
               |vpiDecompile:"@%0dns %s INFO : %s"
               |vpiSize:21
               |STRING:"@%0dns %s INFO : %s"
             |vpiArgument:
-            \_sys_func_call: ($time), line:20
+            \_sys_func_call: ($time), line:20, parent:$display
               |vpiName:$time
             |vpiArgument:
-            \_ref_obj: (msgName), line:20
+            \_ref_obj: (msgName), line:20, parent:$display
               |vpiName:msgName
+              |vpiFullName:work@simple_package.msgPkg::msg_info.msg_info.$display.msgName
             |vpiArgument:
-            \_ref_obj: (msg), line:20
+            \_ref_obj: (msg), line:20, parent:$display
               |vpiName:msg
+              |vpiFullName:work@simple_package.msgPkg::msg_info.msg_info.$display.msg
         |vpiArgument:
-        \_constant: , line:21
+        \_constant: , line:21, parent:msgPkg::msg_info
           |vpiConstType:6
           |vpiDecompile:"Testing Packages"
           |vpiSize:18
@@ -1555,46 +1557,48 @@ design: (work@simple_package)
         \_task_call: (msgPkg::msg_warn), line:22
           |vpiName:msgPkg::msg_warn
           |vpiTask:
-          \_task: (msg_warn), line:25
+          \_task: (msg_warn), line:25, parent:msgPkg::msg_warn
             |vpiName:msg_warn
-            |vpiFullName:msgPkg::msg_warn
+            |vpiFullName:work@simple_package.msgPkg::msg_warn.msg_warn
             |vpiIODecl:
-            \_io_decl: (msg)
+            \_io_decl: (msg), parent:msg_warn
               |vpiName:msg
               |vpiDirection:5
               |vpiExpr:
               \_string_var: , line:25, parent:msg
-                |vpiFullName:msg
+                |vpiFullName:work@simple_package.msgPkg::msg_warn.msg_warn.msg
             |vpiStmt:
             \_begin: , parent:msg_warn
-              |vpiFullName:msgPkg::msg_warn
+              |vpiFullName:work@simple_package.msgPkg::msg_warn.msg_warn
               |vpiStmt:
               \_sys_func_call: ($display), line:26
                 |vpiName:$display
                 |vpiArgument:
-                \_constant: , line:26
+                \_constant: , line:26, parent:$display
                   |vpiConstType:6
                   |vpiDecompile:"@%0dns %s WARN : %s"
                   |vpiSize:21
                   |STRING:"@%0dns %s WARN : %s"
                 |vpiArgument:
-                \_sys_func_call: ($time), line:26
+                \_sys_func_call: ($time), line:26, parent:$display
                   |vpiName:$time
                 |vpiArgument:
-                \_ref_obj: (msgName), line:26
+                \_ref_obj: (msgName), line:26, parent:$display
                   |vpiName:msgName
+                  |vpiFullName:work@simple_package.msgPkg::msg_warn.msg_warn.$display.msgName
                 |vpiArgument:
-                \_ref_obj: (msg), line:26
+                \_ref_obj: (msg), line:26, parent:$display
                   |vpiName:msg
+                  |vpiFullName:work@simple_package.msgPkg::msg_warn.msg_warn.$display.msg
               |vpiStmt:
               \_operation: , line:27
                 |vpiOpType:62
                 |vpiOperand:
                 \_ref_obj: (warnCnt), line:27
                   |vpiName:warnCnt
-                  |vpiFullName:msgPkg::msg_warn::warnCnt
+                  |vpiFullName:work@simple_package.msgPkg::msg_warn.msg_warn.warnCnt
           |vpiArgument:
-          \_constant: , line:22
+          \_constant: , line:22, parent:msgPkg::msg_warn
             |vpiConstType:6
             |vpiDecompile:"Testing Packages"
             |vpiSize:18
@@ -1606,55 +1610,57 @@ design: (work@simple_package)
         \_task_call: (msgPkg::msg_error), line:23
           |vpiName:msgPkg::msg_error
           |vpiTask:
-          \_task: (msg_error), line:32
+          \_task: (msg_error), line:32, parent:msgPkg::msg_error
             |vpiName:msg_error
-            |vpiFullName:msgPkg::msg_error
+            |vpiFullName:work@simple_package.msgPkg::msg_error.msg_error
             |vpiIODecl:
-            \_io_decl: (msg)
+            \_io_decl: (msg), parent:msg_error
               |vpiName:msg
               |vpiDirection:5
               |vpiExpr:
               \_string_var: , line:32, parent:msg
-                |vpiFullName:msg
+                |vpiFullName:work@simple_package.msgPkg::msg_error.msg_error.msg
             |vpiStmt:
             \_begin: , parent:msg_error
-              |vpiFullName:msgPkg::msg_error
+              |vpiFullName:work@simple_package.msgPkg::msg_error.msg_error
               |vpiStmt:
               \_sys_func_call: ($display), line:33
                 |vpiName:$display
                 |vpiArgument:
-                \_constant: , line:33
+                \_constant: , line:33, parent:$display
                   |vpiConstType:6
                   |vpiDecompile:"@%0dns %s ERROR : %s"
                   |vpiSize:22
                   |STRING:"@%0dns %s ERROR : %s"
                 |vpiArgument:
-                \_sys_func_call: ($time), line:33
+                \_sys_func_call: ($time), line:33, parent:$display
                   |vpiName:$time
                 |vpiArgument:
-                \_ref_obj: (msgName), line:33
+                \_ref_obj: (msgName), line:33, parent:$display
                   |vpiName:msgName
+                  |vpiFullName:work@simple_package.msgPkg::msg_error.msg_error.$display.msgName
                 |vpiArgument:
-                \_ref_obj: (msg), line:33
+                \_ref_obj: (msg), line:33, parent:$display
                   |vpiName:msg
+                  |vpiFullName:work@simple_package.msgPkg::msg_error.msg_error.$display.msg
               |vpiStmt:
               \_operation: , line:34
                 |vpiOpType:62
                 |vpiOperand:
                 \_ref_obj: (errCnt), line:34
                   |vpiName:errCnt
-                  |vpiFullName:msgPkg::msg_error::errCnt
+                  |vpiFullName:work@simple_package.msgPkg::msg_error.msg_error.errCnt
               |vpiStmt:
               \_if_stmt: , line:35
                 |vpiCondition:
                 \_ref_obj: (terminate_on_error), line:35
                   |vpiName:terminate_on_error
-                  |vpiFullName:msgPkg::msg_error::terminate_on_error
+                  |vpiFullName:work@simple_package.msgPkg::msg_error.msg_error.terminate_on_error
                 |vpiStmt:
                 \_sys_func_call: ($finish), line:35
                   |vpiName:$finish
           |vpiArgument:
-          \_constant: , line:23
+          \_constant: , line:23, parent:msgPkg::msg_error
             |vpiConstType:6
             |vpiDecompile:"Testing Packages"
             |vpiSize:18
@@ -1663,52 +1669,55 @@ design: (work@simple_package)
       \_task_call: (msgPkg::msg_info), line:24
         |vpiName:msgPkg::msg_info
         |vpiTask:
-        \_task: (msg_info), line:19
+        \_task: (msg_info), line:19, parent:msgPkg::msg_info
           |vpiName:msg_info
-          |vpiFullName:msgPkg::msg_info
+          |vpiFullName:work@simple_package.msgPkg::msg_info.msg_info
           |vpiIODecl:
-          \_io_decl: (msg)
+          \_io_decl: (msg), parent:msg_info
             |vpiName:msg
             |vpiDirection:5
             |vpiExpr:
             \_string_var: , line:19, parent:msg
-              |vpiFullName:msg
+              |vpiFullName:work@simple_package.msgPkg::msg_info.msg_info.msg
           |vpiStmt:
           \_sys_func_call: ($display), line:20, parent:msg_info
             |vpiName:$display
             |vpiArgument:
-            \_constant: , line:20
+            \_constant: , line:20, parent:$display
               |vpiConstType:6
               |vpiDecompile:"@%0dns %s INFO : %s"
               |vpiSize:21
               |STRING:"@%0dns %s INFO : %s"
             |vpiArgument:
-            \_sys_func_call: ($time), line:20
+            \_sys_func_call: ($time), line:20, parent:$display
               |vpiName:$time
             |vpiArgument:
-            \_ref_obj: (msgName), line:20
+            \_ref_obj: (msgName), line:20, parent:$display
               |vpiName:msgName
+              |vpiFullName:work@simple_package.msgPkg::msg_info.msg_info.$display.msgName
             |vpiArgument:
-            \_ref_obj: (msg), line:20
+            \_ref_obj: (msg), line:20, parent:$display
               |vpiName:msg
+              |vpiFullName:work@simple_package.msgPkg::msg_info.msg_info.$display.msg
         |vpiArgument:
-        \_sys_func_call: ($psprintf), line:24
+        \_sys_func_call: ($psprintf), line:24, parent:msgPkg::msg_info
           |vpiName:$psprintf
           |vpiArgument:
-          \_constant: , line:24
+          \_constant: , line:24, parent:$psprintf
             |vpiConstType:6
             |vpiDecompile:"Warning Count %0d, Error Count %0d"
             |vpiSize:36
             |STRING:"Warning Count %0d, Error Count %0d"
           |vpiArgument:
-          \_func_call: (msgPkg::getWarnCnt), line:25
+          \_func_call: (msgPkg::getWarnCnt), line:25, parent:$psprintf
             |vpiName:msgPkg::getWarnCnt
             |vpiFunction:
-            \_function: (getWarnCnt), line:53
+            \_function: (getWarnCnt), line:53, parent:msgPkg::getWarnCnt
               |vpiName:getWarnCnt
-              |vpiFullName:msgPkg::getWarnCnt
+              |vpiFullName:work@simple_package.msgPkg::msg_info.$psprintf.msgPkg::getWarnCnt.getWarnCnt
               |vpiReturn:
-              \_int_var: , line:53
+              \_int_var: , line:53, parent:getWarnCnt
+                |vpiFullName:work@simple_package.msgPkg::msg_info.$psprintf.msgPkg::getWarnCnt.getWarnCnt
               |vpiStmt:
               \_assignment: , line:54, parent:getWarnCnt
                 |vpiOpType:82
@@ -1716,20 +1725,21 @@ design: (work@simple_package)
                 |vpiLhs:
                 \_ref_obj: (getWarnCnt), line:54
                   |vpiName:getWarnCnt
-                  |vpiFullName:msgPkg::getWarnCnt::getWarnCnt
+                  |vpiFullName:work@simple_package.msgPkg::msg_info.$psprintf.msgPkg::getWarnCnt.getWarnCnt.getWarnCnt
                 |vpiRhs:
                 \_ref_obj: (warnCnt), line:54
                   |vpiName:warnCnt
-                  |vpiFullName:msgPkg::getWarnCnt::warnCnt
+                  |vpiFullName:work@simple_package.msgPkg::msg_info.$psprintf.msgPkg::getWarnCnt.getWarnCnt.warnCnt
           |vpiArgument:
-          \_func_call: (msgPkg::getErrCnt), line:25
+          \_func_call: (msgPkg::getErrCnt), line:25, parent:$psprintf
             |vpiName:msgPkg::getErrCnt
             |vpiFunction:
-            \_function: (getErrCnt), line:47
+            \_function: (getErrCnt), line:47, parent:msgPkg::getErrCnt
               |vpiName:getErrCnt
-              |vpiFullName:msgPkg::getErrCnt
+              |vpiFullName:work@simple_package.msgPkg::msg_info.$psprintf.msgPkg::getErrCnt.getErrCnt
               |vpiReturn:
-              \_int_var: , line:47
+              \_int_var: , line:47, parent:getErrCnt
+                |vpiFullName:work@simple_package.msgPkg::msg_info.$psprintf.msgPkg::getErrCnt.getErrCnt
               |vpiStmt:
               \_assignment: , line:48, parent:getErrCnt
                 |vpiOpType:82
@@ -1737,11 +1747,11 @@ design: (work@simple_package)
                 |vpiLhs:
                 \_ref_obj: (getErrCnt), line:48
                   |vpiName:getErrCnt
-                  |vpiFullName:msgPkg::getErrCnt::getErrCnt
+                  |vpiFullName:work@simple_package.msgPkg::msg_info.$psprintf.msgPkg::getErrCnt.getErrCnt.getErrCnt
                 |vpiRhs:
                 \_ref_obj: (errCnt), line:48
                   |vpiName:errCnt
-                  |vpiFullName:msgPkg::getErrCnt::errCnt
+                  |vpiFullName:work@simple_package.msgPkg::msg_info.$psprintf.msgPkg::getErrCnt.getErrCnt.errCnt
       |vpiStmt:
       \_if_stmt: , line:26
         |vpiCondition:
@@ -1781,42 +1791,44 @@ design: (work@simple_package)
           \_task_call: (msgPkg::msg_fatal), line:27
             |vpiName:msgPkg::msg_fatal
             |vpiTask:
-            \_task: (msg_fatal), line:40
+            \_task: (msg_fatal), line:40, parent:msgPkg::msg_fatal
               |vpiName:msg_fatal
-              |vpiFullName:msgPkg::msg_fatal
+              |vpiFullName:work@simple_package.msgPkg::msg_fatal.msg_fatal
               |vpiIODecl:
-              \_io_decl: (msg)
+              \_io_decl: (msg), parent:msg_fatal
                 |vpiName:msg
                 |vpiDirection:5
                 |vpiExpr:
                 \_string_var: , line:40, parent:msg
-                  |vpiFullName:msg
+                  |vpiFullName:work@simple_package.msgPkg::msg_fatal.msg_fatal.msg
               |vpiStmt:
               \_begin: , parent:msg_fatal
-                |vpiFullName:msgPkg::msg_fatal
+                |vpiFullName:work@simple_package.msgPkg::msg_fatal.msg_fatal
                 |vpiStmt:
                 \_sys_func_call: ($display), line:41
                   |vpiName:$display
                   |vpiArgument:
-                  \_constant: , line:41
+                  \_constant: , line:41, parent:$display
                     |vpiConstType:6
                     |vpiDecompile:"@%0dns %s FATAL : %s"
                     |vpiSize:22
                     |STRING:"@%0dns %s FATAL : %s"
                   |vpiArgument:
-                  \_sys_func_call: ($time), line:41
+                  \_sys_func_call: ($time), line:41, parent:$display
                     |vpiName:$time
                   |vpiArgument:
-                  \_ref_obj: (msgName), line:41
+                  \_ref_obj: (msgName), line:41, parent:$display
                     |vpiName:msgName
+                    |vpiFullName:work@simple_package.msgPkg::msg_fatal.msg_fatal.$display.msgName
                   |vpiArgument:
-                  \_ref_obj: (msg), line:41
+                  \_ref_obj: (msg), line:41, parent:$display
                     |vpiName:msg
+                    |vpiFullName:work@simple_package.msgPkg::msg_fatal.msg_fatal.$display.msg
                 |vpiStmt:
                 \_sys_func_call: ($finish), line:42
                   |vpiName:$finish
             |vpiArgument:
-            \_constant: , line:27
+            \_constant: , line:27, parent:msgPkg::msg_fatal
               |vpiConstType:6
               |vpiDecompile:"Value is FALSE"
               |vpiSize:16
@@ -1843,33 +1855,33 @@ design: (work@simple_package)
   \_enum_typespec: (bool), line:10
     |vpiName:bool
     |vpiEnumConst:
-    \_enum_const: (FALSE), line:10
+    \_enum_const: (FALSE), line:10, parent:bool
       |vpiName:FALSE
       |INT:0
     |vpiEnumConst:
-    \_enum_const: (TRUE), line:10
+    \_enum_const: (TRUE), line:10, parent:bool
       |vpiName:TRUE
       |INT:1
   |vpiTypedef:
   \_struct_typespec: (mem_s), line:11
     |vpiName:mem_s
     |vpiTypespecMember:
-    \_typespec_member: (addr), line:12
+    \_typespec_member: (addr), line:12, parent:mem_s
       |vpiName:addr
       |vpiTypespec:
-      \_void_typespec: (bit), line:12
+      \_void_typespec: (bit), line:12, parent:addr
         |vpiName:bit
     |vpiTypespecMember:
-    \_typespec_member: (data), line:13
+    \_typespec_member: (data), line:13, parent:mem_s
       |vpiName:data
       |vpiTypespec:
-      \_void_typespec: (bit), line:13
+      \_void_typespec: (bit), line:13, parent:data
         |vpiName:bit
     |vpiTypespecMember:
-    \_typespec_member: (wr), line:14
+    \_typespec_member: (wr), line:14, parent:mem_s
       |vpiName:wr
       |vpiTypespec:
-      \_void_typespec: (bit), line:14
+      \_void_typespec: (bit), line:14, parent:wr
         |vpiName:bit
   |vpiParameter:
   \_parameter: (SIZE), line:8

--- a/tests/UnitPartSelect/UnitPartSelect.log
+++ b/tests/UnitPartSelect/UnitPartSelect.log
@@ -982,6 +982,7 @@ design: (work@toto)
               |vpiActual:
               \_parameter: (IDLE), line:3
                 |vpiName:IDLE
+                |vpiFullName:work@toto.IDLE
           |vpiRhs:
           \_constant: , line:9
             |vpiConstType:3


### PR DESCRIPTION
Fixes #673.
Elaboration still creates bogus fullnames for objects as the algorithm is not smart, it just concatenates all names of parent objects.
