### PR TITLE
Delegate method handling for this, super etc.

### DIFF
--- a/src/DesignCompile/CompileExpression.cpp
+++ b/src/DesignCompile/CompileExpression.cpp
@@ -2520,6 +2520,18 @@ UHDM::any* CompileHelper::compileComplexFuncCall(
         cvar->VpiDecompile("this");
         result = cvar;
       }
+    } else if (fC->Type(List_of_arguments) == slConstant_bit_select) {
+      // TODO: Fill this
+      method_func_call* fcall = s.MakeMethod_func_call();
+      expr* object = (expr*)compileExpression(
+          component, fC, Handle, compileDesign, pexpr, instance, reduce);
+      VectorOfany* arguments = compileTfCallArguments(
+          component, fC, fC->Sibling(fC->Sibling(List_of_arguments)), compileDesign, fcall);
+      // TODO: make name part of the prefix, get vpiName from sibling
+      fcall->Prefix(object);
+      fcall->VpiName(name);
+      fcall->Tf_call_args(arguments);
+      result = fcall;
     } else if (fC->Type(List_of_arguments) == slStringConst) {
       // TODO: this is a mockup
       constant* cvar = s.MakeConstant();

--- a/src/DesignCompile/CompileExpression.cpp
+++ b/src/DesignCompile/CompileExpression.cpp
@@ -2723,8 +2723,7 @@ UHDM::any* CompileHelper::compileComplexFuncCall(
                                        compileDesign, pexpr, instance);
     }
   } else {
-    tf_call* call = compileTfCall(component, fC, nodeId, compileDesign);
-    result = call;
+    result = compileTfCall(component, fC, nodeId, compileDesign);
   }
   return result;
 }

