### PR TITLE
Fix packed dimension handling in typespecs

### DIFF
--- a/src/DesignCompile/CompileType.cpp
+++ b/src/DesignCompile/CompileType.cpp
@@ -208,7 +208,12 @@ UHDM::typespec* CompileHelper::compileTypespec(
     type = fC->Child(type);
     the_type = fC->Type(type);
   }
-  NodeId Packed_dimension = fC->Sibling(type);
+  NodeId Packed_dimension;
+  if(the_type == VObjectType::slPacked_dimension) {
+    Packed_dimension = type;
+  } else {
+    Packed_dimension = fC->Sibling(type);
+  }
   int size;
   VectorOfrange* ranges = compileRanges(component, fC, Packed_dimension, compileDesign, pstmt, instance, reduce, size);
   switch (the_type) {

--- a/tests/FSMBsp13/FSMBsp13.log
+++ b/tests/FSMBsp13/FSMBsp13.log
@@ -8535,6 +8535,20 @@ design: (work@top)
       |vpiFullName:work@FSM1.ST_Read
       |vpiTypespec:
       \_bit_typespec: , line:7, parent:work@FSM1.ST_Done
+        |vpiRange:
+        \_range: , line:7
+          |vpiLeftRange:
+          \_constant: , line:7
+            |vpiConstType:7
+            |vpiDecompile:3
+            |vpiSize:64
+            |INT:3
+          |vpiRightRange:
+          \_constant: , line:7
+            |vpiConstType:7
+            |vpiDecompile:0
+            |vpiSize:64
+            |INT:0
   |vpiParamAssign:
   \_param_assign: , line:7, parent:work@FSM1
     |vpiRhs:
@@ -10120,6 +10134,20 @@ design: (work@top)
       |vpiFullName:work@FSM2.ST0
       |vpiTypespec:
       \_bit_typespec: , line:6, parent:work@FSM2.ST10
+        |vpiRange:
+        \_range: , line:6
+          |vpiLeftRange:
+          \_constant: , line:6
+            |vpiConstType:7
+            |vpiDecompile:3
+            |vpiSize:64
+            |INT:3
+          |vpiRightRange:
+          \_constant: , line:6
+            |vpiConstType:7
+            |vpiDecompile:0
+            |vpiSize:64
+            |INT:0
   |vpiParamAssign:
   \_param_assign: , line:6, parent:work@FSM2
     |vpiRhs:
@@ -16061,6 +16089,20 @@ design: (work@top)
         |vpiFullName:work@FSM1.ST_Read
         |vpiTypespec:
         \_bit_typespec: , line:7, parent:work@FSM1.ST_Done
+          |vpiRange:
+          \_range: , line:7
+            |vpiLeftRange:
+            \_constant: , line:7
+              |vpiConstType:7
+              |vpiDecompile:3
+              |vpiSize:64
+              |INT:3
+            |vpiRightRange:
+            \_constant: , line:7
+              |vpiConstType:7
+              |vpiDecompile:0
+              |vpiSize:64
+              |INT:0
     |vpiParamAssign:
     \_param_assign: , line:7, parent:work@FSM1
       |vpiRhs:
@@ -17729,6 +17771,20 @@ design: (work@top)
         |vpiFullName:work@FSM2.ST0
         |vpiTypespec:
         \_bit_typespec: , line:6, parent:work@FSM2.ST10
+          |vpiRange:
+          \_range: , line:6
+            |vpiLeftRange:
+            \_constant: , line:6
+              |vpiConstType:7
+              |vpiDecompile:3
+              |vpiSize:64
+              |INT:3
+            |vpiRightRange:
+            \_constant: , line:6
+              |vpiConstType:7
+              |vpiDecompile:0
+              |vpiSize:64
+              |INT:0
     |vpiParamAssign:
     \_param_assign: , line:6, parent:work@FSM2
       |vpiRhs:

--- a/third_party/tests/SimpleParserTest/SimpleParserTest.log
+++ b/third_party/tests/SimpleParserTest/SimpleParserTest.log
@@ -1040,6 +1040,20 @@ design: (work@dff_async_reset)
       |vpiFullName:work@LFSR_TASK.Chain1
       |vpiTypespec:
       \_bit_typespec: , line:7, parent:work@LFSR_TASK.Chain1
+        |vpiRange:
+        \_range: , line:7
+          |vpiLeftRange:
+          \_constant: , line:7
+            |vpiConstType:7
+            |vpiDecompile:7
+            |vpiSize:64
+            |INT:7
+          |vpiRightRange:
+          \_constant: , line:7
+            |vpiConstType:7
+            |vpiDecompile:0
+            |vpiSize:64
+            |INT:0
   |vpiParamAssign:
   \_param_assign: , line:8, parent:work@LFSR_TASK
     |vpiRhs:
@@ -1054,6 +1068,20 @@ design: (work@dff_async_reset)
       |vpiFullName:work@LFSR_TASK.Chain2
       |vpiTypespec:
       \_bit_typespec: , line:8, parent:work@LFSR_TASK.Chain2
+        |vpiRange:
+        \_range: , line:8
+          |vpiLeftRange:
+          \_constant: , line:8
+            |vpiConstType:7
+            |vpiDecompile:7
+            |vpiSize:64
+            |INT:7
+          |vpiRightRange:
+          \_constant: , line:8
+            |vpiConstType:7
+            |vpiDecompile:0
+            |vpiSize:64
+            |INT:0
   |vpiParameter:
   \_parameter: (work@LFSR_TASK.Chain1), line:7, parent:work@LFSR_TASK
   |vpiParameter:
@@ -9962,6 +9990,20 @@ design: (work@dff_async_reset)
       |vpiFullName:work@LFSR_TASK.Chain1
       |vpiTypespec:
       \_bit_typespec: , line:7, parent:work@LFSR_TASK.Chain1
+        |vpiRange:
+        \_range: , line:7
+          |vpiLeftRange:
+          \_constant: , line:7
+            |vpiConstType:7
+            |vpiDecompile:7
+            |vpiSize:64
+            |INT:7
+          |vpiRightRange:
+          \_constant: , line:7
+            |vpiConstType:7
+            |vpiDecompile:0
+            |vpiSize:64
+            |INT:0
   |vpiParamAssign:
   \_param_assign: , line:8, parent:work@LFSR_TASK
     |vpiRhs:
@@ -9976,6 +10018,20 @@ design: (work@dff_async_reset)
       |vpiFullName:work@LFSR_TASK.Chain2
       |vpiTypespec:
       \_bit_typespec: , line:8, parent:work@LFSR_TASK.Chain2
+        |vpiRange:
+        \_range: , line:8
+          |vpiLeftRange:
+          \_constant: , line:8
+            |vpiConstType:7
+            |vpiDecompile:7
+            |vpiSize:64
+            |INT:7
+          |vpiRightRange:
+          \_constant: , line:8
+            |vpiConstType:7
+            |vpiDecompile:0
+            |vpiSize:64
+            |INT:0
   |vpiParameter:
   \_parameter: (work@LFSR_TASK.Chain1), line:7, parent:work@LFSR_TASK
     |vpiName:Chain1


### PR DESCRIPTION
Change node used to calculate ranges if the typespec uses packed dimensions - in this case the sibling is invalid.