### PR TITLE
packed_array_var support

### DIFF
--- a/src/DesignCompile/CompileHelper.cpp
+++ b/src/DesignCompile/CompileHelper.cpp
@@ -1394,6 +1394,8 @@ bool CompileHelper::compileDataDeclaration(DesignComponent* component,
     compileTypeDef(component, fC, id, compileDesign);
     break;
   }
+  case VObjectType::slPackage_import_declaration: // Do nothing here
+    break;
   default:
     /*
      n<> u<29> t<IntVec_TypeReg> p<30> l<29>
@@ -1441,7 +1443,7 @@ bool CompileHelper::compileDataDeclaration(DesignComponent* component,
         }
       }
       Signal* sig = nullptr;
-      if (fC->Type(intVec_TypeReg) == slClass_scope) {
+      if (fC->Type(intVec_TypeReg) == slClass_scope || fC->Type(intVec_TypeReg) == slStringConst) {
         sig = new Signal(fC, signal, fC->Type(intVec_TypeReg), packedDimension, VObjectType::slNoType, intVec_TypeReg,
                unpackedDimension, false); 
       } else {

--- a/tests/ForElab/ForElab.log
+++ b/tests/ForElab/ForElab.log
@@ -262,24 +262,6 @@ design: (work@tlul_socket_m1)
           |vpiGenScope:
           \_gen_scope: , parent:gen_normal_case
             |vpiFullName:work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case
-            |vpiNet:
-            \_logic_net: (req), line:35
-              |vpiName:req
-              |vpiFullName:work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.req
-              |vpiRange:
-              \_range: , line:35
-                |vpiLeftRange:
-                \_constant: , line:35
-                  |vpiConstType:7
-                  |vpiDecompile:3
-                  |vpiSize:32
-                  |INT:3
-                |vpiRightRange:
-                \_constant: , line:35
-                  |vpiConstType:7
-                  |vpiDecompile:0
-                  |vpiSize:32
-                  |INT:0
             |vpiGenScopeArray:
             \_gen_scope_array: (gen_tree[0]), line:37
               |vpiName:gen_tree[0]
@@ -529,6 +511,24 @@ design: (work@tlul_socket_m1)
                 \_parameter: (level), line:37
                   |vpiName:level
                   |INT:2
+            |vpiVariables:
+            \_logic_var: (req), line:35
+              |vpiName:req
+              |vpiFullName:work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.req
+              |vpiRange:
+              \_range: , line:35
+                |vpiLeftRange:
+                \_constant: , line:35
+                  |vpiConstType:7
+                  |vpiDecompile:3
+                  |vpiSize:32
+                  |INT:3
+                |vpiRightRange:
+                \_constant: , line:35
+                  |vpiConstType:7
+                  |vpiDecompile:0
+                  |vpiSize:32
+                  |INT:0
             |vpiParamAssign:
             \_param_assign: , line:34
               |vpiRhs:

--- a/tests/StructVarImp/StructVarImp.log
+++ b/tests/StructVarImp/StructVarImp.log
@@ -1,0 +1,740 @@
+[INF:CM0023] Creating log file ../../build/tests/StructVarImp/slpp_all/surelog.log.
+
+LIB:  work
+FILE: dut.sv
+n<> u<0> t<Null_rule> p<201> s<200> l<1>
+n<flash_ctrl_reg_pkg> u<1> t<StringConst> p<158> s<16> l<1>
+n<> u<2> t<IntegerAtomType_Int> p<3> l<4>
+n<> u<3> t<Data_type> p<4> c<2> l<4>
+n<> u<4> t<Data_type_or_implicit> p<14> c<3> s<13> l<4>
+n<NBanks> u<5> t<StringConst> p<12> s<11> l<4>
+n<2> u<6> t<IntConst> p<7> l<4>
+n<> u<7> t<Primary_literal> p<8> c<6> l<4>
+n<> u<8> t<Constant_primary> p<9> c<7> l<4>
+n<> u<9> t<Constant_expression> p<10> c<8> l<4>
+n<> u<10> t<Constant_mintypmax_expression> p<11> c<9> l<4>
+n<> u<11> t<Constant_param_expression> p<12> c<10> l<4>
+n<> u<12> t<Param_assignment> p<13> c<5> l<4>
+n<> u<13> t<List_of_param_assignments> p<14> c<12> l<4>
+n<> u<14> t<Parameter_declaration> p<15> c<4> l<4>
+n<> u<15> t<Package_or_generate_item_declaration> p<16> c<14> l<4>
+n<> u<16> t<Package_item> p<158> c<15> s<31> l<4>
+n<> u<17> t<IntegerAtomType_Int> p<18> l<5>
+n<> u<18> t<Data_type> p<19> c<17> l<5>
+n<> u<19> t<Data_type_or_implicit> p<29> c<18> s<28> l<5>
+n<NumRegions> u<20> t<StringConst> p<27> s<26> l<5>
+n<8> u<21> t<IntConst> p<22> l<5>
+n<> u<22> t<Primary_literal> p<23> c<21> l<5>
+n<> u<23> t<Constant_primary> p<24> c<22> l<5>
+n<> u<24> t<Constant_expression> p<25> c<23> l<5>
+n<> u<25> t<Constant_mintypmax_expression> p<26> c<24> l<5>
+n<> u<26> t<Constant_param_expression> p<27> c<25> l<5>
+n<> u<27> t<Param_assignment> p<28> c<20> l<5>
+n<> u<28> t<List_of_param_assignments> p<29> c<27> l<5>
+n<> u<29> t<Parameter_declaration> p<30> c<19> l<5>
+n<> u<30> t<Package_or_generate_item_declaration> p<31> c<29> l<5>
+n<> u<31> t<Package_item> p<158> c<30> s<156> l<5>
+n<> u<32> t<Struct_keyword> p<33> l<7>
+n<> u<33> t<Struct_union> p<151> c<32> s<34> l<7>
+n<> u<34> t<Packed_keyword> p<151> s<50> l<7>
+n<> u<35> t<Struct_keyword> p<36> l<8>
+n<> u<36> t<Struct_union> p<45> c<35> s<37> l<8>
+n<> u<37> t<Packed_keyword> p<45> s<44> l<8>
+n<> u<38> t<IntVec_TypeLogic> p<39> l<9>
+n<> u<39> t<Data_type> p<40> c<38> l<9>
+n<> u<40> t<Data_type_or_void> p<44> c<39> s<43> l<9>
+n<q> u<41> t<StringConst> p<42> l<9>
+n<> u<42> t<Variable_decl_assignment> p<43> c<41> l<9>
+n<> u<43> t<List_of_variable_decl_assignments> p<44> c<42> l<9>
+n<> u<44> t<Struct_union_member> p<45> c<40> l<9>
+n<> u<45> t<Data_type> p<46> c<36> l<8>
+n<> u<46> t<Data_type_or_void> p<50> c<45> s<49> l<8>
+n<en> u<47> t<StringConst> p<48> l<10>
+n<> u<48> t<Variable_decl_assignment> p<49> c<47> l<10>
+n<> u<49> t<List_of_variable_decl_assignments> p<50> c<48> l<10>
+n<> u<50> t<Struct_union_member> p<151> c<46> s<66> l<8>
+n<> u<51> t<Struct_keyword> p<52> l<11>
+n<> u<52> t<Struct_union> p<61> c<51> s<53> l<11>
+n<> u<53> t<Packed_keyword> p<61> s<60> l<11>
+n<> u<54> t<IntVec_TypeLogic> p<55> l<12>
+n<> u<55> t<Data_type> p<56> c<54> l<12>
+n<> u<56> t<Data_type_or_void> p<60> c<55> s<59> l<12>
+n<q> u<57> t<StringConst> p<58> l<12>
+n<> u<58> t<Variable_decl_assignment> p<59> c<57> l<12>
+n<> u<59> t<List_of_variable_decl_assignments> p<60> c<58> l<12>
+n<> u<60> t<Struct_union_member> p<61> c<56> l<12>
+n<> u<61> t<Data_type> p<62> c<52> l<11>
+n<> u<62> t<Data_type_or_void> p<66> c<61> s<65> l<11>
+n<rd_en> u<63> t<StringConst> p<64> l<13>
+n<> u<64> t<Variable_decl_assignment> p<65> c<63> l<13>
+n<> u<65> t<List_of_variable_decl_assignments> p<66> c<64> l<13>
+n<> u<66> t<Struct_union_member> p<151> c<62> s<82> l<11>
+n<> u<67> t<Struct_keyword> p<68> l<14>
+n<> u<68> t<Struct_union> p<77> c<67> s<69> l<14>
+n<> u<69> t<Packed_keyword> p<77> s<76> l<14>
+n<> u<70> t<IntVec_TypeLogic> p<71> l<15>
+n<> u<71> t<Data_type> p<72> c<70> l<15>
+n<> u<72> t<Data_type_or_void> p<76> c<71> s<75> l<15>
+n<q> u<73> t<StringConst> p<74> l<15>
+n<> u<74> t<Variable_decl_assignment> p<75> c<73> l<15>
+n<> u<75> t<List_of_variable_decl_assignments> p<76> c<74> l<15>
+n<> u<76> t<Struct_union_member> p<77> c<72> l<15>
+n<> u<77> t<Data_type> p<78> c<68> l<14>
+n<> u<78> t<Data_type_or_void> p<82> c<77> s<81> l<14>
+n<prog_en> u<79> t<StringConst> p<80> l<16>
+n<> u<80> t<Variable_decl_assignment> p<81> c<79> l<16>
+n<> u<81> t<List_of_variable_decl_assignments> p<82> c<80> l<16>
+n<> u<82> t<Struct_union_member> p<151> c<78> s<98> l<14>
+n<> u<83> t<Struct_keyword> p<84> l<17>
+n<> u<84> t<Struct_union> p<93> c<83> s<85> l<17>
+n<> u<85> t<Packed_keyword> p<93> s<92> l<17>
+n<> u<86> t<IntVec_TypeLogic> p<87> l<18>
+n<> u<87> t<Data_type> p<88> c<86> l<18>
+n<> u<88> t<Data_type_or_void> p<92> c<87> s<91> l<18>
+n<q> u<89> t<StringConst> p<90> l<18>
+n<> u<90> t<Variable_decl_assignment> p<91> c<89> l<18>
+n<> u<91> t<List_of_variable_decl_assignments> p<92> c<90> l<18>
+n<> u<92> t<Struct_union_member> p<93> c<88> l<18>
+n<> u<93> t<Data_type> p<94> c<84> l<17>
+n<> u<94> t<Data_type_or_void> p<98> c<93> s<97> l<17>
+n<erase_en> u<95> t<StringConst> p<96> l<19>
+n<> u<96> t<Variable_decl_assignment> p<97> c<95> l<19>
+n<> u<97> t<List_of_variable_decl_assignments> p<98> c<96> l<19>
+n<> u<98> t<Struct_union_member> p<151> c<94> s<124> l<17>
+n<> u<99> t<Struct_keyword> p<100> l<20>
+n<> u<100> t<Struct_union> p<119> c<99> s<101> l<20>
+n<> u<101> t<Packed_keyword> p<119> s<118> l<20>
+n<> u<102> t<IntVec_TypeLogic> p<113> s<112> l<21>
+n<8> u<103> t<IntConst> p<104> l<21>
+n<> u<104> t<Primary_literal> p<105> c<103> l<21>
+n<> u<105> t<Constant_primary> p<106> c<104> l<21>
+n<> u<106> t<Constant_expression> p<111> c<105> s<110> l<21>
+n<0> u<107> t<IntConst> p<108> l<21>
+n<> u<108> t<Primary_literal> p<109> c<107> l<21>
+n<> u<109> t<Constant_primary> p<110> c<108> l<21>
+n<> u<110> t<Constant_expression> p<111> c<109> l<21>
+n<> u<111> t<Constant_range> p<112> c<106> l<21>
+n<> u<112> t<Packed_dimension> p<113> c<111> l<21>
+n<> u<113> t<Data_type> p<114> c<102> l<21>
+n<> u<114> t<Data_type_or_void> p<118> c<113> s<117> l<21>
+n<q> u<115> t<StringConst> p<116> l<21>
+n<> u<116> t<Variable_decl_assignment> p<117> c<115> l<21>
+n<> u<117> t<List_of_variable_decl_assignments> p<118> c<116> l<21>
+n<> u<118> t<Struct_union_member> p<119> c<114> l<21>
+n<> u<119> t<Data_type> p<120> c<100> l<20>
+n<> u<120> t<Data_type_or_void> p<124> c<119> s<123> l<20>
+n<base> u<121> t<StringConst> p<122> l<22>
+n<> u<122> t<Variable_decl_assignment> p<123> c<121> l<22>
+n<> u<123> t<List_of_variable_decl_assignments> p<124> c<122> l<22>
+n<> u<124> t<Struct_union_member> p<151> c<120> s<150> l<20>
+n<> u<125> t<Struct_keyword> p<126> l<23>
+n<> u<126> t<Struct_union> p<145> c<125> s<127> l<23>
+n<> u<127> t<Packed_keyword> p<145> s<144> l<23>
+n<> u<128> t<IntVec_TypeLogic> p<139> s<138> l<24>
+n<8> u<129> t<IntConst> p<130> l<24>
+n<> u<130> t<Primary_literal> p<131> c<129> l<24>
+n<> u<131> t<Constant_primary> p<132> c<130> l<24>
+n<> u<132> t<Constant_expression> p<137> c<131> s<136> l<24>
+n<0> u<133> t<IntConst> p<134> l<24>
+n<> u<134> t<Primary_literal> p<135> c<133> l<24>
+n<> u<135> t<Constant_primary> p<136> c<134> l<24>
+n<> u<136> t<Constant_expression> p<137> c<135> l<24>
+n<> u<137> t<Constant_range> p<138> c<132> l<24>
+n<> u<138> t<Packed_dimension> p<139> c<137> l<24>
+n<> u<139> t<Data_type> p<140> c<128> l<24>
+n<> u<140> t<Data_type_or_void> p<144> c<139> s<143> l<24>
+n<q> u<141> t<StringConst> p<142> l<24>
+n<> u<142> t<Variable_decl_assignment> p<143> c<141> l<24>
+n<> u<143> t<List_of_variable_decl_assignments> p<144> c<142> l<24>
+n<> u<144> t<Struct_union_member> p<145> c<140> l<24>
+n<> u<145> t<Data_type> p<146> c<126> l<23>
+n<> u<146> t<Data_type_or_void> p<150> c<145> s<149> l<23>
+n<size> u<147> t<StringConst> p<148> l<25>
+n<> u<148> t<Variable_decl_assignment> p<149> c<147> l<25>
+n<> u<149> t<List_of_variable_decl_assignments> p<150> c<148> l<25>
+n<> u<150> t<Struct_union_member> p<151> c<146> l<23>
+n<> u<151> t<Data_type> p<153> c<33> s<152> l<7>
+n<flash_ctrl_reg2hw_mp_region_cfg_mreg_t> u<152> t<StringConst> p<153> l<26>
+n<> u<153> t<Type_declaration> p<154> c<151> l<7>
+n<> u<154> t<Data_declaration> p<155> c<153> l<7>
+n<> u<155> t<Package_or_generate_item_declaration> p<156> c<154> l<7>
+n<> u<156> t<Package_item> p<158> c<155> s<157> l<7>
+n<> u<157> t<Endpackage> p<158> l<29>
+n<> u<158> t<Package_declaration> p<159> c<1> l<1>
+n<> u<159> t<Description> p<200> c<158> s<199> l<1>
+n<> u<160> t<Module_keyword> p<164> s<161> l<33>
+n<top> u<161> t<StringConst> p<164> s<163> l<33>
+n<> u<162> t<Port> p<163> l<33>
+n<> u<163> t<List_of_ports> p<164> c<162> l<33>
+n<> u<164> t<Module_nonansi_header> p<198> c<160> s<174> l<33>
+n<flash_ctrl_reg_pkg> u<165> t<StringConst> p<166> l<34>
+n<> u<166> t<Package_import_item> p<167> c<165> l<34>
+n<> u<167> t<Package_import_declaration> p<168> c<166> l<34>
+n<> u<168> t<Data_declaration> p<169> c<167> l<34>
+n<> u<169> t<Package_or_generate_item_declaration> p<170> c<168> l<34>
+n<> u<170> t<Module_or_generate_item_declaration> p<171> c<169> l<34>
+n<> u<171> t<Module_common_item> p<172> c<170> l<34>
+n<> u<172> t<Module_or_generate_item> p<173> c<171> l<34>
+n<> u<173> t<Non_port_module_item> p<174> c<172> l<34>
+n<> u<174> t<Module_item> p<198> c<173> s<197> l<34>
+n<flash_ctrl_reg2hw_mp_region_cfg_mreg_t> u<175> t<StringConst> p<186> s<185> l<36>
+n<MpRegions> u<176> t<StringConst> p<177> l<36>
+n<> u<177> t<Primary_literal> p<178> c<176> l<36>
+n<> u<178> t<Constant_primary> p<179> c<177> l<36>
+n<> u<179> t<Constant_expression> p<184> c<178> s<183> l<36>
+n<0> u<180> t<IntConst> p<181> l<36>
+n<> u<181> t<Primary_literal> p<182> c<180> l<36>
+n<> u<182> t<Constant_primary> p<183> c<181> l<36>
+n<> u<183> t<Constant_expression> p<184> c<182> l<36>
+n<> u<184> t<Constant_range> p<185> c<179> l<36>
+n<> u<185> t<Packed_dimension> p<186> c<184> l<36>
+n<> u<186> t<Data_type> p<190> c<175> s<189> l<36>
+n<region_cfgs> u<187> t<StringConst> p<188> l<36>
+n<> u<188> t<Variable_decl_assignment> p<189> c<187> l<36>
+n<> u<189> t<List_of_variable_decl_assignments> p<190> c<188> l<36>
+n<> u<190> t<Variable_declaration> p<191> c<186> l<36>
+n<> u<191> t<Data_declaration> p<192> c<190> l<36>
+n<> u<192> t<Package_or_generate_item_declaration> p<193> c<191> l<36>
+n<> u<193> t<Module_or_generate_item_declaration> p<194> c<192> l<36>
+n<> u<194> t<Module_common_item> p<195> c<193> l<36>
+n<> u<195> t<Module_or_generate_item> p<196> c<194> l<36>
+n<> u<196> t<Non_port_module_item> p<197> c<195> l<36>
+n<> u<197> t<Module_item> p<198> c<196> l<36>
+n<> u<198> t<Module_declaration> p<199> c<164> l<33>
+n<> u<199> t<Description> p<200> c<198> l<33>
+n<> u<200> t<Source_text> p<201> c<159> l<1>
+n<> u<201> t<Top_level_rule> l<1>
+[WRN:PA0205] dut.sv:1: No timescale set for "flash_ctrl_reg_pkg".
+
+[WRN:PA0205] dut.sv:33: No timescale set for "top".
+
+[INF:CP0300] Compilation...
+
+[INF:CP0301] dut.sv:1: Compile package "flash_ctrl_reg_pkg".
+
+[INF:CP0303] dut.sv:33: Compile module "work@top".
+
+[INF:CP0302] builtin.sv:4: Compile class "work@mailbox".
+
+[INF:CP0302] builtin.sv:33: Compile class "work@process".
+
+[INF:CP0302] builtin.sv:58: Compile class "work@semaphore".
+
+[INF:EL0526] Design Elaboration...
+
+[NTE:EL0503] dut.sv:33: Top level module "work@top".
+
+[NTE:EL0508] Nb Top level modules: 1.
+
+[NTE:EL0509] Max instance depth: 1.
+
+[NTE:EL0510] Nb instances: 1.
+
+[NTE:EL0511] Nb leaf instances: 1.
+
+UHDM HTML COVERAGE REPORT: ../../build/tests/StructVarImp/slpp_all//surelog.uhdm.chk
+====== UHDM =======
+design: (work@top)
+|vpiName:work@top
+|uhdmallPackages:
+\_package: builtin, parent:work@top
+  |vpiDefName:builtin
+  |vpiFullName:builtin
+|uhdmallPackages:
+\_package: flash_ctrl_reg_pkg, file:dut.sv, line:1, parent:work@top
+  |vpiDefName:flash_ctrl_reg_pkg
+  |vpiFullName:flash_ctrl_reg_pkg
+  |vpiTypedef:
+  \_struct_typespec: (flash_ctrl_reg2hw_mp_region_cfg_mreg_t), line:7
+    |vpiPacked:1
+    |vpiName:flash_ctrl_reg2hw_mp_region_cfg_mreg_t
+    |vpiTypespecMember:
+    \_typespec_member: (en), line:10
+      |vpiName:en
+      |vpiTypespec:
+      \_struct_typespec: , line:8
+        |vpiPacked:1
+        |vpiTypespecMember:
+        \_typespec_member: (q), line:9
+          |vpiName:q
+          |vpiTypespec:
+          \_logic_typespec: , line:9
+    |vpiTypespecMember:
+    \_typespec_member: (rd_en), line:13
+      |vpiName:rd_en
+      |vpiTypespec:
+      \_struct_typespec: , line:11
+        |vpiPacked:1
+        |vpiTypespecMember:
+        \_typespec_member: (q), line:12
+          |vpiName:q
+          |vpiTypespec:
+          \_logic_typespec: , line:12
+    |vpiTypespecMember:
+    \_typespec_member: (prog_en), line:16
+      |vpiName:prog_en
+      |vpiTypespec:
+      \_struct_typespec: , line:14
+        |vpiPacked:1
+        |vpiTypespecMember:
+        \_typespec_member: (q), line:15
+          |vpiName:q
+          |vpiTypespec:
+          \_logic_typespec: , line:15
+    |vpiTypespecMember:
+    \_typespec_member: (erase_en), line:19
+      |vpiName:erase_en
+      |vpiTypespec:
+      \_struct_typespec: , line:17
+        |vpiPacked:1
+        |vpiTypespecMember:
+        \_typespec_member: (q), line:18
+          |vpiName:q
+          |vpiTypespec:
+          \_logic_typespec: , line:18
+    |vpiTypespecMember:
+    \_typespec_member: (base), line:22
+      |vpiName:base
+      |vpiTypespec:
+      \_struct_typespec: , line:20
+        |vpiPacked:1
+        |vpiTypespecMember:
+        \_typespec_member: (q), line:21
+          |vpiName:q
+          |vpiTypespec:
+          \_logic_typespec: , line:21
+            |vpiRange:
+            \_range: , line:21
+              |vpiLeftRange:
+              \_constant: , line:21
+                |vpiConstType:7
+                |vpiDecompile:8
+                |vpiSize:32
+                |INT:8
+              |vpiRightRange:
+              \_constant: , line:21
+                |vpiConstType:7
+                |vpiDecompile:0
+                |vpiSize:32
+                |INT:0
+    |vpiTypespecMember:
+    \_typespec_member: (size), line:25
+      |vpiName:size
+      |vpiTypespec:
+      \_struct_typespec: , line:23
+        |vpiPacked:1
+        |vpiTypespecMember:
+        \_typespec_member: (q), line:24
+          |vpiName:q
+          |vpiTypespec:
+          \_logic_typespec: , line:24
+            |vpiRange:
+            \_range: , line:24
+              |vpiLeftRange:
+              \_constant: , line:24
+                |vpiConstType:7
+                |vpiDecompile:8
+                |vpiSize:32
+                |INT:8
+              |vpiRightRange:
+              \_constant: , line:24
+                |vpiConstType:7
+                |vpiDecompile:0
+                |vpiSize:32
+                |INT:0
+  |vpiParamAssign:
+  \_param_assign: , line:4
+    |vpiRhs:
+    \_constant: , line:4
+      |vpiConstType:7
+      |vpiDecompile:2
+      |vpiSize:32
+      |INT:2
+    |vpiLhs:
+    \_parameter: (NBanks), line:4
+      |vpiName:NBanks
+      |vpiFullName:flash_ctrl_reg_pkg::NBanks
+      |vpiTypespec:
+      \_int_typespec: , line:4
+  |vpiParamAssign:
+  \_param_assign: , line:5
+    |vpiRhs:
+    \_constant: , line:5
+      |vpiConstType:7
+      |vpiDecompile:8
+      |vpiSize:32
+      |INT:8
+    |vpiLhs:
+    \_parameter: (NumRegions), line:5
+      |vpiName:NumRegions
+      |vpiFullName:flash_ctrl_reg_pkg::NumRegions
+      |vpiTypespec:
+      \_int_typespec: , line:5
+  |vpiParameter:
+  \_parameter: (NBanks), line:4
+  |vpiParameter:
+  \_parameter: (NumRegions), line:5
+|uhdmallClasses:
+\_class_defn: (builtin::array)
+  |vpiName:builtin::array
+  |vpiFullName:builtin::builtin::array
+|uhdmallClasses:
+\_class_defn: (builtin::queue)
+  |vpiName:builtin::queue
+  |vpiFullName:builtin::builtin::queue
+|uhdmallClasses:
+\_class_defn: (builtin::string)
+  |vpiName:builtin::string
+  |vpiFullName:builtin::builtin::string
+|uhdmallClasses:
+\_class_defn: (builtin::system)
+  |vpiName:builtin::system
+  |vpiFullName:builtin::builtin::system
+|uhdmallClasses:
+\_class_defn: (work@mailbox), file:${SURELOG_DIR}/build/bin/sv/builtin.sv, line:4, parent:work@top
+  |vpiName:work@mailbox
+|uhdmallClasses:
+\_class_defn: (work@process), file:${SURELOG_DIR}/build/bin/sv/builtin.sv, line:33, parent:work@top
+  |vpiName:work@process
+|uhdmallClasses:
+\_class_defn: (work@semaphore), file:${SURELOG_DIR}/build/bin/sv/builtin.sv, line:58, parent:work@top
+  |vpiName:work@semaphore
+|uhdmallModules:
+\_module: work@top, file:dut.sv, line:33, parent:work@top
+  |vpiDefName:work@top
+  |vpiFullName:work@top
+  |vpiNet:
+  \_logic_net: (region_cfgs), line:36
+    |vpiName:region_cfgs
+    |vpiFullName:work@top.region_cfgs
+  |vpiTypedef:
+  \_struct_typespec: (flash_ctrl_reg2hw_mp_region_cfg_mreg_t), line:7
+    |vpiPacked:1
+    |vpiName:flash_ctrl_reg2hw_mp_region_cfg_mreg_t
+    |vpiTypespecMember:
+    \_typespec_member: (en), line:10
+      |vpiName:en
+      |vpiTypespec:
+      \_struct_typespec: , line:8
+        |vpiPacked:1
+        |vpiTypespecMember:
+        \_typespec_member: (q), line:9
+          |vpiName:q
+          |vpiTypespec:
+          \_logic_typespec: , line:9
+    |vpiTypespecMember:
+    \_typespec_member: (rd_en), line:13
+      |vpiName:rd_en
+      |vpiTypespec:
+      \_struct_typespec: , line:11
+        |vpiPacked:1
+        |vpiTypespecMember:
+        \_typespec_member: (q), line:12
+          |vpiName:q
+          |vpiTypespec:
+          \_logic_typespec: , line:12
+    |vpiTypespecMember:
+    \_typespec_member: (prog_en), line:16
+      |vpiName:prog_en
+      |vpiTypespec:
+      \_struct_typespec: , line:14
+        |vpiPacked:1
+        |vpiTypespecMember:
+        \_typespec_member: (q), line:15
+          |vpiName:q
+          |vpiTypespec:
+          \_logic_typespec: , line:15
+    |vpiTypespecMember:
+    \_typespec_member: (erase_en), line:19
+      |vpiName:erase_en
+      |vpiTypespec:
+      \_struct_typespec: , line:17
+        |vpiPacked:1
+        |vpiTypespecMember:
+        \_typespec_member: (q), line:18
+          |vpiName:q
+          |vpiTypespec:
+          \_logic_typespec: , line:18
+    |vpiTypespecMember:
+    \_typespec_member: (base), line:22
+      |vpiName:base
+      |vpiTypespec:
+      \_struct_typespec: , line:20
+        |vpiPacked:1
+        |vpiTypespecMember:
+        \_typespec_member: (q), line:21
+          |vpiName:q
+          |vpiTypespec:
+          \_logic_typespec: , line:21
+            |vpiRange:
+            \_range: , line:21
+              |vpiLeftRange:
+              \_constant: , line:21
+                |vpiConstType:7
+                |vpiDecompile:8
+                |vpiSize:32
+                |INT:8
+              |vpiRightRange:
+              \_constant: , line:21
+                |vpiConstType:7
+                |vpiDecompile:0
+                |vpiSize:32
+                |INT:0
+    |vpiTypespecMember:
+    \_typespec_member: (size), line:25
+      |vpiName:size
+      |vpiTypespec:
+      \_struct_typespec: , line:23
+        |vpiPacked:1
+        |vpiTypespecMember:
+        \_typespec_member: (q), line:24
+          |vpiName:q
+          |vpiTypespec:
+          \_logic_typespec: , line:24
+            |vpiRange:
+            \_range: , line:24
+              |vpiLeftRange:
+              \_constant: , line:24
+                |vpiConstType:7
+                |vpiDecompile:8
+                |vpiSize:32
+                |INT:8
+              |vpiRightRange:
+              \_constant: , line:24
+                |vpiConstType:7
+                |vpiDecompile:0
+                |vpiSize:32
+                |INT:0
+|uhdmtopModules:
+\_module: work@top (work@top), file:dut.sv, line:33
+  |vpiDefName:work@top
+  |vpiName:work@top
+  |vpiVariables:
+  \_packed_array_var: (region_cfgs), line:36, parent:work@top
+    |vpiName:region_cfgs
+    |vpiFullName:work@top.region_cfgs
+    |vpiRange:
+    \_range: , line:36
+      |vpiLeftRange:
+      \_ref_obj: (MpRegions), line:36
+        |vpiName:MpRegions
+      |vpiRightRange:
+      \_constant: , line:36
+        |vpiConstType:7
+        |vpiDecompile:0
+        |vpiSize:32
+        |INT:0
+    |vpiElement:
+    \_struct_var: , parent:region_cfgs
+      |vpiFullName:work@top.region_cfgs
+      |vpiTypespec:
+      \_struct_typespec: (flash_ctrl_reg2hw_mp_region_cfg_mreg_t), line:7
+        |vpiPacked:1
+        |vpiName:flash_ctrl_reg2hw_mp_region_cfg_mreg_t
+        |vpiTypespecMember:
+        \_typespec_member: (en), line:10
+          |vpiName:en
+          |vpiTypespec:
+          \_struct_typespec: , line:8
+            |vpiPacked:1
+            |vpiTypespecMember:
+            \_typespec_member: (q), line:9
+              |vpiName:q
+              |vpiTypespec:
+              \_logic_typespec: , line:9
+        |vpiTypespecMember:
+        \_typespec_member: (rd_en), line:13
+          |vpiName:rd_en
+          |vpiTypespec:
+          \_struct_typespec: , line:11
+            |vpiPacked:1
+            |vpiTypespecMember:
+            \_typespec_member: (q), line:12
+              |vpiName:q
+              |vpiTypespec:
+              \_logic_typespec: , line:12
+        |vpiTypespecMember:
+        \_typespec_member: (prog_en), line:16
+          |vpiName:prog_en
+          |vpiTypespec:
+          \_struct_typespec: , line:14
+            |vpiPacked:1
+            |vpiTypespecMember:
+            \_typespec_member: (q), line:15
+              |vpiName:q
+              |vpiTypespec:
+              \_logic_typespec: , line:15
+        |vpiTypespecMember:
+        \_typespec_member: (erase_en), line:19
+          |vpiName:erase_en
+          |vpiTypespec:
+          \_struct_typespec: , line:17
+            |vpiPacked:1
+            |vpiTypespecMember:
+            \_typespec_member: (q), line:18
+              |vpiName:q
+              |vpiTypespec:
+              \_logic_typespec: , line:18
+        |vpiTypespecMember:
+        \_typespec_member: (base), line:22
+          |vpiName:base
+          |vpiTypespec:
+          \_struct_typespec: , line:20
+            |vpiPacked:1
+            |vpiTypespecMember:
+            \_typespec_member: (q), line:21
+              |vpiName:q
+              |vpiTypespec:
+              \_logic_typespec: , line:21
+                |vpiRange:
+                \_range: , line:21
+                  |vpiLeftRange:
+                  \_constant: , line:21
+                    |vpiConstType:7
+                    |vpiDecompile:8
+                    |vpiSize:32
+                    |INT:8
+                  |vpiRightRange:
+                  \_constant: , line:21
+                    |vpiConstType:7
+                    |vpiDecompile:0
+                    |vpiSize:32
+                    |INT:0
+        |vpiTypespecMember:
+        \_typespec_member: (size), line:25
+          |vpiName:size
+          |vpiTypespec:
+          \_struct_typespec: , line:23
+            |vpiPacked:1
+            |vpiTypespecMember:
+            \_typespec_member: (q), line:24
+              |vpiName:q
+              |vpiTypespec:
+              \_logic_typespec: , line:24
+                |vpiRange:
+                \_range: , line:24
+                  |vpiLeftRange:
+                  \_constant: , line:24
+                    |vpiConstType:7
+                    |vpiDecompile:8
+                    |vpiSize:32
+                    |INT:8
+                  |vpiRightRange:
+                  \_constant: , line:24
+                    |vpiConstType:7
+                    |vpiDecompile:0
+                    |vpiSize:32
+                    |INT:0
+  |vpiTypedef:
+  \_struct_typespec: (flash_ctrl_reg2hw_mp_region_cfg_mreg_t), line:7
+    |vpiPacked:1
+    |vpiName:flash_ctrl_reg2hw_mp_region_cfg_mreg_t
+    |vpiTypespecMember:
+    \_typespec_member: (en), line:10, parent:flash_ctrl_reg2hw_mp_region_cfg_mreg_t
+      |vpiName:en
+      |vpiTypespec:
+      \_struct_typespec: , line:8, parent:en
+        |vpiPacked:1
+        |vpiTypespecMember:
+        \_typespec_member: (q), line:9
+          |vpiName:q
+          |vpiTypespec:
+          \_logic_typespec: , line:9, parent:q
+    |vpiTypespecMember:
+    \_typespec_member: (rd_en), line:13, parent:flash_ctrl_reg2hw_mp_region_cfg_mreg_t
+      |vpiName:rd_en
+      |vpiTypespec:
+      \_struct_typespec: , line:11, parent:rd_en
+        |vpiPacked:1
+        |vpiTypespecMember:
+        \_typespec_member: (q), line:12
+          |vpiName:q
+          |vpiTypespec:
+          \_logic_typespec: , line:12, parent:q
+    |vpiTypespecMember:
+    \_typespec_member: (prog_en), line:16, parent:flash_ctrl_reg2hw_mp_region_cfg_mreg_t
+      |vpiName:prog_en
+      |vpiTypespec:
+      \_struct_typespec: , line:14, parent:prog_en
+        |vpiPacked:1
+        |vpiTypespecMember:
+        \_typespec_member: (q), line:15
+          |vpiName:q
+          |vpiTypespec:
+          \_logic_typespec: , line:15, parent:q
+    |vpiTypespecMember:
+    \_typespec_member: (erase_en), line:19, parent:flash_ctrl_reg2hw_mp_region_cfg_mreg_t
+      |vpiName:erase_en
+      |vpiTypespec:
+      \_struct_typespec: , line:17, parent:erase_en
+        |vpiPacked:1
+        |vpiTypespecMember:
+        \_typespec_member: (q), line:18
+          |vpiName:q
+          |vpiTypespec:
+          \_logic_typespec: , line:18, parent:q
+    |vpiTypespecMember:
+    \_typespec_member: (base), line:22, parent:flash_ctrl_reg2hw_mp_region_cfg_mreg_t
+      |vpiName:base
+      |vpiTypespec:
+      \_struct_typespec: , line:20, parent:base
+        |vpiPacked:1
+        |vpiTypespecMember:
+        \_typespec_member: (q), line:21
+          |vpiName:q
+          |vpiTypespec:
+          \_logic_typespec: , line:21, parent:q
+            |vpiRange:
+            \_range: , line:21
+              |vpiLeftRange:
+              \_constant: , line:21
+                |vpiConstType:7
+                |vpiDecompile:8
+                |vpiSize:32
+                |INT:8
+              |vpiRightRange:
+              \_constant: , line:21
+                |vpiConstType:7
+                |vpiDecompile:0
+                |vpiSize:32
+                |INT:0
+    |vpiTypespecMember:
+    \_typespec_member: (size), line:25, parent:flash_ctrl_reg2hw_mp_region_cfg_mreg_t
+      |vpiName:size
+      |vpiTypespec:
+      \_struct_typespec: , line:23, parent:size
+        |vpiPacked:1
+        |vpiTypespecMember:
+        \_typespec_member: (q), line:24
+          |vpiName:q
+          |vpiTypespec:
+          \_logic_typespec: , line:24, parent:q
+            |vpiRange:
+            \_range: , line:24
+              |vpiLeftRange:
+              \_constant: , line:24
+                |vpiConstType:7
+                |vpiDecompile:8
+                |vpiSize:32
+                |INT:8
+              |vpiRightRange:
+              \_constant: , line:24
+                |vpiConstType:7
+                |vpiDecompile:0
+                |vpiSize:32
+                |INT:0
+  |vpiParameter:
+  \_parameter: (NBanks), line:4
+    |vpiName:NBanks
+    |INT:2
+  |vpiParameter:
+  \_parameter: (NumRegions), line:5
+    |vpiName:NumRegions
+    |INT:8
+===================
+[  FATAL] : 0
+[ SYNTAX] : 0
+[  ERROR] : 0
+[WARNING] : 2
+[   NOTE] : 5
+

--- a/tests/StructVarImp/StructVarImp.sl
+++ b/tests/StructVarImp/StructVarImp.sl
@@ -1,0 +1,1 @@
+-parse -d uhdm -d coveruhdm -elabuhdm -d ast dut.sv

--- a/tests/StructVarImp/dut.sv
+++ b/tests/StructVarImp/dut.sv
@@ -1,0 +1,38 @@
+package flash_ctrl_reg_pkg;
+
+  // Param list
+  parameter int NBanks = 2;
+  parameter int NumRegions = 8;
+
+  typedef struct packed {
+    struct packed {
+      logic        q;
+    } en;
+    struct packed {
+      logic        q;
+    } rd_en;
+    struct packed {
+      logic        q;
+    } prog_en;
+    struct packed {
+      logic        q;
+    } erase_en;
+    struct packed {
+      logic [8:0]  q;
+    } base;
+    struct packed {
+      logic [8:0]  q;
+    } size;
+  } flash_ctrl_reg2hw_mp_region_cfg_mreg_t;
+
+  
+endpackage
+
+
+
+module top ();
+  import flash_ctrl_reg_pkg::*;
+
+  flash_ctrl_reg2hw_mp_region_cfg_mreg_t [MpRegions:0] region_cfgs;
+
+endmodule  

--- a/third_party/tests/ariane/Ariane.log
+++ b/third_party/tests/ariane/Ariane.log
@@ -4066,6 +4066,140 @@ there are 2 more instances of this message.
 [WRN:EL0513] Nb undefined instances: 4.
 
 UHDM HTML COVERAGE REPORT: work-ver/slpp_all//surelog.uhdm.chk
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/ariane.sv:90: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/ariane.sv:96: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/ariane.sv:101: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/ariane.sv:176: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/ariane.sv:202: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/ariane.sv:207: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/ariane.sv:253: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/ariane.sv:257: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/ariane.sv:262: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/ariane.sv:321: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/ariane.sv:366: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/ariane.sv:371: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/ariane.sv:376: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/ariane.sv:421: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/ariane.sv:523: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/ariane.sv:549: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/ariane.sv:562: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/controller.sv:132: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:147: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:160: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:174: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:182: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:185: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:207: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:216: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:225: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:232: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:238: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:274: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:279: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:293: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:296: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:315: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:320: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:323: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:328: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:337: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:348: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:355: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:363: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:367: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:370: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:375: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:410: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:429: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:471: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:479: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:482: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:487: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:489: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:491: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:503: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:528: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:535: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:555: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:564: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:568: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:571: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:575: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:581: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:584: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:602: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:608: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:616: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:620: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:624: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:636: UHDM coverage pointing to empty source line.
+
 [ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_divsqrt_multi.sv:126: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_divsqrt_multi.sv:133: UHDM coverage pointing to empty source line.
@@ -4089,6 +4223,46 @@ UHDM HTML COVERAGE REPORT: work-ver/slpp_all//surelog.uhdm.chk
 [ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_divsqrt_multi.sv:291: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_divsqrt_multi.sv:303: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/cache_subsystem/wt_cache_subsystem.sv:64: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/cache_subsystem/wt_cache_subsystem.sv:69: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/cache_subsystem/wt_cache_subsystem.sv:73: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/cache_subsystem/wt_cache_subsystem.sv:178: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/cache_subsystem/wt_cache_subsystem.sv:184: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/include/wt_cache_pkg.sv:63: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/include/wt_cache_pkg.sv:67: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/include/wt_cache_pkg.sv:75: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/include/wt_cache_pkg.sv:102: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/include/wt_cache_pkg.sv:110: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/include/wt_cache_pkg.sv:115: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/include/wt_cache_pkg.sv:130: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/include/wt_cache_pkg.sv:149: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/include/wt_cache_pkg.sv:197: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/include/wt_cache_pkg.sv:216: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/include/wt_cache_pkg.sv:252: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/include/wt_cache_pkg.sv:261: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/include/wt_cache_pkg.sv:270: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/include/wt_cache_pkg.sv:280: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/include/wt_cache_pkg.sv:290: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/include/ariane_pkg.sv:167: UHDM coverage pointing to empty source line.
 
@@ -4168,71 +4342,243 @@ UHDM HTML COVERAGE REPORT: work-ver/slpp_all//surelog.uhdm.chk
 
 [ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/include/ariane_pkg.sv:795: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/include/wt_cache_pkg.sv:63: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_node.sv:220: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/include/wt_cache_pkg.sv:67: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_node.sv:222: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/include/wt_cache_pkg.sv:75: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_node.sv:228: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/include/wt_cache_pkg.sv:102: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_node.sv:234: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/include/wt_cache_pkg.sv:110: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_node.sv:240: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/include/wt_cache_pkg.sv:115: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_node.sv:246: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/include/wt_cache_pkg.sv:130: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_node.sv:254: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/include/wt_cache_pkg.sv:149: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_node.sv:260: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/include/wt_cache_pkg.sv:197: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_node.sv:274: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/include/wt_cache_pkg.sv:216: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_node.sv:283: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/include/wt_cache_pkg.sv:252: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_node.sv:286: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/include/wt_cache_pkg.sv:261: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_node.sv:397: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/include/wt_cache_pkg.sv:270: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_node.sv:404: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/include/wt_cache_pkg.sv:280: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_node.sv:408: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/include/wt_cache_pkg.sv:290: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_node.sv:461: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/ariane.sv:90: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_node.sv:470: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/ariane.sv:96: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_node.sv:473: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/ariane.sv:101: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_node.sv:481: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/ariane.sv:176: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_node.sv:583: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/ariane.sv:202: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:163: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/ariane.sv:207: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:170: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/ariane.sv:253: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:172: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/ariane.sv:257: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:179: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/ariane.sv:262: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:182: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/ariane.sv:321: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:209: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/ariane.sv:366: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:223: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/ariane.sv:371: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:231: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/ariane.sv:376: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:234: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/ariane.sv:421: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:265: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/ariane.sv:523: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:274: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/ariane.sv:549: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:281: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/ariane.sv:562: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:285: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/controller.sv:132: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:292: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:296: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:300: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:305: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:348: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:355: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:360: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:375: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:378: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:397: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:402: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:405: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:410: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:419: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:430: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:432: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:436: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:444: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:448: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:451: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:456: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:493: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:513: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:557: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:565: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:568: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:573: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:575: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:577: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:589: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:614: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:621: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:641: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:648: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:651: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:654: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:657: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:661: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:665: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:671: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:674: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:676: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:681: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:685: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:702: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:705: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:721: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:727: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:733: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:748: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:755: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:763: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:767: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:771: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:783: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_opgroup_multifmt_slice.sv:127: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_opgroup_multifmt_slice.sv:383: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_opgroup_multifmt_slice.sv:394: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_opgroup_multifmt_slice.sv:398: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_opgroup_multifmt_slice.sv:402: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_opgroup_multifmt_slice.sv:404: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:127: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:132: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:145: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:151: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:155: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:160: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:162: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:167: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:174: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:181: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:184: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:188: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:200: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:203: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:210: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:216: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:219: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:237: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:244: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:252: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:276: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:283: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:303: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:311: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:344: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:359: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_cast_multi.sv:167: UHDM coverage pointing to empty source line.
 
@@ -4375,352 +4721,6 @@ UHDM HTML COVERAGE REPORT: work-ver/slpp_all//surelog.uhdm.chk
 [ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_cast_multi.sv:708: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_cast_multi.sv:721: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:127: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:132: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:145: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:151: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:155: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:160: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:162: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:167: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:174: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:181: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:184: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:188: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:200: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:203: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:210: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:216: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:219: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:237: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:244: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:252: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:276: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:283: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:303: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:311: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:344: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:359: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_opgroup_multifmt_slice.sv:127: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_opgroup_multifmt_slice.sv:383: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_opgroup_multifmt_slice.sv:394: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_opgroup_multifmt_slice.sv:398: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_opgroup_multifmt_slice.sv:402: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_opgroup_multifmt_slice.sv:404: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:163: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:170: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:172: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:179: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:182: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:209: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:223: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:231: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:234: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:265: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:274: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:281: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:285: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:292: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:296: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:300: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:305: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:348: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:355: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:360: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:375: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:378: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:397: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:402: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:405: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:410: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:419: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:430: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:432: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:436: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:444: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:448: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:451: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:456: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:493: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:513: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:557: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:565: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:568: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:573: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:575: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:577: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:589: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:614: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:621: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:641: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:648: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:651: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:654: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:657: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:661: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:665: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:671: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:674: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:676: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:681: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:685: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:702: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:705: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:721: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:727: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:733: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:748: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:755: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:763: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:767: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:771: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:783: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:147: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:160: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:174: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:182: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:185: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:207: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:216: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:225: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:232: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:238: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:274: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:279: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:293: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:296: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:315: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:320: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:323: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:328: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:337: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:348: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:355: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:363: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:367: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:370: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:375: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:410: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:429: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:471: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:479: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:482: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:487: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:489: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:491: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:503: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:528: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:535: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:555: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:564: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:568: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:571: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:575: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:581: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:584: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:602: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:608: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:616: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:620: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:624: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:636: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/cache_subsystem/wt_cache_subsystem.sv:64: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/cache_subsystem/wt_cache_subsystem.sv:69: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/cache_subsystem/wt_cache_subsystem.sv:73: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/cache_subsystem/wt_cache_subsystem.sv:178: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/cache_subsystem/wt_cache_subsystem.sv:184: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_node.sv:220: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_node.sv:222: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_node.sv:228: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_node.sv:234: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_node.sv:240: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_node.sv:246: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_node.sv:254: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_node.sv:260: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_node.sv:274: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_node.sv:283: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_node.sv:286: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_node.sv:397: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_node.sv:404: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_node.sv:408: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_node.sv:461: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_node.sv:470: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_node.sv:473: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_node.sv:481: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_node.sv:583: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpga-support/rtl/SyncSpRamBeNx64.sv:134: UHDM coverage pointing to empty source line.
 


### PR DESCRIPTION
Fixes #697.
One point though, right now, it creates a packed_struct_var and a struct var where the struct actually contains only logic elements,
so it is a struct net. 
A finer analysis of the content of the struct would be necessary to classify it. 
It should not have a major impact on downstream tools. If it does, then open a new case.
