### PR TITLE
Issue #836

### DIFF
--- a/src/API/PythonAPI.cpp
+++ b/src/API/PythonAPI.cpp
@@ -225,6 +225,7 @@ void PythonAPI::initInterp_ () {
 
 void PythonAPI::init(int argc, const char** argv) {
   m_programPath = argv[0];
+  m_programPath = StringUtils::replaceAll(m_programPath, "\\", "/");
   m_programPath = StringUtils::rtrim(m_programPath, '/');
   for (int i = 1; i < argc; i++) {
       if (!strcmp(argv[i], "-builtin")) {


### PR DESCRIPTION
Issue:
Build on windows report the following warings/error which further
down the stream causes regression test failures.

SyntaxError: (unicode error) 'unicodeescape' codec can't decode bytes in position 2-3: truncated \UXXXXXXXX escape

Cause:
String passed to python weren't correctly escaped.

Resolution:
Switched to using forward slashes when dealing with paths to avoid
platform specific issues.