### PR TITLE
Emit empty lines for comments in inactive blocks.

### DIFF
--- a/src/SourceCompile/SV3_1aPpTreeShapeListener.cpp
+++ b/src/SourceCompile/SV3_1aPpTreeShapeListener.cpp
@@ -131,6 +131,8 @@ void SV3_1aPpTreeShapeListener::exitComments(SV3_1aPpParser::CommentsContext * c
       } else if (ctx->One_line_comment()) {
         addVObject (ctx, ctx->One_line_comment()->getText(), VObjectType::slComments);
       }
+    } else {
+      addLineFiller(ctx);
     }
   }
 }


### PR DESCRIPTION
Fixes #715

Signed-off-by: Henner Zeller <h.zeller@acm.org>