### PR TITLE
Switch UHDM submodule to point back to upstream repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,8 +3,7 @@
 	url = https://github.com/google/flatbuffers.git
 [submodule "third_party/UHDM"]
 	path = third_party/UHDM
-	url = https://github.com/hs-apotell/UHDM.git
-	branch = gha-ci
+	url = https://github.com/alainmarcel/UHDM.git
 [submodule "third_party/googletest"]
 	path = third_party/googletest
 	url = https://github.com/google/googletest.git


### PR DESCRIPTION
This file was not meant to be part of previous merge. UHDM should have been brought uptodate with master to bring in the necessary changes. Reverting it back to previous revision.