--- a/src/DesignCompile/CompileHelper.cpp
+++ b/src/DesignCompile/CompileHelper.cpp
@@ -1815,18 +1815,22 @@ UHDM::tf_call* CompileHelper::compileTfCall(DesignComponent* component, const Fi
     name = fC->SymName(fC->Child(dollar_or_string));
   } else if (leaf_type == slImplicit_class_handle) {
     NodeId handle = fC->Child(dollar_or_string);
-    if (fC->Type(handle) == slSuper_keyword) {
-      name = "super.";
-    } else if (fC->Type(handle) == slThis_keyword) {
-      name = "this.";
+    if (fC->Type(handle) == slSuper_keyword ||
+        fC->Type(handle) == slThis_keyword ||
+        fC->Type(handle) == slThis_dot_super) {
+      return (tf_call*) compileComplexFuncCall(component,
+                                               fC,
+                                               Tf_call_stmt,
+                                               compileDesign,
+                                               nullptr,
+                                               nullptr,
+                                               false);
     } else if (fC->Type(handle) == slDollar_root_keyword) {
       name = "$root.";
-    } else if (fC->Type(handle) == slThis_dot_super) {
-      name = "this.super.";
+      tfNameNode = fC->Sibling(dollar_or_string);
+      call = s.MakeSys_func_call();
+      name += fC->SymName(tfNameNode);
     }
-    tfNameNode = fC->Sibling(dollar_or_string);
-    call = s.MakeSys_func_call();
-    name += fC->SymName(tfNameNode);
   } else if (leaf_type == slClass_scope) {
     return (tf_call*) compileComplexFuncCall(component, fC, Tf_call_stmt, compileDesign, nullptr, nullptr, false);
   } else {

--- a/src/DesignCompile/CompileHelper.cpp
+++ b/src/DesignCompile/CompileHelper.cpp
@@ -1762,7 +1762,7 @@ bool CompileHelper::compileParameterDeclaration(DesignComponent* component, cons
   return true;
 }
 
-UHDM::tf_call* CompileHelper::compileTfCall(DesignComponent* component, const FileContent* fC,
+UHDM::any* CompileHelper::compileTfCall(DesignComponent* component, const FileContent* fC,
         NodeId Tf_call_stmt,
         CompileDesign* compileDesign) {
   UHDM::Serializer& s = compileDesign->getSerializer();
@@ -1782,6 +1782,14 @@ UHDM::tf_call* CompileHelper::compileTfCall(DesignComponent* component, const Fi
     tfNameNode = fC->Sibling(dollar_or_string);
     call = s.MakeSys_func_call();
     name = "$" + fC->SymName(tfNameNode);
+  } else if (leaf_type == VObjectType::slImplicit_class_handle) {
+    return compileComplexFuncCall(component,
+                                  fC,
+                                  Tf_call_stmt,
+                                  compileDesign,
+                                  nullptr,
+                                  nullptr,
+                                  false);
   } else if (leaf_type == slDollar_root_keyword) {
     NodeId Dollar_root_keyword = dollar_or_string;
     NodeId nameId = fC->Sibling(Dollar_root_keyword);

--- a/src/DesignCompile/CompileHelper.h
+++ b/src/DesignCompile/CompileHelper.h
@@ -110,7 +110,7 @@ public:
   bool compileAlwaysBlock(DesignComponent* component, const FileContent* fC,
         NodeId id, CompileDesign* compileDesign);
 
-  UHDM::tf_call* compileTfCall(DesignComponent* component, const FileContent* fC,
+  UHDM::any* compileTfCall(DesignComponent* component, const FileContent* fC,
         NodeId Tf_call_stmt,
         CompileDesign* compileDesign);
 

--- a/src/DesignCompile/CompileStmt.cpp
+++ b/src/DesignCompile/CompileStmt.cpp
@@ -108,13 +108,11 @@ VectorOfany* CompileHelper::compileStmt(
   }
   case VObjectType::slSubroutine_call_statement: {
 	  NodeId Subroutine_call = fC->Child(the_stmt);
-    UHDM::tf_call* call = compileTfCall(component, fC, Subroutine_call ,compileDesign);
-	  stmt = call;
+    stmt = compileTfCall(component, fC, Subroutine_call ,compileDesign);
   	break;
   }
   case VObjectType::slSystem_task: {
-    UHDM::tf_call* call = compileTfCall(component, fC, the_stmt, compileDesign);
-    stmt = call;
+    stmt = compileTfCall(component, fC, the_stmt, compileDesign);
     break;
   }
   case VObjectType::slConditional_statement: {

--- a/tests/UnitForeach/UnitForeach.log
+++ b/tests/UnitForeach/UnitForeach.log
@@ -510,8 +510,12 @@ design: (unnamed)
     \_begin: (uvm_pkg::uvm_sequencer_base::do_print), parent:uvm_pkg::uvm_sequencer_base::do_print
       |vpiFullName:uvm_pkg::uvm_sequencer_base::do_print
       |vpiStmt:
-      \_sys_func_call: (super.do_print), line:6, parent:uvm_pkg::uvm_sequencer_base::do_print
-        |vpiName:super.do_print
+      \_method_func_call: (do_print), line:6, parent:uvm_pkg::uvm_sequencer_base::do_print
+        |vpiName:do_print
+        |vpiPrefix:
+        \_constant: , line:6
+          |vpiDecompile:super
+          |STRING:super
         |vpiArgument:
         \_ref_obj: (printer), line:6
           |vpiName:printer

--- a/tests/UnitThisNew/UnitThisNew.log
+++ b/tests/UnitThisNew/UnitThisNew.log
@@ -561,8 +561,12 @@ design: (unnamed)
         \_begin: (toto::uvm_reg_backdoor::start_update_thread), line:38
           |vpiFullName:toto::uvm_reg_backdoor::start_update_thread
           |vpiStmt:
-          \_sys_func_call: (this.kill_update_thread), line:39, parent:toto::uvm_reg_backdoor::start_update_thread
-            |vpiName:this.kill_update_thread
+          \_method_func_call: (kill_update_thread), line:39, parent:toto::uvm_reg_backdoor::start_update_thread
+            |vpiName:kill_update_thread
+            |vpiPrefix:
+            \_constant: , line:39
+              |vpiDecompile:this
+              |STRING:this
             |vpiArgument:
             \_ref_obj: (element), line:39
               |vpiName:element


### PR DESCRIPTION
Compile method calls for these statements in `compileComplexFuncCall`,
which already accounts for the keywords. This prevents leaving them as
plain `vpiSysFuncCall` in UHDM.

Many logs for test cases still need to be updated, but I'd like to have your opinion on this approach. The `compileComplexFuncCall` needs to be expanded as well before merging this, but at least the code responsible for the calls would be kept in one place.