### PR TITLE
Export built-in methods

### DIFF
--- a/src/DesignCompile/CompileExpression.cpp
+++ b/src/DesignCompile/CompileExpression.cpp
@@ -2679,18 +2679,26 @@ UHDM::any* CompileHelper::compileComplexFuncCall(
         fcall->VpiName(method_name);
 
         NodeId list_of_arguments = fC->Sibling(fC->Child(fC->Child(method_child)));
-        VectorOfany* arguments = compileTfCallArguments(
-            component, fC, list_of_arguments, compileDesign, fcall);
-        fcall->Tf_call_args(arguments);
+        NodeId with_conditions_node;
+        if (fC->Type(list_of_arguments) == slList_of_arguments) {
+          VectorOfany* arguments = compileTfCallArguments(
+              component, fC, list_of_arguments, compileDesign, fcall);
+          fcall->Tf_call_args(arguments);
+          with_conditions_node = fC->Sibling(list_of_arguments);
+        } else {
+          with_conditions_node = list_of_arguments;
+        }
         // vpiWith: with conditions (expression in node u<62> above)
-        NodeId with_conditions_node = fC->Sibling(list_of_arguments);
-        expr* with_conditions = (expr*)compileExpression(component,
-                                                         fC,
-                                                         with_conditions_node,
-                                                         compileDesign,
-                                                         pexpr,
-                                                         instance);
-        fcall->With(with_conditions);
+        // (not in every method, node id is 0 if missing)
+        if (with_conditions_node != 0) {
+          expr* with_conditions = (expr*)compileExpression(component,
+                                                           fC,
+                                                           with_conditions_node,
+                                                           compileDesign,
+                                                           pexpr,
+                                                           instance);
+          fcall->With(with_conditions);
+        }
 
         // vpiPrefix: object to which the method is being applied (sval here)
         ref_obj* ref = s.MakeRef_obj();

--- a/src/DesignCompile/CompileExpression.cpp
+++ b/src/DesignCompile/CompileExpression.cpp
@@ -2639,9 +2639,67 @@ UHDM::any* CompileHelper::compileComplexFuncCall(
     const std::string& sval = fC->SymName(name);
     NodeId selectName = fC->Sibling(dotedName);
     if (fC->Type(selectName) == slMethod_call_body) {
-      // TODO:
+      // Example tree
+      //
+      // Verilog:
+      //   a.find(i) with (i<5);
+      //
+      // AST:
+      //   n<a> u<43> t<StringConst> p<66> s<45> l<4>
+      //   n<> u<44> t<Bit_select> p<45> l<4>
+      //   n<> u<45> t<Select> p<66> c<44> s<65> l<4>
+      //   n<find> u<46> t<StringConst> p<47> l<4>
+      //   n<> u<47> t<Array_method_name> p<63> c<46> s<52> l<4>
+      //   n<i> u<48> t<StringConst> p<49> l<4>
+      //   n<> u<49> t<Primary_literal> p<50> c<48> l<4>
+      //   n<> u<50> t<Primary> p<51> c<49> l<4>
+      //   n<> u<51> t<Expression> p<52> c<50> l<4>
+      //   n<> u<52> t<List_of_arguments> p<63> c<51> s<62> l<4>
+      //   n<i> u<53> t<StringConst> p<54> l<4>
+      //   n<> u<54> t<Primary_literal> p<55> c<53> l<4>
+      //   n<> u<55> t<Primary> p<56> c<54> l<4>
+      //   n<> u<56> t<Expression> p<62> c<55> s<61> l<4>
+      //   n<5> u<57> t<IntConst> p<58> l<4>
+      //   n<> u<58> t<Primary_literal> p<59> c<57> l<4>
+      //   n<> u<59> t<Primary> p<60> c<58> l<4>
+      //   n<> u<60> t<Expression> p<62> c<59> l<4>
+      //   n<> u<61> t<BinOp_Less> p<62> s<60> l<4>
+      //   n<> u<62> t<Expression> p<63> c<56> l<4>
+      //   n<> u<63> t<Array_manipulation_call> p<64> c<47> l<4>
+      //   n<> u<64> t<Built_in_method_call> p<65> c<63> l<4>
+      //   n<> u<65> t<Method_call_body> p<66> c<64> l<4>
+      //   n<> u<66> t<Complex_func_call> p<67> c<43> l<4>
+
       method_func_call* fcall = s.MakeMethod_func_call();
-      fcall->VpiName(sval);
+      NodeId method_child = fC->Child(selectName);
+      if (fC->Type(method_child) == slBuilt_in_method_call) {
+        // vpiName: method name (Array_method_name above)
+        NodeId method_name_node = fC->Child(fC->Child(fC->Child(method_child)));
+        const std::string& method_name = fC->SymName(method_name_node);
+        fcall->VpiName(method_name);
+
+        NodeId list_of_arguments = fC->Sibling(fC->Child(fC->Child(method_child)));
+        VectorOfany* arguments = compileTfCallArguments(
+            component, fC, list_of_arguments, compileDesign, fcall);
+        fcall->Tf_call_args(arguments);
+        // vpiWith: with conditions (expression in node u<62> above)
+        NodeId with_conditions_node = fC->Sibling(list_of_arguments);
+        expr* with_conditions = (expr*)compileExpression(component,
+                                                         fC,
+                                                         with_conditions_node,
+                                                         compileDesign,
+                                                         pexpr,
+                                                         instance);
+        fcall->With(with_conditions);
+
+        // vpiPrefix: object to which the method is being applied (sval here)
+        ref_obj* ref = s.MakeRef_obj();
+        ref->VpiName(sval);
+        fcall->Prefix(ref);
+      } else {
+        // TODO: non-builtin methods
+        fcall->VpiName(sval);
+      }
       result = fcall;
     } else if (selectName) {
       // This is deviating from the standard VPI, in the standard VPI the


### PR DESCRIPTION
This PR adds support for built-in methods, like array `find() with`, to the expression compiler.