### PR TITLE
Update PreprocessFile.cpp

### DIFF
--- a/src/SourceCompile/PreprocessFile.cpp
+++ b/src/SourceCompile/PreprocessFile.cpp
@@ -34,6 +34,7 @@
 #include <iostream>
 #include <regex>
 #include <algorithm>
+#include <cctype>
 
 using namespace std;
 using namespace SURELOG;


### PR DESCRIPTION
added missing #include <cctype>needed by std::isalpha function call to avoid visual 2017 compilation error