### PR TITLE
Issue #631 - Windows compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,11 +5,13 @@ on:
   pull_request:
 
 jobs:
-
   linux:
     runs-on: ubuntu-latest
-    steps:
+    defaults:
+      run:
+        shell: bash
 
+    steps:
     - uses: actions/checkout@v2
       with:
         submodules: recursive

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 # If you have runtime memory issues, disable tcmalloc: add -DNO_TCMALLOC to the make line
 
+# Use bash as the default shell
+SHELL := /bin/bash
+
 ifeq ($(CPU_CORES),)
 CPU_CORES := $(shell nproc)
 ifeq ($(CPU_CORES),)
@@ -10,32 +13,22 @@ endif
 PREFIX ?= /usr/local
 
 release: run-cmake-release
-	$(MAKE) -C build
-#       Broken on Linux:
-# cmake --build build
+	cmake --build build
 
 debug: run-cmake-debug
-	$(MAKE) -C dbuild
-#       Broken on Linux:
-# cmake --build dbuild
+	cmake --build dbuild
 
 run-cmake-release:
-	mkdir -p build/tests build/dist dist
-	cd build; cmake ../ -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(PREFIX)
-#	mkdir -p build/tests dist
-#	cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(PREFIX) -S . -B build
+	mkdir -p build/tests dist
+	cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(PREFIX) -S . -B build
 
 run-cmake-debug:
-	mkdir -p dbuild/tests dbuild/dist dist
-	cd dbuild; cmake ../ -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$(PREFIX)
-#	mkdir -p dbuild/tests dist
-#	cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$(PREFIX) -S . -B dbuild
+	mkdir -p dbuild/tests dist
+	cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$(PREFIX) -S . -B dbuild
 
 test/unittest: run-cmake-release
-	$(MAKE) -C build UnitTests
-	cd build && ctest --output-on-failure
-#	cmake --build build --target UnitTests
-#	pushd build; ctest --output-on-failure; popd
+	cmake --build build --target UnitTests
+	pushd build; ctest --output-on-failure; popd
 
 test/regression: run-cmake-release
 	cd build; ../tests/regression.tcl mt=0 show_diff
@@ -43,37 +36,30 @@ test/regression: run-cmake-release
 test: test/unittest test/regression
 
 test-parallel: release test/unittest
-	mkdir -p build/tests; cd build; rm -rf test; mkdir test; cd test; ../../tests/cmake_gen.tcl; cmake .; time make -j $(CPU_CORES); cd ..; ../tests/regression.tcl diff_mode show_diff;
-#       Broken on Linux:
-#	mkdir -p build/tests
-#	rm -rf build/test; mkdir build/test
-#	tclsh tests/cmake_gen.tcl `pwd` `pwd`/build/test
-#	cmake -S build/test -B build/test/build
-#	pushd build; cmake --build test/build; popd
-#	pushd build; tclsh ../tests/regression.tcl diff_mode show_diff; popd
+	mkdir -p build/tests
+	rm -rf build/test; mkdir build/test
+	tclsh tests/cmake_gen.tcl `pwd` `pwd`/build/test
+	cmake -S build/test -B build/test/build
+	pushd build; cmake --build test/build; popd
+	pushd build; tclsh ../tests/regression.tcl diff_mode show_diff; popd
 
 regression: release
-	mkdir -p build/tests; cd build; rm -rf test; mkdir test; cd test; ../../tests/cmake_gen.tcl; cmake .; time make -j $(CPU_CORES); cd ..; ../tests/regression.tcl diff_mode show_diff;
-#       Broken on Linux:
-#	mkdir -p build/tests
-#	rm -rf build/test; mkdir build/test
-#	tclsh tests/cmake_gen.tcl `pwd` `pwd`/build/test
-#	cmake -S build/test -B build/test/build
-#	pushd build; cmake --build test/build; popd
-#	pushd build; tclsh ../tests/regression.tcl diff_mode show_diff; popd
+	mkdir -p build/tests
+	rm -rf build/test; mkdir build/test
+	tclsh tests/cmake_gen.tcl `pwd` `pwd`/build/test
+	cmake -S build/test -B build/test/build
+	pushd build; cmake --build test/build; popd
+	pushd build; tclsh ../tests/regression.tcl diff_mode show_diff; popd
 
 clean:
 	rm -rf build dist
 
 install: release
-	$(MAKE) -C build install
-#       Broken on Linux:
-#       cmake --install build
+	cmake --install build
 
 test_install: release
