### PR TITLE
Fix inconsistency in BIN

### DIFF
--- a/src/DesignCompile/CompileExpression.cpp
+++ b/src/DesignCompile/CompileExpression.cpp
@@ -1018,7 +1018,7 @@ UHDM::any* CompileHelper::compileExpression(
       case VObjectType::slScalar_TickB1:
       case VObjectType::sl1: {
         UHDM::constant* c = s.MakeConstant();
-        std::string value = "BIN:1";
+        std::string value = "BIN:1'b1";
         c->VpiValue(value);
         c->VpiConstType(vpiBinaryConst);
         c->VpiSize(1);
@@ -1039,7 +1039,7 @@ UHDM::any* CompileHelper::compileExpression(
       case VObjectType::slScalar_TickB0:
       case VObjectType::sl0: {
         UHDM::constant* c = s.MakeConstant();
-        std::string value = "BIN:0";
+        std::string value = "BIN:1'b0";
         c->VpiValue(value);
         c->VpiConstType(vpiBinaryConst);
         c->VpiSize(1);
@@ -1057,7 +1057,7 @@ UHDM::any* CompileHelper::compileExpression(
       case VObjectType::slInitVal_1TickBX:
       case VObjectType::slX: {
         UHDM::constant* c = s.MakeConstant();
-        std::string value = "BIN:X";
+        std::string value = "BIN:1'bX";
         c->VpiValue(value);
         c->VpiConstType(vpiBinaryConst);
         c->VpiSize(1);
@@ -1067,7 +1067,7 @@ UHDM::any* CompileHelper::compileExpression(
       }
       case VObjectType::slZ: {
         UHDM::constant* c = s.MakeConstant();
-        std::string value = "BIN:Z";
+        std::string value = "BIN:1'bz";
         c->VpiValue(value);
         c->VpiConstType(vpiBinaryConst);
         c->VpiSize(1);
@@ -1078,7 +1078,7 @@ UHDM::any* CompileHelper::compileExpression(
       case VObjectType::slTime_literal: {
         // TODO:
         UHDM::constant* c = s.MakeConstant();
-        std::string value = "BIN:0";
+        std::string value = "BIN:1'b0";
         c->VpiValue(value);
         c->VpiConstType(vpiBinaryConst);
         c->VpiSize(1);

--- a/tests/BinarySize/BinarySize.log
+++ b/tests/BinarySize/BinarySize.log
@@ -1,0 +1,298 @@
+[INF:CM0023] Creating log file ./slpp_unit/surelog.log.
+
+[INF:CM0020] Separate compilation-unit mode is on.
+
+[WRN:PA0205] dut.sv:1: No timescale set for "top".
+
+[INF:CP0300] Compilation...
+
+[INF:CP0303] dut.sv:1: Compile module "work@top".
+
+[INF:EL0526] Design Elaboration...
+
+[NTE:EL0503] dut.sv:1: Top level module "work@top".
+
+[NTE:EL0508] Nb Top level modules: 1.
+
+[NTE:EL0509] Max instance depth: 1.
+
+[NTE:EL0510] Nb instances: 1.
+
+[NTE:EL0511] Nb leaf instances: 1.
+
+UHDM HTML COVERAGE REPORT: ./slpp_unit//surelog.uhdm.chk.html
+====== UHDM =======
+design: (work@top)
+|vpiName:work@top
+|uhdmallModules:
+\_module: work@top (work@top) dut.sv:1: , parent:work@top
+  |vpiDefName:work@top
+  |vpiFullName:work@top
+  |vpiContAssign:
+  \_cont_assign: , line:3, parent:work@top
+    |vpiRhs:
+    \_constant: , line:3
+      |vpiConstType:3
+      |vpiDecompile:32'b1
+      |vpiSize:32
+      |BIN:32'b1
+    |vpiLhs:
+    \_ref_obj: (work@top.first), line:3
+      |vpiName:first
+      |vpiFullName:work@top.first
+  |vpiContAssign:
+  \_cont_assign: , line:4, parent:work@top
+    |vpiRhs:
+    \_constant: , line:4
+      |vpiConstType:3
+      |vpiDecompile:'b0
+      |vpiSize:1
+      |BIN:1'b0
+    |vpiLhs:
+    \_ref_obj: (work@top.first), line:4
+      |vpiName:first
+      |vpiFullName:work@top.first
+  |vpiContAssign:
+  \_cont_assign: , line:5, parent:work@top
+    |vpiRhs:
+    \_constant: , line:5
+      |vpiConstType:3
+      |vpiDecompile:2'b00
+      |vpiSize:2
+      |BIN:2'b00
+    |vpiLhs:
+    \_ref_obj: (work@top.first), line:5
+      |vpiName:first
+      |vpiFullName:work@top.first
+  |vpiContAssign:
+  \_cont_assign: , line:6, parent:work@top
+    |vpiRhs:
+    \_constant: , line:6
+      |vpiConstType:3
+      |vpiDecompile:'b1
+      |vpiSize:1
+      |BIN:1'b1
+    |vpiLhs:
+    \_ref_obj: (work@top.first), line:6
+      |vpiName:first
+      |vpiFullName:work@top.first
+  |vpiContAssign:
+  \_cont_assign: , line:7, parent:work@top
+    |vpiRhs:
+    \_constant: , line:7
+      |vpiConstType:3
+      |vpiDecompile:2'b01
+      |vpiSize:2
+      |BIN:2'b01
+    |vpiLhs:
+    \_ref_obj: (work@top.first), line:7
+      |vpiName:first
+      |vpiFullName:work@top.first
+  |vpiContAssign:
+  \_cont_assign: , line:8, parent:work@top
+    |vpiRhs:
+    \_constant: , line:8
+      |vpiConstType:3
+      |vpiDecompile:'bX
+      |vpiSize:1
+      |BIN:1'bX
+    |vpiLhs:
+    \_ref_obj: (work@top.first), line:8
+      |vpiName:first
+      |vpiFullName:work@top.first
+  |vpiContAssign:
+  \_cont_assign: , line:9, parent:work@top
+    |vpiRhs:
+    \_constant: , line:9
+      |vpiConstType:3
+      |vpiDecompile:2'b0x
+      |vpiSize:2
+      |BIN:2'b0x
+    |vpiLhs:
+    \_ref_obj: (work@top.first), line:9
+      |vpiName:first
+      |vpiFullName:work@top.first
+  |vpiContAssign:
+  \_cont_assign: , line:10, parent:work@top
+    |vpiRhs:
+    \_constant: , line:10
+      |vpiConstType:3
+      |vpiDecompile:1'bz
+      |vpiSize:1
+      |BIN:1'bz
+    |vpiLhs:
+    \_ref_obj: (work@top.first), line:10
+      |vpiName:first
+      |vpiFullName:work@top.first
+  |vpiContAssign:
+  \_cont_assign: , line:11, parent:work@top
+    |vpiRhs:
+    \_constant: , line:11
+      |vpiConstType:3
+      |vpiDecompile:2'b0z
+      |vpiSize:2
+      |BIN:2'b0z
+    |vpiLhs:
+    \_ref_obj: (work@top.first), line:11
+      |vpiName:first
+      |vpiFullName:work@top.first
+  |vpiNet:
+  \_logic_net: (work@top.first), line:2, parent:work@top
+    |vpiName:first
+    |vpiFullName:work@top.first
+    |vpiNetType:36
+|uhdmtopModules:
+\_module: work@top (work@top) dut.sv:1: 
+  |vpiDefName:work@top
+  |vpiName:work@top
+  |vpiContAssign:
+  \_cont_assign: , line:3, parent:work@top
+    |vpiRhs:
+    \_constant: , line:3
+      |vpiConstType:3
+      |vpiDecompile:32'b1
+      |vpiSize:32
+      |BIN:32'b1
+    |vpiLhs:
+    \_ref_obj: (work@top.first), line:3
+      |vpiName:first
+      |vpiFullName:work@top.first
+      |vpiActual:
+      \_logic_net: (work@top.first), line:2, parent:work@top
+        |vpiName:first
+        |vpiFullName:work@top.first
+        |vpiNetType:36
+        |vpiRange:
+        \_range: , line:2
+          |vpiLeftRange:
+          \_constant: , line:2
+            |vpiConstType:7
+            |vpiDecompile:31
+            |vpiSize:64
+            |INT:31
+          |vpiRightRange:
+          \_constant: , line:2
+            |vpiConstType:7
+            |vpiDecompile:0
+            |vpiSize:64
+            |INT:0
+  |vpiContAssign:
+  \_cont_assign: , line:4, parent:work@top
+    |vpiRhs:
+    \_constant: , line:4
+      |vpiConstType:3
+      |vpiDecompile:'b0
+      |vpiSize:1
+      |BIN:1'b0
+    |vpiLhs:
+    \_ref_obj: (work@top.first), line:4
+      |vpiName:first
+      |vpiFullName:work@top.first
+      |vpiActual:
+      \_logic_net: (work@top.first), line:2, parent:work@top
+  |vpiContAssign:
+  \_cont_assign: , line:5, parent:work@top
+    |vpiRhs:
+    \_constant: , line:5
+      |vpiConstType:3
+      |vpiDecompile:2'b00
+      |vpiSize:2
+      |BIN:2'b00
+    |vpiLhs:
+    \_ref_obj: (work@top.first), line:5
+      |vpiName:first
+      |vpiFullName:work@top.first
+      |vpiActual:
+      \_logic_net: (work@top.first), line:2, parent:work@top
+  |vpiContAssign:
+  \_cont_assign: , line:6, parent:work@top
+    |vpiRhs:
+    \_constant: , line:6
+      |vpiConstType:3
+      |vpiDecompile:'b1
+      |vpiSize:1
+      |BIN:1'b1
+    |vpiLhs:
+    \_ref_obj: (work@top.first), line:6
+      |vpiName:first
+      |vpiFullName:work@top.first
+      |vpiActual:
+      \_logic_net: (work@top.first), line:2, parent:work@top
+  |vpiContAssign:
+  \_cont_assign: , line:7, parent:work@top
+    |vpiRhs:
+    \_constant: , line:7
+      |vpiConstType:3
+      |vpiDecompile:2'b01
+      |vpiSize:2
+      |BIN:2'b01
+    |vpiLhs:
+    \_ref_obj: (work@top.first), line:7
+      |vpiName:first
+      |vpiFullName:work@top.first
+      |vpiActual:
+      \_logic_net: (work@top.first), line:2, parent:work@top
+  |vpiContAssign:
+  \_cont_assign: , line:8, parent:work@top
+    |vpiRhs:
+    \_constant: , line:8
+      |vpiConstType:3
+      |vpiDecompile:'bX
+      |vpiSize:1
+      |BIN:1'bX
+    |vpiLhs:
+    \_ref_obj: (work@top.first), line:8
+      |vpiName:first
+      |vpiFullName:work@top.first
+      |vpiActual:
+      \_logic_net: (work@top.first), line:2, parent:work@top
+  |vpiContAssign:
+  \_cont_assign: , line:9, parent:work@top
+    |vpiRhs:
+    \_constant: , line:9
+      |vpiConstType:3
+      |vpiDecompile:2'b0x
+      |vpiSize:2
+      |BIN:2'b0x
+    |vpiLhs:
+    \_ref_obj: (work@top.first), line:9
+      |vpiName:first
+      |vpiFullName:work@top.first
+      |vpiActual:
+      \_logic_net: (work@top.first), line:2, parent:work@top
+  |vpiContAssign:
+  \_cont_assign: , line:10, parent:work@top
+    |vpiRhs:
+    \_constant: , line:10
+      |vpiConstType:3
+      |vpiDecompile:1'bz
+      |vpiSize:1
+      |BIN:1'bz
+    |vpiLhs:
+    \_ref_obj: (work@top.first), line:10
+      |vpiName:first
+      |vpiFullName:work@top.first
+      |vpiActual:
+      \_logic_net: (work@top.first), line:2, parent:work@top
+  |vpiContAssign:
+  \_cont_assign: , line:11, parent:work@top
+    |vpiRhs:
+    \_constant: , line:11
+      |vpiConstType:3
+      |vpiDecompile:2'b0z
+      |vpiSize:2
+      |BIN:2'b0z
+    |vpiLhs:
+    \_ref_obj: (work@top.first), line:11
+      |vpiName:first
+      |vpiFullName:work@top.first
+      |vpiActual:
+      \_logic_net: (work@top.first), line:2, parent:work@top
+  |vpiNet:
+  \_logic_net: (work@top.first), line:2, parent:work@top
+===================
+[  FATAL] : 0
+[ SYNTAX] : 0
+[  ERROR] : 0
+[WARNING] : 1
+[   NOTE] : 5

--- a/tests/BinarySize/BinarySize.sl
+++ b/tests/BinarySize/BinarySize.sl
@@ -1,0 +1,1 @@
+-fileunit -writepp -parse  -d uhdm -sv dut.sv -nobuiltin -nocache -elabuhdm

--- a/tests/BinarySize/dut.sv
+++ b/tests/BinarySize/dut.sv
@@ -1,0 +1,13 @@
+module top();
+  logic       [31:0] first;
+  assign first = 32'b1;
+  assign first = 1'b0;
+  assign first = 2'b00;
+  assign first = 1'b1;
+  assign first = 2'b01;
+  assign first = 1'bx;
+  assign first = 2'b0x;
+  assign first = 1'bz;
+  assign first = 2'b0z;
+
+endmodule


### PR DESCRIPTION
This PR fixes inconsistency in BIN field when parsing binary constants. Before this PR ``1'b0`` (and others 1 bit binary constants) was parsed as:
```
     |vpiRhs:                                                                                                                                                                                                      
     \_constant: , line:4                                                                                                                                                                                          
       |vpiConstType:3                                                                                                                                                                                             
       |vpiDecompile:'b0                                                                                                                                                                                           
       |vpiSize:1                                                                                                                                                                                                  
       |BIN:0
```
but ``2'b00`` as:
```
     \_constant: , line:5                                                                                                                                                                                          
       |vpiConstType:3                                                                                                                                                                                             
       |vpiDecompile:2'b00                                                                                                                                                                                         
       |vpiSize:2                                                                                                                                                                                                  
       |BIN:2'b00
```
This PR changes ``1'b0`` to be parsed as ``BIN:1'b0``.