-	cd tests/TestInstall ; rm -rf build; mkdir -p build; cd build; cmake ../ -DINSTALL_DIR=$(PREFIX); make ; ./test_hellosureworld --version
-#        cmake -DCMAKE_BUILD_TYPE=Release -DINSTALL_DIR=`readlink -f ${PREFIX}` -S tests/TestInstall -B tests/TestInstall/build
-#	cmake --build tests/TestInstall/build
+	cmake -DCMAKE_BUILD_TYPE=Release -DINSTALL_DIR=`readlink -f ${PREFIX}` -S tests/TestInstall -B tests/TestInstall/build
+	cmake --build tests/TestInstall/build
 
 uninstall:
 	rm -f  $(PREFIX)/bin/surelog

--- a/tests/cmake_gen.tcl
+++ b/tests/cmake_gen.tcl
@@ -14,10 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set mem [exec sh -c "free -m"]
-set cpu [exec lscpu]
-puts "MEMORY ON HOST:\n$mem"
-puts "CPUs on HOST:\n$cpu"
+#set mem [exec sh -c "free -m"]
+#set cpu [exec lscpu]
+#puts "MEMORY ON HOST:\n$mem"
+#puts "CPUs on HOST:\n$cpu"
+
+set workspace_root [lindex $argv 0]
+set output_dir [lindex $argv 1]
 
 proc findFiles { basedir pattern } {
 
@@ -48,44 +51,44 @@ proc findFiles { basedir pattern } {
 }
 
 proc load_tests { } {
-    global TESTS TESTS_DIR  
-    set dirs "../../tests/ ../../third_party/tests/"
+    global TESTS TESTS_DIR workspace_root
+    set dirs "$workspace_root/tests/ $workspace_root/third_party/tests/"
     set fileLists ""
     foreach dir $dirs {
-	append fileList "[findFiles $dir *.sl] "
+        append fileList "[findFiles $dir *.sl] "
     }
     set testcommand ""
     set LONGESTTESTNAME 1
     set totaltest 0
     foreach file $fileList {
-	regexp {([a-zA-Z0-9_/-]+)/([a-zA-Z0-9_-]+)\.sl} $file tmp testdir testname
-	regsub [pwd]/ $testdir "" testdir
-	incr totaltest
+        regexp {([a-zA-Z0-9_/-]+)/([a-zA-Z0-9_-]+)\.sl} $file tmp testdir testname
+        regsub [pwd]/ $testdir "" testdir
+        incr totaltest
 
-	set fid [open $testdir/$testname.sl]
-	set testcommand [read $fid]
-	close $fid
+        set fid [open $testdir/$testname.sl]
+        set testcommand [read $fid]
+        close $fid
 
-	set TESTS($testname) $testcommand
-	set TESTS_DIR($testname) $testdir
+        set TESTS($testname) $testcommand
+        set TESTS_DIR($testname) $testdir
     }
 }
 
 proc run_regression { } {
-    global TESTS
-    set fid [open "CMakeLists.txt" "w"]
+    global TESTS output_dir workspace_root
+    set fid [open "$output_dir/CMakeLists.txt" "w"]
     puts $fid "cmake_minimum_required (VERSION 3.0)"
     puts $fid "project(SurelogRegression)"
     foreach testname [lsort -dictionary [array names TESTS]] {
-	puts $fid "add_custom_command(OUTPUT $testname"
-	puts $fid "  COMMAND ../tests/regression.tcl path=[file dirname [pwd]]/bin mute test=$testname"
-	puts $fid "  WORKING_DIRECTORY ../"
-	puts $fid ")"
+        puts $fid "add_custom_command(OUTPUT $testname"
+        puts $fid "  COMMAND tclsh $workspace_root/tests/regression.tcl path=$workspace_root/build/bin mute test=$testname"
+        puts $fid "  WORKING_DIRECTORY $workspace_root/build"
+        puts $fid ")"
     }
 
     puts $fid "add_custom_target(Regression ALL DEPENDS"
     foreach testname [lsort -dictionary [array names TESTS]] {
-	puts $fid "  $testname"
+        puts $fid "  $testname"
     }
     puts $fid ")"
 


### PR DESCRIPTION
Reintroducing with change to make bash the default shell
The root cause for the failures was the use of sh shell instead of bash.
Latter is the default but Github Actions defaults to sh.

Issue #631 -

Issue:
Builds and regreession tests failing on Windows

Root Cause:
* Process was defaulting to use Makefile which isn't preferred
  tool on Windows
- tcmalloc wasn't handled correctly in both CMakeLists.txt and
  tests/TestInstall/CMakeLists.txt

Solution:
* Handle tcmalloc usage correctly in CMakefile.txt
* Temporarily install pdbs only for Debug builds
* Update Makefile to not assume default generator for cmake.
  Unix uses Makefiles, but windows uses Ninja.
* Update cmake_gen.tcl to not assume location of generated
  binaries. Instead take it as an argument.