### PR TITLE
Enum const bug

### DIFF
--- a/tests/ConcatVal/ConcatVal.log
+++ b/tests/ConcatVal/ConcatVal.log
@@ -616,15 +616,15 @@ design: (work@dut)
     |vpiEnumConst:
     \_enum_const: (EXC_CAUSE_ECALL_MMODE), line:10
       |vpiName:EXC_CAUSE_ECALL_MMODE
-      |INT:11
+      |BIN:01101
     |vpiEnumConst:
     \_enum_const: (EXC_CAUSE_IRQ_SOFTWARE_M), line:8
       |vpiName:EXC_CAUSE_IRQ_SOFTWARE_M
-      |INT:100003
+      |BIN:100011
     |vpiEnumConst:
     \_enum_const: (EXC_CAUSE_IRQ_TIMER_M), line:9
       |vpiName:EXC_CAUSE_IRQ_TIMER_M
-      |INT:100007
+      |BIN:100111
   |vpiParamAssign:
   \_param_assign: , line:2, parent:work@dut
     |vpiRhs:
@@ -808,15 +808,15 @@ design: (work@dut)
     |vpiEnumConst:
     \_enum_const: (EXC_CAUSE_ECALL_MMODE), line:10, parent:exc_cause_e
       |vpiName:EXC_CAUSE_ECALL_MMODE
-      |INT:11
+      |BIN:01101
     |vpiEnumConst:
     \_enum_const: (EXC_CAUSE_IRQ_SOFTWARE_M), line:8, parent:exc_cause_e
       |vpiName:EXC_CAUSE_IRQ_SOFTWARE_M
-      |INT:100003
+      |BIN:100011
     |vpiEnumConst:
     \_enum_const: (EXC_CAUSE_IRQ_TIMER_M), line:9, parent:exc_cause_e
       |vpiName:EXC_CAUSE_IRQ_TIMER_M
-      |INT:100007
+      |BIN:100111
   |vpiParamAssign:
   \_param_assign: , line:2, parent:work@dut
     |vpiRhs:

--- a/tests/EnumConst/EnumConst.log
+++ b/tests/EnumConst/EnumConst.log
@@ -1,0 +1,155 @@
+[INF:CM0023] Creating log file ../../build/tests/EnumConst/slpp_unit/surelog.log.
+
+[INF:CM0020] Separate compilation-unit mode is on.
+
+LIB:  work
+FILE: dut.sv
+n<> u<0> t<Null_rule> p<57> s<56> l<1>
+n<> u<1> t<Module_keyword> p<5> s<2> l<1>
+n<dut> u<2> t<StringConst> p<5> s<4> l<1>
+n<> u<3> t<Port> p<4> l<1>
+n<> u<4> t<List_of_ports> p<5> c<3> l<1>
+n<> u<5> t<Module_nonansi_header> p<54> c<1> s<53> l<1>
+n<> u<6> t<IntVec_TypeLogic> p<17> s<16> l<2>
+n<5> u<7> t<IntConst> p<8> l<2>
+n<> u<8> t<Primary_literal> p<9> c<7> l<2>
+n<> u<9> t<Constant_primary> p<10> c<8> l<2>
+n<> u<10> t<Constant_expression> p<15> c<9> s<14> l<2>
+n<0> u<11> t<IntConst> p<12> l<2>
+n<> u<12> t<Primary_literal> p<13> c<11> l<2>
+n<> u<13> t<Constant_primary> p<14> c<12> l<2>
+n<> u<14> t<Constant_expression> p<15> c<13> l<2>
+n<> u<15> t<Constant_range> p<16> c<10> l<2>
+n<> u<16> t<Packed_dimension> p<17> c<15> l<2>
+n<> u<17> t<Enum_base_type> p<44> c<6> s<30> l<2>
+n<EXC_CAUSE_IRQ_SOFTWARE_M> u<18> t<StringConst> p<30> s<29> l<3>
+n<> u<19> t<Number_1Tickb1> p<20> l<3>
+n<> u<20> t<Primary_literal> p<21> c<19> l<3>
+n<> u<21> t<Constant_primary> p<22> c<20> l<3>
+n<> u<22> t<Constant_expression> p<27> c<21> s<26> l<3>
+n<5'd03> u<23> t<IntConst> p<24> l<3>
+n<> u<24> t<Primary_literal> p<25> c<23> l<3>
+n<> u<25> t<Constant_primary> p<26> c<24> l<3>
+n<> u<26> t<Constant_expression> p<27> c<25> l<3>
+n<> u<27> t<Constant_concatenation> p<28> c<22> l<3>
+n<> u<28> t<Constant_primary> p<29> c<27> l<3>
+n<> u<29> t<Constant_expression> p<30> c<28> l<3>
+n<> u<30> t<Enum_name_declaration> p<44> c<18> s<43> l<3>
+n<EXC_CAUSE_IRQ_TIMER_M> u<31> t<StringConst> p<43> s<42> l<4>
+n<> u<32> t<Number_1Tickb1> p<33> l<4>
+n<> u<33> t<Primary_literal> p<34> c<32> l<4>
+n<> u<34> t<Constant_primary> p<35> c<33> l<4>
+n<> u<35> t<Constant_expression> p<40> c<34> s<39> l<4>
+n<5'd07> u<36> t<IntConst> p<37> l<4>
+n<> u<37> t<Primary_literal> p<38> c<36> l<4>
+n<> u<38> t<Constant_primary> p<39> c<37> l<4>
+n<> u<39> t<Constant_expression> p<40> c<38> l<4>
+n<> u<40> t<Constant_concatenation> p<41> c<35> l<4>
+n<> u<41> t<Constant_primary> p<42> c<40> l<4>
+n<> u<42> t<Constant_expression> p<43> c<41> l<4>
+n<> u<43> t<Enum_name_declaration> p<44> c<31> l<4>
+n<> u<44> t<Data_type> p<46> c<17> s<45> l<2>
+n<exc_cause_e> u<45> t<StringConst> p<46> l<5>
+n<> u<46> t<Type_declaration> p<47> c<44> l<2>
+n<> u<47> t<Data_declaration> p<48> c<46> l<2>
+n<> u<48> t<Package_or_generate_item_declaration> p<49> c<47> l<2>
+n<> u<49> t<Module_or_generate_item_declaration> p<50> c<48> l<2>
+n<> u<50> t<Module_common_item> p<51> c<49> l<2>
+n<> u<51> t<Module_or_generate_item> p<52> c<50> l<2>
+n<> u<52> t<Non_port_module_item> p<53> c<51> l<2>
+n<> u<53> t<Module_item> p<54> c<52> l<2>
+n<> u<54> t<Module_declaration> p<55> c<5> l<1>
+n<> u<55> t<Description> p<56> c<54> l<1>
+n<> u<56> t<Source_text> p<57> c<55> l<1>
+n<> u<57> t<Top_level_rule> l<1>
+[WRN:PA0205] dut.sv:1: No timescale set for "dut".
+
+[INF:CP0300] Compilation...
+
+[INF:CP0303] dut.sv:1: Compile module "work@dut".
+
+[INF:EL0526] Design Elaboration...
+
+[NTE:EL0503] dut.sv:1: Top level module "work@dut".
+
+[NTE:EL0508] Nb Top level modules: 1.
+
+[NTE:EL0509] Max instance depth: 1.
+
+[NTE:EL0510] Nb instances: 1.
+
+[NTE:EL0511] Nb leaf instances: 1.
+
+UHDM HTML COVERAGE REPORT: ../../build/tests/EnumConst/slpp_unit//surelog.uhdm.chk.html
+====== UHDM =======
+design: (work@dut)
+|vpiName:work@dut
+|uhdmallModules:
+\_module: work@dut (work@dut) dut.sv:1: , parent:work@dut
+  |vpiDefName:work@dut
+  |vpiFullName:work@dut
+  |vpiTypedef:
+  \_enum_typespec: (exc_cause_e), line:5
+    |vpiName:exc_cause_e
+    |vpiBaseTypespec:
+    \_logic_typespec: , line:2
+      |vpiRange:
+      \_range: , line:2
+        |vpiLeftRange:
+        \_constant: , line:2
+          |vpiConstType:7
+          |vpiDecompile:5
+          |vpiSize:32
+          |INT:5
+        |vpiRightRange:
+        \_constant: , line:2
+          |vpiConstType:7
+          |vpiDecompile:0
+          |vpiSize:32
+          |INT:0
+    |vpiEnumConst:
+    \_enum_const: (EXC_CAUSE_IRQ_SOFTWARE_M), line:3
+      |vpiName:EXC_CAUSE_IRQ_SOFTWARE_M
+      |BIN:100011
+    |vpiEnumConst:
+    \_enum_const: (EXC_CAUSE_IRQ_TIMER_M), line:4
+      |vpiName:EXC_CAUSE_IRQ_TIMER_M
+      |BIN:100111
+|uhdmtopModules:
+\_module: work@dut (work@dut) dut.sv:1: 
+  |vpiDefName:work@dut
+  |vpiName:work@dut
+  |vpiTypedef:
+  \_enum_typespec: (exc_cause_e), line:5
+    |vpiName:exc_cause_e
+    |vpiBaseTypespec:
+    \_logic_typespec: , line:2
+      |vpiRange:
+      \_range: , line:2
+        |vpiLeftRange:
+        \_constant: , line:2
+          |vpiConstType:7
+          |vpiDecompile:5
+          |vpiSize:32
+          |INT:5
+        |vpiRightRange:
+        \_constant: , line:2
+          |vpiConstType:7
+          |vpiDecompile:0
+          |vpiSize:32
+          |INT:0
+    |vpiEnumConst:
+    \_enum_const: (EXC_CAUSE_IRQ_SOFTWARE_M), line:3
+      |vpiName:EXC_CAUSE_IRQ_SOFTWARE_M
+      |BIN:100011
+    |vpiEnumConst:
+    \_enum_const: (EXC_CAUSE_IRQ_TIMER_M), line:4
+      |vpiName:EXC_CAUSE_IRQ_TIMER_M
+      |BIN:100111
+===================
+[  FATAL] : 0
+[ SYNTAX] : 0
+[  ERROR] : 0
+[WARNING] : 1
+[   NOTE] : 5
+

--- a/tests/EnumConst/EnumConst.sl
+++ b/tests/EnumConst/EnumConst.sl
@@ -1,0 +1,1 @@
+-fileunit -writepp -parse -d ast -d uhdm  dut.sv -nobuiltin -nocache

--- a/tests/EnumConst/dut.sv
+++ b/tests/EnumConst/dut.sv
@@ -1,0 +1,8 @@
+module dut ();
+typedef enum logic [5:0] {
+  EXC_CAUSE_IRQ_SOFTWARE_M     = {1'b1, 5'd03},
+  EXC_CAUSE_IRQ_TIMER_M        = {1'b1, 5'd07}
+} exc_cause_e;
+
+endmodule
+

--- a/tests/ModPortTest/ModPortTest.log
+++ b/tests/ModPortTest/ModPortTest.log
@@ -273,6 +273,543 @@ PP TOKENS:
 [@266,684:683='<EOF>',<-1>,56:0]
 PP TREE: (top_level_rule null_rule (source_text (description (module module)) (description (text_blob  )) (description (text_blob dff0_test)) (description (text_blob ()) (description (text_blob n1)) (description (text_blob ))) (description (text_blob ;)) (description (text_blob \n)) (description (text_blob   )) (description (text_blob ()) (description (text_blob *)) (description (text_blob  )) (description (text_blob init)) (description (text_blob  )) (description (text_blob =)) (description (text_blob  )) (description (number 32'd1 )) (description (text_blob *)) (description (text_blob ))) (description (text_blob \n)) (description (text_blob   )) (description (text_blob output)) (description (text_blob  )) (description (text_blob n1)) (description (text_blob ;)) (description (text_blob \n)) (description (text_blob   )) (description (text_blob reg)) (description (text_blob  )) (description (text_blob n1)) (description (text_blob  )) (description (text_blob =)) (description (text_blob  )) (description (number 32'd0)) (description (text_blob ;)) (description (text_blob \n)) (description (endmodule endmodule)) (description (text_blob \n)) (description (text_blob \n)) (description (text_blob \n)) (description (sv_interface interface)) (description (text_blob  )) (description (text_blob AXI_BUS)) (description (text_blob  )) (description (text_blob #)) (description (text_blob ()) (description (text_blob \n)) (description (text_blob  )) (description (text_blob parameter)) (description (text_blob  )) (description (text_blob AXI_ID_WIDTH)) (description (text_blob    )) (description (text_blob =)) (description (text_blob  )) (description (text_blob -)) (description (number 1)) (description (text_blob \n)) (description (text_blob ))) (description (text_blob ;)) (description (text_blob \n)) (description (text_blob \n)) (description (text_blob   )) (description (text_blob typedef)) (description (text_blob  )) (description (text_blob logic)) (description (text_blob  )) (description (text_blob [)) (description (text_blob AXI_ID_WIDTH)) (description (text_blob -)) (description (number 1)) (description (text_blob :)) (description (number 0)) (description (text_blob ])) (description (text_blob    )) (description (text_blob id_t)) (description (text_blob ;)) (description (text_blob \n)) (description (text_blob   )) (description (text_blob \n)) (description (text_blob   )) (description (text_blob id_t1)) (description (text_blob        )) (description (text_blob aw_id)) (description (text_blob ;)) (description (text_blob \n)) (description (text_blob    )) (description (text_blob \n)) (description (text_blob   )) (description (text_blob modport)) (description (text_blob  )) (description (text_blob Master)) (description (text_blob  )) (description (text_blob ()) (description (text_blob \n)) (description (text_blob     )) (description (text_blob output)) (description (text_blob  )) (description (text_blob aw_id)) (description (text_blob \n)) (description (text_blob   )) (description (text_blob ))) (description (text_blob ;)) (description (text_blob \n)) (description (text_blob \n)) (description (text_blob   )) (description (text_blob id_t)) (description (text_blob        )) (description (text_blob rw_id)) (description (text_blob ;)) (description (text_blob \n)) (description (text_blob    )) (description (text_blob \n)) (description (text_blob   )) (description (text_blob modport)) (description (text_blob  )) (description (text_blob Slave)) (description (text_blob  )) (description (text_blob ()) (description (text_blob \n)) (description (text_blob     )) (description (text_blob output)) (description (text_blob  )) (description (text_blob ww_id)) (description (text_blob \n)) (description (text_blob   )) (description (text_blob ))) (description (text_blob ;)) (description (text_blob \n)) (description (text_blob \n)) (description (endinterface endinterface)) (description (text_blob \n)) (description (text_blob \n)) (description (text_blob \n)) (description (sv_interface interface)) (description (text_blob  )) (description (text_blob mem_if)) (description (text_blob  )) (description (text_blob ()) (description (text_blob input)) (description (text_blob  )) (description (text_blob wire)) (description (text_blob  )) (description (text_blob clk)) (description (text_blob ))) (description (text_blob ;)) (description (text_blob \n)) (description (text_blob \n)) (description (text_blob   )) (description (text_blob modport)) (description (text_blob   )) (description (text_blob system)) (description (text_blob  )) (description (text_blob ()) (description (text_blob input)) (description (text_blob  )) (description (text_blob clk)) (description (text_blob ))) (description (text_blob ;)) (description (text_blob \n)) (description (text_blob   )) (description (text_blob modport)) (description (text_blob   )) (description (text_blob memory)) (description (text_blob  )) (description (text_blob ()) (description (text_blob output)) (description (text_blob  )) (description (text_blob clk)) (description (text_blob ))) (description (text_blob ;)) (description (text_blob \n)) (description (text_blob  )) (description (text_blob \n)) (description (endinterface endinterface)) (description (text_blob \n)) (description (text_blob \n)) (description (module module)) (description (text_blob  )) (description (text_blob memory_ctrl1)) (description (text_blob  )) (description (text_blob ()) (description (text_blob mem_if)) (description (text_blob .)) (description (text_blob system1)) (description (text_blob  )) (description (text_blob sif)) (description (text_blob ))) (description (text_blob ;)) (description (text_blob \n)) (description (text_blob \n)) (description (text_blob typedef)) (description (text_blob   )) (description (text_blob enum)) (description (text_blob  )) (description (text_blob {)) (description (text_blob IDLE)) (description (text_blob ,)) (description (text_blob WRITE)) (description (text_blob ,)) (description (text_blob READ)) (description (text_blob ,)) (description (text_blob DONE)) (description (text_blob })) (description (text_blob  )) (description (text_blob fsm_t)) (description (text_blob ;)) (description (text_blob \n)) (description (text_blob \n)) (description (text_blob fsm_t)) (description (text_blob  )) (description (text_blob state)) (description (text_blob ;)) (description (text_blob \n)) (description (text_blob \n)) (description (text_blob \n)) (description (endmodule endmodule)) (description (text_blob \n)) (description (text_blob \n)) (description (module module)) (description (text_blob  )) (description (text_blob memory_ctrl2)) (description (text_blob  )) (description (text_blob ()) (description (text_blob mem_if)) (description (text_blob .)) (description (text_blob system)) (description (text_blob  )) (description (text_blob sif)) (description (text_blob ))) (description (text_blob ;)) (description (text_blob \n)) (description (text_blob \n)) (description (text_blob typedef)) (description (text_blob   )) (description (text_blob enum)) (description (text_blob  )) (description (text_blob {)) (description (text_blob IDLE)) (description (text_blob ,)) (description (text_blob WRITE)) (description (text_blob ,)) (description (text_blob READ)) (description (text_blob ,)) (description (text_blob DONE)) (description (text_blob })) (description (text_blob  )) (description (text_blob fsm_t)) (description (text_blob ;)) (description (text_blob \n)) (description (text_blob \n)) (description (text_blob fsm_t)) (description (text_blob  )) (description (text_blob state)) (description (text_blob ;)) (description (text_blob \n)) (description (text_blob \n)) (description (text_blob DD)) (description (text_blob  )) (description (text_blob t)) (description (text_blob ;)) (description (text_blob \n)) (description (text_blob \n)) (description (endmodule endmodule)) (description (text_blob \n)) (description (text_blob \n)) (description (text_blob \n))) <EOF>)
 
+LIB:  work
+FILE: top.v
+n<> u<0> t<Null_rule> p<534> s<533> l<1>
+n<> u<1> t<Module> p<2> l<1>
+n<module> u<2> t<Description> p<533> c<1> s<4> l<1>
+n<> u<3> t<Spaces> p<4> l<1>
+n<> u<4> t<Text_blob> p<533> c<3> s<6> l<1>
+n<dff0_test> u<5> t<Ps_identifier> p<6> l<1>
+n<dff0_test> u<6> t<Text_blob> p<533> c<5> s<8> l<1>
+n<(> u<7> t<Text_blob> p<8> l<1>
+n<(> u<8> t<Text_blob> p<533> c<7> s<10> l<1>
+n<n1> u<9> t<Ps_identifier> p<10> l<1>
+n<n1> u<10> t<Text_blob> p<533> c<9> s<12> l<1>
+n<)> u<11> t<Text_blob> p<12> l<1>
+n<)> u<12> t<Text_blob> p<533> c<11> s<14> l<1>
+n<;> u<13> t<Text_blob> p<14> l<1>
+n<;> u<14> t<Text_blob> p<533> c<13> s<16> l<1>
+n<> u<15> t<CR> p<16> l<1>
+n<> u<16> t<Text_blob> p<533> c<15> s<18> l<1>
+n<> u<17> t<Spaces> p<18> l<2>
+n<> u<18> t<Text_blob> p<533> c<17> s<20> l<2>
+n<(> u<19> t<Text_blob> p<20> l<2>
+n<(> u<20> t<Text_blob> p<533> c<19> s<22> l<2>
+n<*> u<21> t<Text_blob> p<22> l<2>
+n<*> u<22> t<Text_blob> p<533> c<21> s<24> l<2>
+n<> u<23> t<Spaces> p<24> l<2>
+n<> u<24> t<Text_blob> p<533> c<23> s<26> l<2>
+n<init> u<25> t<Ps_identifier> p<26> l<2>
+n<init> u<26> t<Text_blob> p<533> c<25> s<28> l<2>
+n<> u<27> t<Spaces> p<28> l<2>
+n<> u<28> t<Text_blob> p<533> c<27> s<30> l<2>
+n<=> u<29> t<Text_blob> p<30> l<2>
+n<=> u<30> t<Text_blob> p<533> c<29> s<32> l<2>
+n<> u<31> t<Spaces> p<32> l<2>
+n<> u<32> t<Text_blob> p<533> c<31> s<34> l<2>
+n<32'd1 > u<33> t<Number> p<34> l<2>
+n<32'd1 > u<34> t<Description> p<533> c<33> s<36> l<2>
+n<*> u<35> t<Text_blob> p<36> l<2>
+n<*> u<36> t<Text_blob> p<533> c<35> s<38> l<2>
+n<)> u<37> t<Text_blob> p<38> l<2>
+n<)> u<38> t<Text_blob> p<533> c<37> s<40> l<2>
+n<> u<39> t<CR> p<40> l<2>
+n<> u<40> t<Text_blob> p<533> c<39> s<42> l<2>
+n<> u<41> t<Spaces> p<42> l<3>
+n<> u<42> t<Text_blob> p<533> c<41> s<44> l<3>
+n<output> u<43> t<Ps_identifier> p<44> l<3>
+n<output> u<44> t<Text_blob> p<533> c<43> s<46> l<3>
+n<> u<45> t<Spaces> p<46> l<3>
+n<> u<46> t<Text_blob> p<533> c<45> s<48> l<3>
+n<n1> u<47> t<Ps_identifier> p<48> l<3>
+n<n1> u<48> t<Text_blob> p<533> c<47> s<50> l<3>
+n<;> u<49> t<Text_blob> p<50> l<3>
+n<;> u<50> t<Text_blob> p<533> c<49> s<52> l<3>
+n<> u<51> t<CR> p<52> l<3>
+n<> u<52> t<Text_blob> p<533> c<51> s<54> l<3>
+n<> u<53> t<Spaces> p<54> l<4>
+n<> u<54> t<Text_blob> p<533> c<53> s<56> l<4>
+n<reg> u<55> t<Ps_identifier> p<56> l<4>
+n<reg> u<56> t<Text_blob> p<533> c<55> s<58> l<4>
+n<> u<57> t<Spaces> p<58> l<4>
+n<> u<58> t<Text_blob> p<533> c<57> s<60> l<4>
+n<n1> u<59> t<Ps_identifier> p<60> l<4>
+n<n1> u<60> t<Text_blob> p<533> c<59> s<62> l<4>
+n<> u<61> t<Spaces> p<62> l<4>
+n<> u<62> t<Text_blob> p<533> c<61> s<64> l<4>
+n<=> u<63> t<Text_blob> p<64> l<4>
+n<=> u<64> t<Text_blob> p<533> c<63> s<66> l<4>
+n<> u<65> t<Spaces> p<66> l<4>
+n<> u<66> t<Text_blob> p<533> c<65> s<68> l<4>
+n<32'd0> u<67> t<Number> p<68> l<4>
+n<32'd0> u<68> t<Description> p<533> c<67> s<70> l<4>
+n<;> u<69> t<Text_blob> p<70> l<4>
+n<;> u<70> t<Text_blob> p<533> c<69> s<72> l<4>
+n<> u<71> t<CR> p<72> l<4>
+n<> u<72> t<Text_blob> p<533> c<71> s<74> l<4>
+n<> u<73> t<Endmodule> p<74> l<5>
+n<endmodule> u<74> t<Description> p<533> c<73> s<76> l<5>
+n<> u<75> t<CR> p<76> l<5>
+n<> u<76> t<Text_blob> p<533> c<75> s<78> l<5>
+n<> u<77> t<CR> p<78> l<6>
+n<> u<78> t<Text_blob> p<533> c<77> s<80> l<6>
+n<> u<79> t<CR> p<80> l<7>
+n<> u<80> t<Text_blob> p<533> c<79> s<82> l<7>
+n<> u<81> t<Sv_interface> p<82> l<8>
+n<interface> u<82> t<Description> p<533> c<81> s<84> l<8>
+n<> u<83> t<Spaces> p<84> l<8>
+n<> u<84> t<Text_blob> p<533> c<83> s<86> l<8>
+n<AXI_BUS> u<85> t<Ps_identifier> p<86> l<8>
+n<AXI_BUS> u<86> t<Text_blob> p<533> c<85> s<88> l<8>
+n<> u<87> t<Spaces> p<88> l<8>
+n<> u<88> t<Text_blob> p<533> c<87> s<90> l<8>
+n<#> u<89> t<Text_blob> p<90> l<8>
+n<#> u<90> t<Text_blob> p<533> c<89> s<92> l<8>
+n<(> u<91> t<Text_blob> p<92> l<8>
+n<(> u<92> t<Text_blob> p<533> c<91> s<94> l<8>
+n<> u<93> t<CR> p<94> l<8>
+n<> u<94> t<Text_blob> p<533> c<93> s<96> l<8>
+n<> u<95> t<Spaces> p<96> l<9>
+n<> u<96> t<Text_blob> p<533> c<95> s<98> l<9>
+n<parameter> u<97> t<Ps_identifier> p<98> l<9>
+n<parameter> u<98> t<Text_blob> p<533> c<97> s<100> l<9>
+n<> u<99> t<Spaces> p<100> l<9>
+n<> u<100> t<Text_blob> p<533> c<99> s<102> l<9>
+n<AXI_ID_WIDTH> u<101> t<Ps_identifier> p<102> l<9>
+n<AXI_ID_WIDTH> u<102> t<Text_blob> p<533> c<101> s<104> l<9>
+n<> u<103> t<Spaces> p<104> l<9>
+n<> u<104> t<Text_blob> p<533> c<103> s<106> l<9>
+n<=> u<105> t<Text_blob> p<106> l<9>
+n<=> u<106> t<Text_blob> p<533> c<105> s<108> l<9>
+n<> u<107> t<Spaces> p<108> l<9>
+n<> u<108> t<Text_blob> p<533> c<107> s<110> l<9>
+n<-> u<109> t<Text_blob> p<110> l<9>
+n<-> u<110> t<Text_blob> p<533> c<109> s<112> l<9>
+n<1> u<111> t<Number> p<112> l<9>
+n<1> u<112> t<Description> p<533> c<111> s<114> l<9>
+n<> u<113> t<CR> p<114> l<9>
+n<> u<114> t<Text_blob> p<533> c<113> s<116> l<9>
+n<)> u<115> t<Text_blob> p<116> l<10>
+n<)> u<116> t<Text_blob> p<533> c<115> s<118> l<10>
+n<;> u<117> t<Text_blob> p<118> l<10>
+n<;> u<118> t<Text_blob> p<533> c<117> s<120> l<10>
+n<> u<119> t<CR> p<120> l<10>
+n<> u<120> t<Text_blob> p<533> c<119> s<122> l<10>
+n<> u<121> t<CR> p<122> l<11>
+n<> u<122> t<Text_blob> p<533> c<121> s<124> l<11>
+n<> u<123> t<Spaces> p<124> l<12>
+n<> u<124> t<Text_blob> p<533> c<123> s<126> l<12>
+n<typedef> u<125> t<Ps_identifier> p<126> l<12>
+n<typedef> u<126> t<Text_blob> p<533> c<125> s<128> l<12>
+n<> u<127> t<Spaces> p<128> l<12>
+n<> u<128> t<Text_blob> p<533> c<127> s<130> l<12>
+n<logic> u<129> t<Ps_identifier> p<130> l<12>
+n<logic> u<130> t<Text_blob> p<533> c<129> s<132> l<12>
+n<> u<131> t<Spaces> p<132> l<12>
+n<> u<132> t<Text_blob> p<533> c<131> s<134> l<12>
+n<[> u<133> t<Text_blob> p<134> l<12>
+n<[> u<134> t<Text_blob> p<533> c<133> s<136> l<12>
+n<AXI_ID_WIDTH> u<135> t<Ps_identifier> p<136> l<12>
+n<AXI_ID_WIDTH> u<136> t<Text_blob> p<533> c<135> s<138> l<12>
+n<-> u<137> t<Text_blob> p<138> l<12>
+n<-> u<138> t<Text_blob> p<533> c<137> s<140> l<12>
+n<1> u<139> t<Number> p<140> l<12>
+n<1> u<140> t<Description> p<533> c<139> s<142> l<12>
+n<:> u<141> t<Text_blob> p<142> l<12>
+n<:> u<142> t<Text_blob> p<533> c<141> s<144> l<12>
+n<0> u<143> t<Number> p<144> l<12>
+n<0> u<144> t<Description> p<533> c<143> s<146> l<12>
+n<]> u<145> t<Text_blob> p<146> l<12>
+n<]> u<146> t<Text_blob> p<533> c<145> s<148> l<12>
+n<> u<147> t<Spaces> p<148> l<12>
+n<> u<148> t<Text_blob> p<533> c<147> s<150> l<12>
+n<id_t> u<149> t<Ps_identifier> p<150> l<12>
+n<id_t> u<150> t<Text_blob> p<533> c<149> s<152> l<12>
+n<;> u<151> t<Text_blob> p<152> l<12>
+n<;> u<152> t<Text_blob> p<533> c<151> s<154> l<12>
+n<> u<153> t<CR> p<154> l<12>
+n<> u<154> t<Text_blob> p<533> c<153> s<156> l<12>
+n<> u<155> t<Spaces> p<156> l<13>
+n<> u<156> t<Text_blob> p<533> c<155> s<158> l<13>
+n<> u<157> t<CR> p<158> l<13>
+n<> u<158> t<Text_blob> p<533> c<157> s<160> l<13>
+n<> u<159> t<Spaces> p<160> l<14>
+n<> u<160> t<Text_blob> p<533> c<159> s<162> l<14>
+n<id_t1> u<161> t<Ps_identifier> p<162> l<14>
+n<id_t1> u<162> t<Text_blob> p<533> c<161> s<164> l<14>
+n<> u<163> t<Spaces> p<164> l<14>
+n<> u<164> t<Text_blob> p<533> c<163> s<166> l<14>
+n<aw_id> u<165> t<Ps_identifier> p<166> l<14>
+n<aw_id> u<166> t<Text_blob> p<533> c<165> s<168> l<14>
+n<;> u<167> t<Text_blob> p<168> l<14>
+n<;> u<168> t<Text_blob> p<533> c<167> s<170> l<14>
+n<> u<169> t<CR> p<170> l<14>
+n<> u<170> t<Text_blob> p<533> c<169> s<172> l<14>
+n<> u<171> t<Spaces> p<172> l<15>
+n<> u<172> t<Text_blob> p<533> c<171> s<174> l<15>
+n<> u<173> t<CR> p<174> l<15>
+n<> u<174> t<Text_blob> p<533> c<173> s<176> l<15>
+n<> u<175> t<Spaces> p<176> l<16>
+n<> u<176> t<Text_blob> p<533> c<175> s<178> l<16>
+n<modport> u<177> t<Ps_identifier> p<178> l<16>
+n<modport> u<178> t<Text_blob> p<533> c<177> s<180> l<16>
+n<> u<179> t<Spaces> p<180> l<16>
+n<> u<180> t<Text_blob> p<533> c<179> s<182> l<16>
+n<Master> u<181> t<Ps_identifier> p<182> l<16>
+n<Master> u<182> t<Text_blob> p<533> c<181> s<184> l<16>
+n<> u<183> t<Spaces> p<184> l<16>
+n<> u<184> t<Text_blob> p<533> c<183> s<186> l<16>
+n<(> u<185> t<Text_blob> p<186> l<16>
+n<(> u<186> t<Text_blob> p<533> c<185> s<188> l<16>
+n<> u<187> t<CR> p<188> l<16>
+n<> u<188> t<Text_blob> p<533> c<187> s<190> l<16>
+n<> u<189> t<Spaces> p<190> l<17>
+n<> u<190> t<Text_blob> p<533> c<189> s<192> l<17>
+n<output> u<191> t<Ps_identifier> p<192> l<17>
+n<output> u<192> t<Text_blob> p<533> c<191> s<194> l<17>
+n<> u<193> t<Spaces> p<194> l<17>
+n<> u<194> t<Text_blob> p<533> c<193> s<196> l<17>
+n<aw_id> u<195> t<Ps_identifier> p<196> l<17>
+n<aw_id> u<196> t<Text_blob> p<533> c<195> s<198> l<17>
+n<> u<197> t<CR> p<198> l<17>
+n<> u<198> t<Text_blob> p<533> c<197> s<200> l<17>
+n<> u<199> t<Spaces> p<200> l<18>
+n<> u<200> t<Text_blob> p<533> c<199> s<202> l<18>
+n<)> u<201> t<Text_blob> p<202> l<18>
+n<)> u<202> t<Text_blob> p<533> c<201> s<204> l<18>
+n<;> u<203> t<Text_blob> p<204> l<18>
+n<;> u<204> t<Text_blob> p<533> c<203> s<206> l<18>
+n<> u<205> t<CR> p<206> l<18>
+n<> u<206> t<Text_blob> p<533> c<205> s<208> l<18>
+n<> u<207> t<CR> p<208> l<19>
+n<> u<208> t<Text_blob> p<533> c<207> s<210> l<19>
+n<> u<209> t<Spaces> p<210> l<20>
+n<> u<210> t<Text_blob> p<533> c<209> s<212> l<20>
+n<id_t> u<211> t<Ps_identifier> p<212> l<20>
+n<id_t> u<212> t<Text_blob> p<533> c<211> s<214> l<20>
+n<> u<213> t<Spaces> p<214> l<20>
+n<> u<214> t<Text_blob> p<533> c<213> s<216> l<20>
+n<rw_id> u<215> t<Ps_identifier> p<216> l<20>
+n<rw_id> u<216> t<Text_blob> p<533> c<215> s<218> l<20>
+n<;> u<217> t<Text_blob> p<218> l<20>
+n<;> u<218> t<Text_blob> p<533> c<217> s<220> l<20>
+n<> u<219> t<CR> p<220> l<20>
+n<> u<220> t<Text_blob> p<533> c<219> s<222> l<20>
+n<> u<221> t<Spaces> p<222> l<21>
+n<> u<222> t<Text_blob> p<533> c<221> s<224> l<21>
+n<> u<223> t<CR> p<224> l<21>
+n<> u<224> t<Text_blob> p<533> c<223> s<226> l<21>
+n<> u<225> t<Spaces> p<226> l<22>
+n<> u<226> t<Text_blob> p<533> c<225> s<228> l<22>
+n<modport> u<227> t<Ps_identifier> p<228> l<22>
+n<modport> u<228> t<Text_blob> p<533> c<227> s<230> l<22>
+n<> u<229> t<Spaces> p<230> l<22>
+n<> u<230> t<Text_blob> p<533> c<229> s<232> l<22>
+n<Slave> u<231> t<Ps_identifier> p<232> l<22>
+n<Slave> u<232> t<Text_blob> p<533> c<231> s<234> l<22>
+n<> u<233> t<Spaces> p<234> l<22>
+n<> u<234> t<Text_blob> p<533> c<233> s<236> l<22>
+n<(> u<235> t<Text_blob> p<236> l<22>
+n<(> u<236> t<Text_blob> p<533> c<235> s<238> l<22>
+n<> u<237> t<CR> p<238> l<22>
+n<> u<238> t<Text_blob> p<533> c<237> s<240> l<22>
+n<> u<239> t<Spaces> p<240> l<23>
+n<> u<240> t<Text_blob> p<533> c<239> s<242> l<23>
+n<output> u<241> t<Ps_identifier> p<242> l<23>
+n<output> u<242> t<Text_blob> p<533> c<241> s<244> l<23>
+n<> u<243> t<Spaces> p<244> l<23>
+n<> u<244> t<Text_blob> p<533> c<243> s<246> l<23>
+n<ww_id> u<245> t<Ps_identifier> p<246> l<23>
+n<ww_id> u<246> t<Text_blob> p<533> c<245> s<248> l<23>
+n<> u<247> t<CR> p<248> l<23>
+n<> u<248> t<Text_blob> p<533> c<247> s<250> l<23>
+n<> u<249> t<Spaces> p<250> l<24>
+n<> u<250> t<Text_blob> p<533> c<249> s<252> l<24>
+n<)> u<251> t<Text_blob> p<252> l<24>
+n<)> u<252> t<Text_blob> p<533> c<251> s<254> l<24>
+n<;> u<253> t<Text_blob> p<254> l<24>
+n<;> u<254> t<Text_blob> p<533> c<253> s<256> l<24>
+n<> u<255> t<CR> p<256> l<24>
+n<> u<256> t<Text_blob> p<533> c<255> s<258> l<24>
+n<> u<257> t<CR> p<258> l<25>
+n<> u<258> t<Text_blob> p<533> c<257> s<260> l<25>
+n<> u<259> t<Endinterface> p<260> l<26>
+n<endinterface> u<260> t<Description> p<533> c<259> s<262> l<26>
+n<> u<261> t<CR> p<262> l<26>
+n<> u<262> t<Text_blob> p<533> c<261> s<264> l<26>
+n<> u<263> t<CR> p<264> l<27>
+n<> u<264> t<Text_blob> p<533> c<263> s<266> l<27>
+n<> u<265> t<CR> p<266> l<28>
+n<> u<266> t<Text_blob> p<533> c<265> s<268> l<28>
+n<> u<267> t<Sv_interface> p<268> l<29>
+n<interface> u<268> t<Description> p<533> c<267> s<270> l<29>
+n<> u<269> t<Spaces> p<270> l<29>
+n<> u<270> t<Text_blob> p<533> c<269> s<272> l<29>
+n<mem_if> u<271> t<Ps_identifier> p<272> l<29>
+n<mem_if> u<272> t<Text_blob> p<533> c<271> s<274> l<29>
+n<> u<273> t<Spaces> p<274> l<29>
+n<> u<274> t<Text_blob> p<533> c<273> s<276> l<29>
+n<(> u<275> t<Text_blob> p<276> l<29>
+n<(> u<276> t<Text_blob> p<533> c<275> s<278> l<29>
+n<input> u<277> t<Ps_identifier> p<278> l<29>
+n<input> u<278> t<Text_blob> p<533> c<277> s<280> l<29>
+n<> u<279> t<Spaces> p<280> l<29>
+n<> u<280> t<Text_blob> p<533> c<279> s<282> l<29>
+n<wire> u<281> t<Ps_identifier> p<282> l<29>
+n<wire> u<282> t<Text_blob> p<533> c<281> s<284> l<29>
+n<> u<283> t<Spaces> p<284> l<29>
+n<> u<284> t<Text_blob> p<533> c<283> s<286> l<29>
+n<clk> u<285> t<Ps_identifier> p<286> l<29>
+n<clk> u<286> t<Text_blob> p<533> c<285> s<288> l<29>
+n<)> u<287> t<Text_blob> p<288> l<29>
+n<)> u<288> t<Text_blob> p<533> c<287> s<290> l<29>
+n<;> u<289> t<Text_blob> p<290> l<29>
+n<;> u<290> t<Text_blob> p<533> c<289> s<292> l<29>
+n<> u<291> t<CR> p<292> l<29>
+n<> u<292> t<Text_blob> p<533> c<291> s<294> l<29>
+n<> u<293> t<CR> p<294> l<30>
+n<> u<294> t<Text_blob> p<533> c<293> s<296> l<30>
+n<> u<295> t<Spaces> p<296> l<31>
+n<> u<296> t<Text_blob> p<533> c<295> s<298> l<31>
+n<modport> u<297> t<Ps_identifier> p<298> l<31>
+n<modport> u<298> t<Text_blob> p<533> c<297> s<300> l<31>
+n<> u<299> t<Spaces> p<300> l<31>
+n<> u<300> t<Text_blob> p<533> c<299> s<302> l<31>
+n<system> u<301> t<Ps_identifier> p<302> l<31>
+n<system> u<302> t<Text_blob> p<533> c<301> s<304> l<31>
+n<> u<303> t<Spaces> p<304> l<31>
+n<> u<304> t<Text_blob> p<533> c<303> s<306> l<31>
+n<(> u<305> t<Text_blob> p<306> l<31>
+n<(> u<306> t<Text_blob> p<533> c<305> s<308> l<31>
+n<input> u<307> t<Ps_identifier> p<308> l<31>
+n<input> u<308> t<Text_blob> p<533> c<307> s<310> l<31>
+n<> u<309> t<Spaces> p<310> l<31>
+n<> u<310> t<Text_blob> p<533> c<309> s<312> l<31>
+n<clk> u<311> t<Ps_identifier> p<312> l<31>
+n<clk> u<312> t<Text_blob> p<533> c<311> s<314> l<31>
+n<)> u<313> t<Text_blob> p<314> l<31>
+n<)> u<314> t<Text_blob> p<533> c<313> s<316> l<31>
+n<;> u<315> t<Text_blob> p<316> l<31>
+n<;> u<316> t<Text_blob> p<533> c<315> s<318> l<31>
+n<> u<317> t<CR> p<318> l<31>
+n<> u<318> t<Text_blob> p<533> c<317> s<320> l<31>
+n<> u<319> t<Spaces> p<320> l<32>
+n<> u<320> t<Text_blob> p<533> c<319> s<322> l<32>
+n<modport> u<321> t<Ps_identifier> p<322> l<32>
+n<modport> u<322> t<Text_blob> p<533> c<321> s<324> l<32>
+n<> u<323> t<Spaces> p<324> l<32>
+n<> u<324> t<Text_blob> p<533> c<323> s<326> l<32>
+n<memory> u<325> t<Ps_identifier> p<326> l<32>
+n<memory> u<326> t<Text_blob> p<533> c<325> s<328> l<32>
+n<> u<327> t<Spaces> p<328> l<32>
+n<> u<328> t<Text_blob> p<533> c<327> s<330> l<32>
+n<(> u<329> t<Text_blob> p<330> l<32>
+n<(> u<330> t<Text_blob> p<533> c<329> s<332> l<32>
+n<output> u<331> t<Ps_identifier> p<332> l<32>
+n<output> u<332> t<Text_blob> p<533> c<331> s<334> l<32>
+n<> u<333> t<Spaces> p<334> l<32>
+n<> u<334> t<Text_blob> p<533> c<333> s<336> l<32>
+n<clk> u<335> t<Ps_identifier> p<336> l<32>
+n<clk> u<336> t<Text_blob> p<533> c<335> s<338> l<32>
+n<)> u<337> t<Text_blob> p<338> l<32>
+n<)> u<338> t<Text_blob> p<533> c<337> s<340> l<32>
+n<;> u<339> t<Text_blob> p<340> l<32>
+n<;> u<340> t<Text_blob> p<533> c<339> s<342> l<32>
+n<> u<341> t<CR> p<342> l<32>
+n<> u<342> t<Text_blob> p<533> c<341> s<344> l<32>
+n<> u<343> t<Spaces> p<344> l<33>
+n<> u<344> t<Text_blob> p<533> c<343> s<346> l<33>
+n<> u<345> t<CR> p<346> l<33>
+n<> u<346> t<Text_blob> p<533> c<345> s<348> l<33>
+n<> u<347> t<Endinterface> p<348> l<34>
+n<endinterface> u<348> t<Description> p<533> c<347> s<350> l<34>
+n<> u<349> t<CR> p<350> l<34>
+n<> u<350> t<Text_blob> p<533> c<349> s<352> l<34>
+n<> u<351> t<CR> p<352> l<35>
+n<> u<352> t<Text_blob> p<533> c<351> s<354> l<35>
+n<> u<353> t<Module> p<354> l<36>
+n<module> u<354> t<Description> p<533> c<353> s<356> l<36>
+n<> u<355> t<Spaces> p<356> l<36>
+n<> u<356> t<Text_blob> p<533> c<355> s<358> l<36>
+n<memory_ctrl1> u<357> t<Ps_identifier> p<358> l<36>
+n<memory_ctrl1> u<358> t<Text_blob> p<533> c<357> s<360> l<36>
+n<> u<359> t<Spaces> p<360> l<36>
+n<> u<360> t<Text_blob> p<533> c<359> s<362> l<36>
+n<(> u<361> t<Text_blob> p<362> l<36>
+n<(> u<362> t<Text_blob> p<533> c<361> s<364> l<36>
+n<mem_if> u<363> t<Ps_identifier> p<364> l<36>
+n<mem_if> u<364> t<Text_blob> p<533> c<363> s<366> l<36>
+n<.> u<365> t<Text_blob> p<366> l<36>
+n<.> u<366> t<Text_blob> p<533> c<365> s<368> l<36>
+n<system1> u<367> t<Ps_identifier> p<368> l<36>
+n<system1> u<368> t<Text_blob> p<533> c<367> s<370> l<36>
+n<> u<369> t<Spaces> p<370> l<36>
+n<> u<370> t<Text_blob> p<533> c<369> s<372> l<36>
+n<sif> u<371> t<Ps_identifier> p<372> l<36>
+n<sif> u<372> t<Text_blob> p<533> c<371> s<374> l<36>
+n<)> u<373> t<Text_blob> p<374> l<36>
+n<)> u<374> t<Text_blob> p<533> c<373> s<376> l<36>
+n<;> u<375> t<Text_blob> p<376> l<36>
+n<;> u<376> t<Text_blob> p<533> c<375> s<378> l<36>
+n<> u<377> t<CR> p<378> l<36>
+n<> u<378> t<Text_blob> p<533> c<377> s<380> l<36>
+n<> u<379> t<CR> p<380> l<37>
+n<> u<380> t<Text_blob> p<533> c<379> s<382> l<37>
+n<typedef> u<381> t<Ps_identifier> p<382> l<38>
+n<typedef> u<382> t<Text_blob> p<533> c<381> s<384> l<38>
+n<> u<383> t<Spaces> p<384> l<38>
+n<> u<384> t<Text_blob> p<533> c<383> s<386> l<38>
+n<enum> u<385> t<Ps_identifier> p<386> l<38>
+n<enum> u<386> t<Text_blob> p<533> c<385> s<388> l<38>
+n<> u<387> t<Spaces> p<388> l<38>
+n<> u<388> t<Text_blob> p<533> c<387> s<390> l<38>
+n<{> u<389> t<Text_blob> p<390> l<38>
+n<{> u<390> t<Text_blob> p<533> c<389> s<392> l<38>
+n<IDLE> u<391> t<Ps_identifier> p<392> l<38>
+n<IDLE> u<392> t<Text_blob> p<533> c<391> s<394> l<38>
+n<,> u<393> t<Text_blob> p<394> l<38>
+n<,> u<394> t<Text_blob> p<533> c<393> s<396> l<38>
+n<WRITE> u<395> t<Ps_identifier> p<396> l<38>
+n<WRITE> u<396> t<Text_blob> p<533> c<395> s<398> l<38>
+n<,> u<397> t<Text_blob> p<398> l<38>
+n<,> u<398> t<Text_blob> p<533> c<397> s<400> l<38>
+n<READ> u<399> t<Ps_identifier> p<400> l<38>
+n<READ> u<400> t<Text_blob> p<533> c<399> s<402> l<38>
+n<,> u<401> t<Text_blob> p<402> l<38>
+n<,> u<402> t<Text_blob> p<533> c<401> s<404> l<38>
+n<DONE> u<403> t<Ps_identifier> p<404> l<38>
+n<DONE> u<404> t<Text_blob> p<533> c<403> s<406> l<38>
+n<}> u<405> t<Text_blob> p<406> l<38>
+n<}> u<406> t<Text_blob> p<533> c<405> s<408> l<38>
+n<> u<407> t<Spaces> p<408> l<38>
+n<> u<408> t<Text_blob> p<533> c<407> s<410> l<38>
+n<fsm_t> u<409> t<Ps_identifier> p<410> l<38>
+n<fsm_t> u<410> t<Text_blob> p<533> c<409> s<412> l<38>
+n<;> u<411> t<Text_blob> p<412> l<38>
+n<;> u<412> t<Text_blob> p<533> c<411> s<414> l<38>
+n<> u<413> t<CR> p<414> l<38>
+n<> u<414> t<Text_blob> p<533> c<413> s<416> l<38>
+n<> u<415> t<CR> p<416> l<39>
+n<> u<416> t<Text_blob> p<533> c<415> s<418> l<39>
+n<fsm_t> u<417> t<Ps_identifier> p<418> l<40>
+n<fsm_t> u<418> t<Text_blob> p<533> c<417> s<420> l<40>
+n<> u<419> t<Spaces> p<420> l<40>
+n<> u<420> t<Text_blob> p<533> c<419> s<422> l<40>
+n<state> u<421> t<Ps_identifier> p<422> l<40>
+n<state> u<422> t<Text_blob> p<533> c<421> s<424> l<40>
+n<;> u<423> t<Text_blob> p<424> l<40>
+n<;> u<424> t<Text_blob> p<533> c<423> s<426> l<40>
+n<> u<425> t<CR> p<426> l<40>
+n<> u<426> t<Text_blob> p<533> c<425> s<428> l<40>
+n<> u<427> t<CR> p<428> l<41>
+n<> u<428> t<Text_blob> p<533> c<427> s<430> l<41>
+n<> u<429> t<CR> p<430> l<42>
+n<> u<430> t<Text_blob> p<533> c<429> s<432> l<42>
+n<> u<431> t<Endmodule> p<432> l<43>
+n<endmodule> u<432> t<Description> p<533> c<431> s<434> l<43>
+n<> u<433> t<CR> p<434> l<43>
+n<> u<434> t<Text_blob> p<533> c<433> s<436> l<43>
+n<> u<435> t<CR> p<436> l<44>
+n<> u<436> t<Text_blob> p<533> c<435> s<438> l<44>
+n<> u<437> t<Module> p<438> l<45>
+n<module> u<438> t<Description> p<533> c<437> s<440> l<45>
+n<> u<439> t<Spaces> p<440> l<45>
+n<> u<440> t<Text_blob> p<533> c<439> s<442> l<45>
+n<memory_ctrl2> u<441> t<Ps_identifier> p<442> l<45>
+n<memory_ctrl2> u<442> t<Text_blob> p<533> c<441> s<444> l<45>
+n<> u<443> t<Spaces> p<444> l<45>
+n<> u<444> t<Text_blob> p<533> c<443> s<446> l<45>
+n<(> u<445> t<Text_blob> p<446> l<45>
+n<(> u<446> t<Text_blob> p<533> c<445> s<448> l<45>
+n<mem_if> u<447> t<Ps_identifier> p<448> l<45>
+n<mem_if> u<448> t<Text_blob> p<533> c<447> s<450> l<45>
+n<.> u<449> t<Text_blob> p<450> l<45>
+n<.> u<450> t<Text_blob> p<533> c<449> s<452> l<45>
+n<system> u<451> t<Ps_identifier> p<452> l<45>
+n<system> u<452> t<Text_blob> p<533> c<451> s<454> l<45>
+n<> u<453> t<Spaces> p<454> l<45>
+n<> u<454> t<Text_blob> p<533> c<453> s<456> l<45>
+n<sif> u<455> t<Ps_identifier> p<456> l<45>
+n<sif> u<456> t<Text_blob> p<533> c<455> s<458> l<45>
+n<)> u<457> t<Text_blob> p<458> l<45>
+n<)> u<458> t<Text_blob> p<533> c<457> s<460> l<45>
+n<;> u<459> t<Text_blob> p<460> l<45>
+n<;> u<460> t<Text_blob> p<533> c<459> s<462> l<45>
+n<> u<461> t<CR> p<462> l<45>
+n<> u<462> t<Text_blob> p<533> c<461> s<464> l<45>
+n<> u<463> t<CR> p<464> l<46>
+n<> u<464> t<Text_blob> p<533> c<463> s<466> l<46>
+n<typedef> u<465> t<Ps_identifier> p<466> l<47>
+n<typedef> u<466> t<Text_blob> p<533> c<465> s<468> l<47>
+n<> u<467> t<Spaces> p<468> l<47>
+n<> u<468> t<Text_blob> p<533> c<467> s<470> l<47>
+n<enum> u<469> t<Ps_identifier> p<470> l<47>
+n<enum> u<470> t<Text_blob> p<533> c<469> s<472> l<47>
+n<> u<471> t<Spaces> p<472> l<47>
+n<> u<472> t<Text_blob> p<533> c<471> s<474> l<47>
+n<{> u<473> t<Text_blob> p<474> l<47>
+n<{> u<474> t<Text_blob> p<533> c<473> s<476> l<47>
+n<IDLE> u<475> t<Ps_identifier> p<476> l<47>
+n<IDLE> u<476> t<Text_blob> p<533> c<475> s<478> l<47>
+n<,> u<477> t<Text_blob> p<478> l<47>
+n<,> u<478> t<Text_blob> p<533> c<477> s<480> l<47>
+n<WRITE> u<479> t<Ps_identifier> p<480> l<47>
+n<WRITE> u<480> t<Text_blob> p<533> c<479> s<482> l<47>
+n<,> u<481> t<Text_blob> p<482> l<47>
+n<,> u<482> t<Text_blob> p<533> c<481> s<484> l<47>
+n<READ> u<483> t<Ps_identifier> p<484> l<47>
+n<READ> u<484> t<Text_blob> p<533> c<483> s<486> l<47>
+n<,> u<485> t<Text_blob> p<486> l<47>
+n<,> u<486> t<Text_blob> p<533> c<485> s<488> l<47>
+n<DONE> u<487> t<Ps_identifier> p<488> l<47>
+n<DONE> u<488> t<Text_blob> p<533> c<487> s<490> l<47>
+n<}> u<489> t<Text_blob> p<490> l<47>
+n<}> u<490> t<Text_blob> p<533> c<489> s<492> l<47>
+n<> u<491> t<Spaces> p<492> l<47>
+n<> u<492> t<Text_blob> p<533> c<491> s<494> l<47>
+n<fsm_t> u<493> t<Ps_identifier> p<494> l<47>
+n<fsm_t> u<494> t<Text_blob> p<533> c<493> s<496> l<47>
+n<;> u<495> t<Text_blob> p<496> l<47>
+n<;> u<496> t<Text_blob> p<533> c<495> s<498> l<47>
+n<> u<497> t<CR> p<498> l<47>
+n<> u<498> t<Text_blob> p<533> c<497> s<500> l<47>
+n<> u<499> t<CR> p<500> l<48>
+n<> u<500> t<Text_blob> p<533> c<499> s<502> l<48>
+n<fsm_t> u<501> t<Ps_identifier> p<502> l<49>
+n<fsm_t> u<502> t<Text_blob> p<533> c<501> s<504> l<49>
+n<> u<503> t<Spaces> p<504> l<49>
+n<> u<504> t<Text_blob> p<533> c<503> s<506> l<49>
+n<state> u<505> t<Ps_identifier> p<506> l<49>
+n<state> u<506> t<Text_blob> p<533> c<505> s<508> l<49>
+n<;> u<507> t<Text_blob> p<508> l<49>
+n<;> u<508> t<Text_blob> p<533> c<507> s<510> l<49>
+n<> u<509> t<CR> p<510> l<49>
+n<> u<510> t<Text_blob> p<533> c<509> s<512> l<49>
+n<> u<511> t<CR> p<512> l<50>
+n<> u<512> t<Text_blob> p<533> c<511> s<514> l<50>
+n<DD> u<513> t<Ps_identifier> p<514> l<51>
+n<DD> u<514> t<Text_blob> p<533> c<513> s<516> l<51>
+n<> u<515> t<Spaces> p<516> l<51>
+n<> u<516> t<Text_blob> p<533> c<515> s<518> l<51>
+n<t> u<517> t<Ps_identifier> p<518> l<51>
+n<t> u<518> t<Text_blob> p<533> c<517> s<520> l<51>
+n<;> u<519> t<Text_blob> p<520> l<51>
+n<;> u<520> t<Text_blob> p<533> c<519> s<522> l<51>
+n<> u<521> t<CR> p<522> l<51>
+n<> u<522> t<Text_blob> p<533> c<521> s<524> l<51>
+n<> u<523> t<CR> p<524> l<52>
+n<> u<524> t<Text_blob> p<533> c<523> s<526> l<52>
+n<> u<525> t<Endmodule> p<526> l<53>
+n<endmodule> u<526> t<Description> p<533> c<525> s<528> l<53>
+n<> u<527> t<CR> p<528> l<53>
+n<> u<528> t<Text_blob> p<533> c<527> s<530> l<53>
+n<> u<529> t<CR> p<530> l<54>
+n<> u<530> t<Text_blob> p<533> c<529> s<532> l<54>
+n<> u<531> t<CR> p<532> l<55>
+n<> u<532> t<Text_blob> p<533> c<531> l<55>
+n<> u<533> t<Source_text> p<534> c<2> l<1>
+n<> u<534> t<Top_level_rule> l<1>
 [WRN:PA0205] top.v:1: No timescale set for "dff0_test".
 
 [WRN:PA0205] top.v:8: No timescale set for "AXI_BUS".

--- a/third_party/tests/BlackParrot/BlackParrot.log
+++ b/third_party/tests/BlackParrot/BlackParrot.log
@@ -2165,6 +2165,24 @@ there are 2 more instances of this message.
 [WRN:EL0513] Nb undefined instances: 10.
 
 UHDM HTML COVERAGE REPORT: ../../../build/tests/BlackParrot/slpp_all//surelog.uhdm.chk.html
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_fp.v:38: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_fp.v:44: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_fp.v:48: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_fp.v:55: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_fp.v:57: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_fp.v:65: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_fp.v:69: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_fp.v:76: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_fp.v:85: UHDM coverage pointing to empty source line.
+
 [ERR:UH0704] ./bp_be/src/v/bp_be_checker/bp_be_director.v:18: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./bp_be/src/v/bp_be_checker/bp_be_director.v:28: UHDM coverage pointing to empty source line.
@@ -2227,261 +2245,231 @@ UHDM HTML COVERAGE REPORT: ../../../build/tests/BlackParrot/slpp_all//surelog.uh
 
 [ERR:UH0704] ./bp_be/src/v/bp_be_checker/bp_be_director.v:305: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_instr_scan.v:19: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:57: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_instr_scan.v:27: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:61: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_instr_scan.v:30: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:69: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_instr_scan.v:33: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:74: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:41: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:77: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:45: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:80: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:51: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:83: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:62: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:87: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:64: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:110: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:68: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:112: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:75: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:116: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:81: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:124: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:83: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:144: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:88: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:152: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:92: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:154: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:94: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:157: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:101: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:165: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:115: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:176: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:122: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:180: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:124: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:183: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:132: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:187: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:136: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:197: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:140: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:199: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:145: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:247: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:150: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:252: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:154: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:255: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:165: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:260: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:170: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:263: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:180: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:270: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:185: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:277: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:205: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_lce_id_to_cord.v:27: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:210: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_core.v:7: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:212: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_core.v:28: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:214: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_core.v:36: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:230: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_core.v:38: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:235: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_core.v:43: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:237: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_core.v:48: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:240: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_core.v:52: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:247: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_core.v:57: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:252: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_core.v:61: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:259: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_core.v:66: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:262: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_core.v:72: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:269: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_core.v:76: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:275: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_core.v:80: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:278: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_core.v:82: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:285: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_core.v:89: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:289: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_core.v:91: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:294: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_core.v:95: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:298: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_core.v:99: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:301: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_core.v:104: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:308: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_core.v:108: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:315: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_core.v:112: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:321: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_core.v:116: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:323: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_core.v:121: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:327: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_core.v:132: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:329: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_core.v:145: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:350: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_core.v:156: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:353: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_core.v:160: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:361: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_core.v:164: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:44: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_core.v:169: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:47: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_core.v:178: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:54: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_core.v:182: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:58: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_core.v:185: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:62: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_core.v:189: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:69: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_core.v:193: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:73: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_core.v:197: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:77: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_core.v:201: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:82: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_core.v:205: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:91: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_core.v:209: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:96: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_core.v:216: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:101: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_chip.v:8: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:107: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_chip.v:27: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:109: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_chip.v:30: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:132: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_chip.v:33: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:140: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_chip.v:39: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:143: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_chip.v:42: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:145: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_chip.v:45: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:151: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_chip.v:48: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:155: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_chip.v:62: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:161: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_chip.v:65: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:164: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_chip.v:71: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:168: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_chip.v:74: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:172: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_chip.v:77: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:175: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_chip.v:82: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:177: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_chip.v:86: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:180: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_chip.v:90: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:193: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_chip.v:93: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:208: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_chip.v:97: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:210: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_chip.v:103: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:216: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_chip.v:106: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:231: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_chip.v:108: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:233: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_chip.v:112: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:8: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_chip.v:116: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:29: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_chip.v:119: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:32: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_chip.v:122: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:35: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_chip.v:125: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:41: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_chip.v:128: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:46: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_chip.v:131: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:51: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_chip.v:135: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:54: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_chip.v:137: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:66: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_chip.v:138: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:68: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_be/src/include/bp_be_pkg.vh:10: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:72: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_be/src/include/bp_be_pkg.vh:12: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:75: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_be/src/include/bp_be_pkg.vh:13: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:82: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_fe/src/include/bp_fe_pkg.vh:9: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:87: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_common/src/include/bp_common_pkg.vh:38: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:93: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_common/src/include/bp_common_pkg.vh:53: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:99: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_common/src/include/bp_common_pkg.vh:55: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:128: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/include/v/bp_cce_pkg.v:25: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:131: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/include/v/bp_cce_pkg.v:27: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:150: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/include/v/bp_cce_pkg.v:44: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:178: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/include/v/bp_cce_pkg.v:51: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:181: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:196: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:199: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:214: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:217: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:233: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:236: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:241: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:253: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:256: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:261: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_common/src/v/bp_addr_map.v:12: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_common/src/v/bp_addr_map.v:15: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_common/src/v/bp_addr_map.v:23: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_common/src/v/bp_addr_map.v:25: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_common/src/v/bp_addr_map.v:35: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/include/v/bp_cce_pkg.v:53: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./bp_common/src/include/bp_common_aviary_pkg.vh:8: UHDM coverage pointing to empty source line.
 
@@ -2549,30 +2537,6 @@ UHDM HTML COVERAGE REPORT: ../../../build/tests/BlackParrot/slpp_all//surelog.uh
 
 [ERR:UH0704] ./bp_common/src/include/bp_common_aviary_pkg.vh:328: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/include/v/bp_cce_pkg.v:25: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/include/v/bp_cce_pkg.v:27: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/include/v/bp_cce_pkg.v:44: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/include/v/bp_cce_pkg.v:51: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/include/v/bp_cce_pkg.v:53: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_common/src/include/bp_common_pkg.vh:38: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_common/src/include/bp_common_pkg.vh:53: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_common/src/include/bp_common_pkg.vh:55: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/include/bp_be_pkg.vh:10: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/include/bp_be_pkg.vh:12: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/include/bp_be_pkg.vh:13: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/include/bp_fe_pkg.vh:9: UHDM coverage pointing to empty source line.
-
 [ERR:UH0704] ./external/basejump_stl/bsg_dataflow/bsg_channel_tunnel.v:70: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./external/basejump_stl/bsg_dataflow/bsg_channel_tunnel.v:74: UHDM coverage pointing to empty source line.
@@ -2611,27 +2575,25 @@ UHDM HTML COVERAGE REPORT: ../../../build/tests/BlackParrot/slpp_all//surelog.uh
 
 [ERR:UH0704] ./external/basejump_stl/bsg_dataflow/bsg_1_to_n_tagged.v:46: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./external/basejump_stl/bsg_dataflow/bsg_serial_in_parallel_out_dynamic.v:111: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./external/basejump_stl/bsg_dataflow/bsg_fifo_1rw_large.v:31: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./external/basejump_stl/bsg_dataflow/bsg_serial_in_parallel_out_dynamic.v:149: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./external/basejump_stl/bsg_dataflow/bsg_fifo_1rw_large.v:33: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./external/basejump_stl/bsg_dataflow/bsg_serial_in_parallel_out_dynamic.v:153: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./external/basejump_stl/bsg_dataflow/bsg_fifo_1rw_large.v:35: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./external/basejump_stl/bsg_dataflow/bsg_serial_in_parallel_out_dynamic.v:167: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./external/basejump_stl/bsg_dataflow/bsg_fifo_1rw_large.v:39: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./external/basejump_stl/bsg_dataflow/bsg_serial_in_parallel_out_dynamic.v:171: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./external/basejump_stl/bsg_dataflow/bsg_fifo_1rw_large.v:46: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./external/basejump_stl/bsg_dataflow/bsg_fifo_1r1w_small.v:52: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./external/basejump_stl/bsg_dataflow/bsg_fifo_1rw_large.v:54: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./external/basejump_stl/bsg_dataflow/bsg_fifo_1r1w_small.v:56: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./external/basejump_stl/bsg_dataflow/bsg_fifo_1rw_large.v:57: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./external/basejump_stl/bsg_dataflow/bsg_fifo_1r1w_small.v:92: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./external/basejump_stl/bsg_dataflow/bsg_fifo_1rw_large.v:64: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./external/basejump_stl/bsg_async/bsg_launch_sync_sync.v:249: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./external/basejump_stl/bsg_dataflow/bsg_fifo_1rw_large.v:69: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./external/basejump_stl/bsg_async/bsg_launch_sync_sync.v:251: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_async/bsg_launch_sync_sync.v:299: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./external/basejump_stl/bsg_dataflow/bsg_fifo_1rw_large.v:88: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./external/basejump_stl/bsg_dataflow/bsg_1_to_n_tagged_fifo.v:23: UHDM coverage pointing to empty source line.
 
@@ -2654,6 +2616,18 @@ UHDM HTML COVERAGE REPORT: ../../../build/tests/BlackParrot/slpp_all//surelog.uh
 [ERR:UH0704] ./external/basejump_stl/bsg_dataflow/bsg_1_to_n_tagged_fifo.v:85: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./external/basejump_stl/bsg_dataflow/bsg_1_to_n_tagged_fifo.v:89: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_dataflow/bsg_fifo_1r1w_small.v:52: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_dataflow/bsg_fifo_1r1w_small.v:56: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_dataflow/bsg_fifo_1r1w_small.v:92: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_async/bsg_launch_sync_sync.v:249: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_async/bsg_launch_sync_sync.v:251: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_async/bsg_launch_sync_sync.v:299: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./external/basejump_stl/bsg_dataflow/bsg_flow_counter.v:19: UHDM coverage pointing to empty source line.
 
@@ -2699,125 +2673,27 @@ UHDM HTML COVERAGE REPORT: ../../../build/tests/BlackParrot/slpp_all//surelog.uh
 
 [ERR:UH0704] ./external/basejump_stl/bsg_dataflow/bsg_fifo_tracker.v:87: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./external/basejump_stl/bsg_dataflow/bsg_fifo_1rw_large.v:31: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./external/basejump_stl/bsg_dataflow/bsg_serial_in_parallel_out_dynamic.v:111: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./external/basejump_stl/bsg_dataflow/bsg_fifo_1rw_large.v:33: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./external/basejump_stl/bsg_dataflow/bsg_serial_in_parallel_out_dynamic.v:149: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./external/basejump_stl/bsg_dataflow/bsg_fifo_1rw_large.v:35: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./external/basejump_stl/bsg_dataflow/bsg_serial_in_parallel_out_dynamic.v:153: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./external/basejump_stl/bsg_dataflow/bsg_fifo_1rw_large.v:39: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./external/basejump_stl/bsg_dataflow/bsg_serial_in_parallel_out_dynamic.v:167: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./external/basejump_stl/bsg_dataflow/bsg_fifo_1rw_large.v:46: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./external/basejump_stl/bsg_dataflow/bsg_serial_in_parallel_out_dynamic.v:171: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./external/basejump_stl/bsg_dataflow/bsg_fifo_1rw_large.v:54: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./external/basejump_stl/bsg_misc/bsg_mux_butterfly.v:44: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./external/basejump_stl/bsg_dataflow/bsg_fifo_1rw_large.v:57: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./external/basejump_stl/bsg_misc/bsg_mux_butterfly.v:46: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./external/basejump_stl/bsg_dataflow/bsg_fifo_1rw_large.v:64: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./external/basejump_stl/bsg_misc/bsg_mux_butterfly.v:49: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./external/basejump_stl/bsg_dataflow/bsg_fifo_1rw_large.v:69: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_dataflow/bsg_fifo_1rw_large.v:88: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1rw_sync.v:23: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./external/basejump_stl/bsg_misc/bsg_mux_butterfly.v:62: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./external/basejump_stl/bsg_dataflow/bsg_shift_reg.v:30: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1r1w.v:16: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1r1w.v:20: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1r1w.v:24: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1r1w.v:35: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1r1w.v:50: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1rw_sync_synth.v:25: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1rw_sync_synth.v:30: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1rw_sync_synth.v:33: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1rw_sync_synth.v:39: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1rw_sync_synth.v:43: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1rw_sync_synth.v:70: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.v:23: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.v:60: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_2r1w_sync.v:22: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_2r1w_sync.v:26: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_2r1w_sync.v:31: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_2r1w_sync.v:38: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_2r1w_sync.v:80: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_2r1w_sync.v:83: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_synth.v:8: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_synth.v:14: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_synth.v:17: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_synth.v:22: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_synth.v:27: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.v:3: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.v:11: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.v:14: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.v:19: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.v:24: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.v:57: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1r1w_synth.v:19: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1r1w_synth.v:23: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1r1w_synth.v:27: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1r1w_synth.v:32: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1r1w_synth.v:35: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1r1w_synth.v:38: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1r1w_sync.v:23: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1r1w_sync.v:27: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1r1w_sync.v:31: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1r1w_sync.v:36: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1r1w_sync.v:78: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_synth.v:27: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_synth.v:31: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_synth.v:33: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_synth.v:39: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_synth.v:41: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_synth.v:43: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_synth.v:47: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1rw_sync.v:23: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_2r1w_sync_synth.v:23: UHDM coverage pointing to empty source line.
 
@@ -2839,7 +2715,57 @@ UHDM HTML COVERAGE REPORT: ../../../build/tests/BlackParrot/slpp_all//surelog.uh
 
 [ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_2r1w_sync_synth.v:86: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_cam_1r1w.v:28: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.v:23: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.v:60: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.v:3: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.v:11: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.v:14: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.v:19: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.v:24: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.v:57: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_synth.v:27: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_synth.v:31: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_synth.v:33: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_synth.v:39: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_synth.v:41: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_synth.v:43: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_synth.v:47: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1rw_sync_synth.v:25: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1rw_sync_synth.v:30: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1rw_sync_synth.v:33: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1rw_sync_synth.v:39: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1rw_sync_synth.v:43: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1rw_sync_synth.v:70: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_synth.v:8: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_synth.v:14: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_synth.v:17: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_synth.v:22: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_synth.v:27: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1r1w_sync_synth.v:23: UHDM coverage pointing to empty source line.
 
@@ -2859,6 +2785,56 @@ UHDM HTML COVERAGE REPORT: ../../../build/tests/BlackParrot/slpp_all//surelog.uh
 
 [ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1r1w_sync_synth.v:71: UHDM coverage pointing to empty source line.
 
+[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1r1w.v:16: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1r1w.v:20: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1r1w.v:24: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1r1w.v:35: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1r1w.v:50: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1r1w_sync.v:23: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1r1w_sync.v:27: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1r1w_sync.v:31: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1r1w_sync.v:36: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1r1w_sync.v:78: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_cam_1r1w.v:28: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_2r1w_sync.v:22: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_2r1w_sync.v:26: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_2r1w_sync.v:31: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_2r1w_sync.v:38: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_2r1w_sync.v:80: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_2r1w_sync.v:83: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1r1w_synth.v:19: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1r1w_synth.v:23: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1r1w_synth.v:27: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1r1w_synth.v:32: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1r1w_synth.v:35: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_mem/bsg_mem_1r1w_synth.v:38: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_misc/bsg_counter_up_down_variable.v:18: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_misc/bsg_counter_up_down_variable.v:21: UHDM coverage pointing to empty source line.
+
 [ERR:UH0704] ./external/basejump_stl/bsg_misc/bsg_array_concentrate_static.v:10: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./external/basejump_stl/bsg_misc/bsg_array_concentrate_static.v:13: UHDM coverage pointing to empty source line.
@@ -2870,6 +2846,8 @@ UHDM HTML COVERAGE REPORT: ../../../build/tests/BlackParrot/slpp_all//surelog.uh
 [ERR:UH0704] ./external/basejump_stl/bsg_misc/bsg_counter_up_down.v:35: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./external/basejump_stl/bsg_misc/bsg_counter_up_down.v:38: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_misc/bsg_counter_clear_up.v:16: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./external/basejump_stl/bsg_misc/bsg_concentrate_static.v:14: UHDM coverage pointing to empty source line.
 
@@ -2885,12 +2863,6 @@ UHDM HTML COVERAGE REPORT: ../../../build/tests/BlackParrot/slpp_all//surelog.uh
 
 [ERR:UH0704] ./external/basejump_stl/bsg_misc/bsg_circular_ptr.v:71: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./external/basejump_stl/bsg_misc/bsg_counter_clear_up.v:16: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_misc/bsg_counter_up_down_variable.v:18: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_misc/bsg_counter_up_down_variable.v:21: UHDM coverage pointing to empty source line.
-
 [ERR:UH0704] ./external/basejump_stl/bsg_misc/bsg_encode_one_hot.v:26: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./external/basejump_stl/bsg_misc/bsg_encode_one_hot.v:28: UHDM coverage pointing to empty source line.
@@ -2900,14 +2872,6 @@ UHDM HTML COVERAGE REPORT: ../../../build/tests/BlackParrot/slpp_all//surelog.uh
 [ERR:UH0704] ./external/basejump_stl/bsg_misc/bsg_encode_one_hot.v:58: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./external/basejump_stl/bsg_misc/bsg_mux.v:15: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_misc/bsg_mux_butterfly.v:44: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_misc/bsg_mux_butterfly.v:46: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_misc/bsg_mux_butterfly.v:49: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_misc/bsg_mux_butterfly.v:62: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./external/basejump_stl/bsg_misc/bsg_priority_encode.v:26: UHDM coverage pointing to empty source line.
 
@@ -3019,26 +2983,6 @@ UHDM HTML COVERAGE REPORT: ../../../build/tests/BlackParrot/slpp_all//surelog.uh
 
 [ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_mesh_router_buffered.v:144: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_concentrator_out.v:18: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_concentrator_out.v:39: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_concentrator_out.v:58: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_concentrator_out.v:67: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_concentrator_out.v:72: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_concentrator_out.v:75: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_concentrator_out.v:78: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_concentrator_out.v:81: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_concentrator_out.v:83: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_concentrator_out.v:119: UHDM coverage pointing to empty source line.
-
 [ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_concentrator.v:18: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_concentrator.v:39: UHDM coverage pointing to empty source line.
@@ -3075,6 +3019,26 @@ UHDM HTML COVERAGE REPORT: ../../../build/tests/BlackParrot/slpp_all//surelog.uh
 
 [ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_noc_repeater_node.v:90: UHDM coverage pointing to empty source line.
 
+[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_concentrator_out.v:18: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_concentrator_out.v:39: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_concentrator_out.v:58: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_concentrator_out.v:67: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_concentrator_out.v:72: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_concentrator_out.v:75: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_concentrator_out.v:78: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_concentrator_out.v:81: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_concentrator_out.v:83: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_concentrator_out.v:119: UHDM coverage pointing to empty source line.
+
 [ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_router_adapter_in.v:15: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_router_adapter_in.v:23: UHDM coverage pointing to empty source line.
@@ -3094,28 +3058,6 @@ UHDM HTML COVERAGE REPORT: ../../../build/tests/BlackParrot/slpp_all//surelog.uh
 [ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_router_adapter_in.v:59: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_router_adapter_in.v:68: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_concentrator_in.v:18: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_concentrator_in.v:39: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_concentrator_in.v:58: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_concentrator_in.v:67: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_concentrator_in.v:72: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_concentrator_in.v:75: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_concentrator_in.v:78: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_concentrator_in.v:81: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_concentrator_in.v:84: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_concentrator_in.v:98: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_concentrator_in.v:114: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_router_adapter_out.v:9: UHDM coverage pointing to empty source line.
 
@@ -3142,30 +3084,6 @@ UHDM HTML COVERAGE REPORT: ../../../build/tests/BlackParrot/slpp_all//surelog.uh
 [ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_router_adapter_out.v:80: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_router_adapter_out.v:85: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_router_adapter.v:17: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_router_adapter.v:25: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_router_adapter.v:34: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_router_adapter.v:44: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_router_adapter.v:47: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_router_adapter.v:51: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_router_adapter.v:54: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_router_adapter.v:65: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_router_adapter.v:69: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_router_adapter.v:83: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_router_adapter.v:86: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_router_adapter.v:92: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_router.v:11: UHDM coverage pointing to empty source line.
 
@@ -3216,6 +3134,52 @@ UHDM HTML COVERAGE REPORT: ../../../build/tests/BlackParrot/slpp_all//surelog.uh
 [ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_router.v:205: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_router.v:208: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_concentrator_in.v:18: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_concentrator_in.v:39: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_concentrator_in.v:58: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_concentrator_in.v:67: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_concentrator_in.v:72: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_concentrator_in.v:75: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_concentrator_in.v:78: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_concentrator_in.v:81: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_concentrator_in.v:84: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_concentrator_in.v:98: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_concentrator_in.v:114: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_router_adapter.v:17: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_router_adapter.v:25: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_router_adapter.v:34: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_router_adapter.v:44: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_router_adapter.v:47: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_router_adapter.v:51: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_router_adapter.v:54: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_router_adapter.v:65: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_router_adapter.v:69: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_router_adapter.v:83: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_router_adapter.v:86: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./external/basejump_stl/bsg_noc/bsg_wormhole_router_adapter.v:92: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./bp_common/src/v/bsg_fifo_1r1w_rolly.v:11: UHDM coverage pointing to empty source line.
 
@@ -3359,6 +3323,56 @@ UHDM HTML COVERAGE REPORT: ../../../build/tests/BlackParrot/slpp_all//surelog.uh
 
 [ERR:UH0704] ./bp_be/src/v/bp_be_top.v:286: UHDM coverage pointing to empty source line.
 
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_instr_decoder.v:42: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_instr_decoder.v:49: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_instr_decoder.v:52: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_instr_decoder.v:54: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_instr_decoder.v:63: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_instr_decoder.v:70: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_instr_decoder.v:76: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_instr_decoder.v:80: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_instr_decoder.v:83: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_instr_decoder.v:89: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_instr_decoder.v:97: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_instr_decoder.v:99: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_instr_decoder.v:119: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_instr_decoder.v:141: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_regfile.v:26: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_regfile.v:30: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_regfile.v:35: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_regfile.v:54: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_regfile.v:61: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_regfile.v:65: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_regfile.v:69: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_regfile.v:82: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_regfile.v:119: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_regfile.v:121: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_regfile.v:122: UHDM coverage pointing to empty source line.
+
 [ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_calculator_top.v:14: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_calculator_top.v:24: UHDM coverage pointing to empty source line.
@@ -3477,33 +3491,17 @@ UHDM HTML COVERAGE REPORT: ../../../build/tests/BlackParrot/slpp_all//surelog.uh
 
 [ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_calculator_top.v:591: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_instr_decoder.v:42: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_int_alu.v:46: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_instr_decoder.v:49: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_int_alu.v:50: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_instr_decoder.v:52: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_int_alu.v:69: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_instr_decoder.v:54: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_int_alu.v:72: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_instr_decoder.v:63: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_int_alu.v:113: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_instr_decoder.v:70: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_instr_decoder.v:76: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_instr_decoder.v:80: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_instr_decoder.v:83: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_instr_decoder.v:89: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_instr_decoder.v:97: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_instr_decoder.v:99: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_instr_decoder.v:119: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_instr_decoder.v:141: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_int_alu.v:115: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./bp_be/src/v/bp_be_checker/bp_be_detector.v:23: UHDM coverage pointing to empty source line.
 
@@ -3565,78 +3563,6 @@ UHDM HTML COVERAGE REPORT: ../../../build/tests/BlackParrot/slpp_all//surelog.uh
 
 [ERR:UH0704] ./bp_be/src/v/bp_be_checker/bp_be_detector.v:164: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_mul.v:38: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_mul.v:42: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_mul.v:46: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_mul.v:53: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_mul.v:55: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_mul.v:61: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_mul.v:65: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_mul.v:70: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_mul.v:79: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_int_alu.v:46: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_int_alu.v:50: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_int_alu.v:69: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_int_alu.v:72: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_int_alu.v:113: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_int_alu.v:115: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_fp.v:38: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_fp.v:44: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_fp.v:48: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_fp.v:55: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_fp.v:57: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_fp.v:65: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_fp.v:69: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_fp.v:76: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_fp.v:85: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_int.v:47: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_int.v:50: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_int.v:56: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_int.v:59: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_int.v:65: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_int.v:67: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_int.v:72: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_int.v:75: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_int.v:80: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_int.v:88: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_int.v:104: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_int.v:106: UHDM coverage pointing to empty source line.
-
 [ERR:UH0704] ./bp_be/src/v/bp_be_checker/bp_be_checker_top.v:18: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./bp_be/src/v/bp_be_checker/bp_be_checker_top.v:28: UHDM coverage pointing to empty source line.
@@ -3689,27 +3615,29 @@ UHDM HTML COVERAGE REPORT: ../../../build/tests/BlackParrot/slpp_all//surelog.uh
 
 [ERR:UH0704] ./bp_be/src/v/bp_be_checker/bp_be_checker_top.v:173: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_regfile.v:26: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_int.v:47: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_regfile.v:30: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_int.v:50: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_regfile.v:35: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_int.v:56: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_regfile.v:54: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_int.v:59: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_regfile.v:61: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_int.v:65: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_regfile.v:65: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_int.v:67: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_regfile.v:69: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_int.v:72: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_regfile.v:82: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_int.v:75: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_regfile.v:119: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_int.v:80: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_regfile.v:121: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_int.v:88: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_regfile.v:122: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_int.v:104: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_int.v:106: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.v:26: UHDM coverage pointing to empty source line.
 
@@ -3756,6 +3684,24 @@ UHDM HTML COVERAGE REPORT: ../../../build/tests/BlackParrot/slpp_all//surelog.uh
 [ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.v:163: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_mem.v:165: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_mul.v:38: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_mul.v:42: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_mul.v:46: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_mul.v:53: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_mul.v:55: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_mul.v:61: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_mul.v:65: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_mul.v:70: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_calculator/bp_be_pipe_mul.v:79: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./bp_be/src/v/bp_be_checker/bp_be_scheduler.v:21: UHDM coverage pointing to empty source line.
 
@@ -3920,146 +3866,6 @@ UHDM HTML COVERAGE REPORT: ../../../build/tests/BlackParrot/slpp_all//surelog.uh
 [ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_csr.v:485: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_csr.v:487: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:85: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:98: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:114: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:116: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:120: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:123: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:128: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:132: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:137: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:141: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:146: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:151: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:154: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:164: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:177: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:189: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:255: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:357: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:359: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:363: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:377: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:381: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:411: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:424: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:455: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:462: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:470: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:481: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:488: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:499: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:513: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:516: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:520: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:527: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:535: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:538: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:541: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:551: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:581: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:598: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:631: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:635: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:638: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:641: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:654: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:656: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:665: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:669: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:674: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:678: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:688: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:692: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:696: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:700: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:703: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:714: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:743: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:811: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:842: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:848: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:851: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:853: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:885: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:930: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:934: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:947: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:996: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:1000: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:1019: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:1072: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_lce_cmd.v:38: UHDM coverage pointing to empty source line.
 
@@ -4265,6 +4071,182 @@ UHDM HTML COVERAGE REPORT: ../../../build/tests/BlackParrot/slpp_all//surelog.uh
 
 [ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_lce.v:398: UHDM coverage pointing to empty source line.
 
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_wbuf.v:15: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_wbuf.v:23: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_wbuf.v:33: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_wbuf.v:37: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_wbuf.v:44: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_wbuf.v:57: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_wbuf.v:59: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_wbuf.v:66: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_wbuf.v:145: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_wbuf.v:150: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_wbuf.v:154: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_wbuf.v:166: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_wbuf.v:170: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_wbuf.v:209: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_wbuf.v:213: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_wbuf.v:217: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_wbuf.v:221: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_wbuf.v:223: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:85: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:98: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:114: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:116: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:120: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:123: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:128: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:132: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:137: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:141: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:146: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:151: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:154: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:164: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:177: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:189: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:255: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:357: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:359: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:363: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:377: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:381: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:411: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:424: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:455: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:462: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:470: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:481: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:488: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:499: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:513: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:516: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:520: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:527: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:535: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:538: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:541: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:551: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:581: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:598: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:631: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:635: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:638: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:641: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:654: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:656: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:665: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:669: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:674: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:678: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:688: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:692: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:696: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:700: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:703: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:714: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:743: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:811: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:842: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:848: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:851: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:853: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:885: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:930: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:934: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:947: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:996: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:1000: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:1019: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache.v:1072: UHDM coverage pointing to empty source line.
+
 [ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_lce_req.v:49: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_lce_req.v:51: UHDM coverage pointing to empty source line.
@@ -4340,114 +4322,6 @@ UHDM HTML COVERAGE REPORT: ../../../build/tests/BlackParrot/slpp_all//surelog.uh
 [ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_lce_req.v:306: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_lce_req.v:310: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_wbuf.v:15: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_wbuf.v:23: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_wbuf.v:33: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_wbuf.v:37: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_wbuf.v:44: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_wbuf.v:57: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_wbuf.v:59: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_wbuf.v:66: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_wbuf.v:145: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_wbuf.v:150: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_wbuf.v:154: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_wbuf.v:166: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_wbuf.v:170: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_wbuf.v:209: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_wbuf.v:213: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_wbuf.v:217: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_wbuf.v:221: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_dcache/bp_be_dcache_wbuf.v:223: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:38: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:40: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:46: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:51: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:55: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:59: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:63: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:81: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:99: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:103: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:110: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:112: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:116: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:118: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:122: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:125: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:132: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:138: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:153: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:160: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:168: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:171: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:179: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:182: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:196: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:202: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:209: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:216: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:218: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:221: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:229: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:259: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:275: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:303: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:307: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:314: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_mem_top.v:10: UHDM coverage pointing to empty source line.
 
@@ -4556,6 +4430,194 @@ UHDM HTML COVERAGE REPORT: ../../../build/tests/BlackParrot/slpp_all//surelog.uh
 [ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_mem_top.v:442: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./bp_be/src/v/bp_be_mem/bp_be_mem_top.v:452: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:47: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:52: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:54: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:57: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:60: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:62: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:67: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:81: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:85: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:89: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:93: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:96: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:100: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:105: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:115: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:116: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:127: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:131: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:136: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:140: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:150: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:157: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:162: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:165: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:170: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:174: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:187: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:192: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:195: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:201: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:206: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:210: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:214: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:218: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:222: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:234: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:250: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:38: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:40: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:46: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:51: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:55: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:59: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:63: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:81: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:99: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:103: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:110: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:112: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:116: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:118: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:122: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:125: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:132: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:138: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:153: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:160: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:168: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:171: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:179: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:182: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:196: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:202: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:209: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:216: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:218: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:221: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:229: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:259: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:275: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:303: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:307: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_cmd.v:314: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_req.v:41: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_req.v:48: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_req.v:73: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_req.v:84: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_req.v:104: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_req.v:111: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_req.v:114: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_req.v:116: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_req.v:121: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_req.v:128: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_req.v:129: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_req.v:131: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_req.v:163: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_req.v:174: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_req.v:184: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_req.v:193: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_req.v:195: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_instr_scan.v:19: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_instr_scan.v:27: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_instr_scan.v:30: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_instr_scan.v:33: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./bp_fe/src/v/bp_fe_icache.v:34: UHDM coverage pointing to empty source line.
 
@@ -4683,114 +4745,6 @@ UHDM HTML COVERAGE REPORT: ../../../build/tests/BlackParrot/slpp_all//surelog.uh
 
 [ERR:UH0704] ./bp_fe/src/v/bp_fe_icache.v:534: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:47: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:52: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:54: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:57: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:60: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:62: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:67: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:81: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:85: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:89: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:93: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:96: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:100: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:105: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:115: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:116: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:127: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:131: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:136: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:140: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:150: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:157: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:162: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:165: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:170: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:174: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:187: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:192: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:195: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:201: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:206: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:210: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:214: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:218: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:222: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:234: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce.v:250: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_req.v:41: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_req.v:48: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_req.v:73: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_req.v:84: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_req.v:104: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_req.v:111: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_req.v:114: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_req.v:116: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_req.v:121: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_req.v:128: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_req.v:129: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_req.v:131: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_req.v:163: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_req.v:174: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_req.v:184: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_req.v:193: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_lce_req.v:195: UHDM coverage pointing to empty source line.
-
 [ERR:UH0704] ./bp_fe/src/v/bp_fe_mem.v:9: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./bp_fe/src/v/bp_fe_mem.v:18: UHDM coverage pointing to empty source line.
@@ -4840,56 +4794,6 @@ UHDM HTML COVERAGE REPORT: ../../../build/tests/BlackParrot/slpp_all//surelog.uh
 [ERR:UH0704] ./bp_fe/src/v/bp_fe_mem.v:136: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./bp_fe/src/v/bp_fe_mem.v:140: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_top.v:4: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_top.v:16: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_top.v:22: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_top.v:24: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_top.v:28: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_top.v:33: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_top.v:37: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_top.v:41: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_top.v:45: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_top.v:49: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_top.v:54: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_top.v:63: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_top.v:73: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_top.v:75: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_top.v:79: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_top.v:84: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_top.v:89: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_top.v:102: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_top.v:106: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_top.v:108: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_top.v:112: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_top.v:124: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_top.v:129: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_top.v:131: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_fe/src/v/bp_fe_top.v:132: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./bp_fe/src/v/bp_fe_pc_gen.v:9: UHDM coverage pointing to empty source line.
 
@@ -5115,6 +5019,56 @@ UHDM HTML COVERAGE REPORT: ../../../build/tests/BlackParrot/slpp_all//surelog.uh
 
 [ERR:UH0704] ./bp_me/src/v/cce/bp_cce.v:590: UHDM coverage pointing to empty source line.
 
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_top.v:4: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_top.v:16: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_top.v:22: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_top.v:24: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_top.v:28: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_top.v:33: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_top.v:37: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_top.v:41: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_top.v:45: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_top.v:49: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_top.v:54: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_top.v:63: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_top.v:73: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_top.v:75: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_top.v:79: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_top.v:84: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_top.v:89: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_top.v:102: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_top.v:106: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_top.v:108: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_top.v:112: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_top.v:124: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_top.v:129: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_top.v:131: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_fe/src/v/bp_fe_top.v:132: UHDM coverage pointing to empty source line.
+
 [ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir_lru_extract.v:25: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir_lru_extract.v:35: UHDM coverage pointing to empty source line.
@@ -5128,6 +5082,116 @@ UHDM HTML COVERAGE REPORT: ../../../build/tests/BlackParrot/slpp_all//surelog.uh
 [ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir_lru_extract.v:54: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir_lru_extract.v:66: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:41: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:45: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:51: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:62: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:64: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:68: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:75: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:81: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:83: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:88: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:92: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:94: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:101: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:115: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:122: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:124: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:132: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:136: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:140: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:145: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:150: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:154: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:165: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:170: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:180: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:185: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:205: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:210: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:212: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:214: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:230: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:235: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:237: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:240: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:247: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:252: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:259: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:262: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:269: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:275: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:278: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:285: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:289: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:294: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:298: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:301: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:308: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:315: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:321: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:323: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:327: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:329: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:350: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:353: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir.v:361: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./bp_me/src/v/cce/bp_cce_dir_tag_checker.v:27: UHDM coverage pointing to empty source line.
 
@@ -5164,96 +5228,6 @@ UHDM HTML COVERAGE REPORT: ../../../build/tests/BlackParrot/slpp_all//surelog.uh
 [ERR:UH0704] ./bp_me/src/v/cce/bp_cce_gad.v:122: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./bp_me/src/v/cce/bp_cce_gad.v:137: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:39: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:42: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:49: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:53: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:57: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:64: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:68: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:72: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:76: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:79: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:82: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:87: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:91: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:93: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:95: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:97: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:100: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:108: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:110: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:115: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:121: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:133: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:145: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:162: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:165: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:170: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:174: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:179: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:187: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:195: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:198: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:202: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:205: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:209: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:226: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:229: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:234: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:238: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:243: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:251: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:259: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:274: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:280: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:287: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:293: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_cached.v:37: UHDM coverage pointing to empty source line.
 
@@ -5369,65 +5343,161 @@ UHDM HTML COVERAGE REPORT: ../../../build/tests/BlackParrot/slpp_all//surelog.uh
 
 [ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_cached.v:451: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:57: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:39: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:61: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:42: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:69: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:49: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:74: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:53: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:77: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:57: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:80: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:64: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:83: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:68: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:87: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:72: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:110: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:76: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:112: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:79: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:116: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:82: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:124: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:87: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:144: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:91: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:152: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:93: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:154: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:95: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:157: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:97: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:165: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:100: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:176: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:108: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:180: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:110: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:183: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:115: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:187: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:121: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:197: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:133: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:199: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:145: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:247: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:162: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:252: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:165: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:255: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:170: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:260: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:174: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:263: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:179: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:270: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:187: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pc.v:277: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:195: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:198: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:202: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:205: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:209: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:226: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:229: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:234: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:238: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:243: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:251: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:259: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:274: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:280: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:287: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg.v:293: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:44: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:47: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:54: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:58: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:62: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:69: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:73: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:77: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:82: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:91: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:96: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:101: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:107: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:109: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:132: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:140: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:143: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:145: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:151: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:155: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:161: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:164: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:168: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:172: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:175: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:177: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:180: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:193: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:208: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:210: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:216: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:231: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_msg_uncached.v:233: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pending.v:32: UHDM coverage pointing to empty source line.
 
@@ -5444,124 +5514,6 @@ UHDM HTML COVERAGE REPORT: ../../../build/tests/BlackParrot/slpp_all//surelog.uh
 [ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pending.v:81: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./bp_me/src/v/cce/bp_cce_pending.v:84: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_cce_to_wormhole_link_master.v:21: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_cce_to_wormhole_link_master.v:41: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_cce_to_wormhole_link_master.v:50: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_cce_to_wormhole_link_master.v:53: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_cce_to_wormhole_link_master.v:66: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_cce_to_wormhole_link_master.v:70: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_cce_to_wormhole_link_master.v:96: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_cce_to_wormhole_link_master.v:100: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_cce_to_wormhole_link_master.v:104: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_cce_to_wormhole_link_master.v:115: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_cce_to_wormhole_link_master.v:118: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_cce_to_wormhole_link_master.v:126: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_cce_to_wormhole_link_master.v:128: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_cce_to_wormhole_link_master.v:129: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_top.v:38: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_top.v:47: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_top.v:52: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_top.v:59: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_top.v:63: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_top.v:69: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_top.v:77: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_top.v:81: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_top.v:85: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_top.v:89: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_top.v:92: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_top.v:111: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_top.v:126: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_top.v:142: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_top.v:159: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_top.v:210: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_top.v:212: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_top.v:216: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_top.v:224: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_top.v:229: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_top.v:237: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_mem_cmd.v:22: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_mem_cmd.v:34: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_mem_cmd.v:44: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_mem_cmd.v:47: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_mem_cmd.v:49: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_mem_cmd.v:66: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_mem_cmd.v:68: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_mem_cmd.v:74: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_mem_cmd.v:78: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_mem_cmd.v:102: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_mem_cmd.v:103: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_cce_to_wormhole_link_client.v:24: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_cce_to_wormhole_link_client.v:32: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_cce_to_wormhole_link_client.v:40: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_cce_to_wormhole_link_client.v:55: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_cce_to_wormhole_link_client.v:91: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_cce_to_wormhole_link_client.v:95: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_cce_to_wormhole_link_client.v:101: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_cce_to_wormhole_link_client.v:136: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_cce_to_wormhole_link_client.v:137: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_lce_resp.v:29: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_lce_resp.v:34: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_lce_resp.v:39: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_lce_resp.v:54: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./bp_me/src/v/cce/bp_cce_reg.v:9: UHDM coverage pointing to empty source line.
 
@@ -5623,169 +5575,103 @@ UHDM HTML COVERAGE REPORT: ../../../build/tests/BlackParrot/slpp_all//surelog.uh
 
 [ERR:UH0704] ./bp_me/src/v/cce/bp_cce_reg.v:409: UHDM coverage pointing to empty source line.
 
+[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_lce_resp.v:29: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_lce_resp.v:34: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_lce_resp.v:39: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_lce_resp.v:54: UHDM coverage pointing to empty source line.
+
 [ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_cce_id_to_cord.v:25: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core.v:7: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_cce_to_wormhole_link_client.v:24: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core.v:28: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_cce_to_wormhole_link_client.v:32: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core.v:36: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_cce_to_wormhole_link_client.v:40: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core.v:38: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_cce_to_wormhole_link_client.v:55: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core.v:43: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_cce_to_wormhole_link_client.v:91: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core.v:48: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_cce_to_wormhole_link_client.v:95: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core.v:52: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_cce_to_wormhole_link_client.v:101: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core.v:57: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_cce_to_wormhole_link_client.v:136: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core.v:61: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_cce_to_wormhole_link_client.v:137: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core.v:66: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_top.v:38: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core.v:72: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_top.v:47: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core.v:76: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_top.v:52: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core.v:80: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_top.v:59: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core.v:82: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_top.v:63: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core.v:89: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_top.v:69: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core.v:91: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_top.v:77: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core.v:95: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_top.v:81: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core.v:99: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_top.v:85: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core.v:104: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_top.v:89: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core.v:108: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_top.v:92: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core.v:112: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_top.v:111: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core.v:116: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_top.v:126: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core.v:121: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_top.v:142: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core.v:132: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_top.v:159: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core.v:145: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_top.v:210: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core.v:156: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_top.v:212: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core.v:160: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_top.v:216: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core.v:164: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_top.v:224: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core.v:169: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_top.v:229: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core.v:178: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/cce/bp_cce_top.v:237: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core.v:182: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_cce_to_wormhole_link_master.v:21: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core.v:185: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_cce_to_wormhole_link_master.v:41: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core.v:189: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_cce_to_wormhole_link_master.v:50: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core.v:193: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_cce_to_wormhole_link_master.v:53: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core.v:197: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_cce_to_wormhole_link_master.v:66: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core.v:201: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_cce_to_wormhole_link_master.v:70: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core.v:205: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_cce_to_wormhole_link_master.v:96: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core.v:209: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_cce_to_wormhole_link_master.v:100: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_core.v:216: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_cce_to_wormhole_link_master.v:104: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_lce_id_to_cord.v:27: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_cce_to_wormhole_link_master.v:115: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_lce_req.v:29: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_cce_to_wormhole_link_master.v:118: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_lce_req.v:34: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_cce_to_wormhole_link_master.v:126: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_lce_req.v:41: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_cce_to_wormhole_link_master.v:128: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_lce_req.v:56: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_lce_cmd.v:29: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_lce_cmd.v:34: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_lce_cmd.v:41: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_lce_cmd.v:56: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_lce_cmd.v:73: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_lce_cmd.v:74: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_chip.v:8: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_chip.v:27: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_chip.v:30: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_chip.v:33: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_chip.v:39: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_chip.v:42: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_chip.v:45: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_chip.v:48: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_chip.v:62: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_chip.v:65: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_chip.v:71: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_chip.v:74: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_chip.v:77: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_chip.v:82: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_chip.v:86: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_chip.v:90: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_chip.v:93: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_chip.v:97: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_chip.v:103: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_chip.v:106: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_chip.v:108: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_chip.v:112: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_chip.v:116: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_chip.v:119: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_chip.v:122: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_chip.v:125: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_chip.v:128: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_chip.v:131: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_chip.v:135: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_chip.v:137: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_chip.v:138: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_cce_to_wormhole_link_master.v:129: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_mem_resp.v:22: UHDM coverage pointing to empty source line.
 
@@ -5808,6 +5694,134 @@ UHDM HTML COVERAGE REPORT: ../../../build/tests/BlackParrot/slpp_all//surelog.uh
 [ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_mem_resp.v:99: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_mem_resp.v:100: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_lce_req.v:29: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_lce_req.v:34: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_lce_req.v:41: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_lce_req.v:56: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:8: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:29: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:32: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:35: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:41: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:46: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:51: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:54: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:66: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:68: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:72: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:75: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:82: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:87: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:93: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:99: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:128: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:131: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:150: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:178: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:181: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:196: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:199: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:214: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:217: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:233: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:236: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:241: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:253: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:256: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_core_complex.v:261: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_lce_cmd.v:29: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_lce_cmd.v:34: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_lce_cmd.v:41: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_lce_cmd.v:56: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_lce_cmd.v:73: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_lce_cmd.v:74: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_mem_cmd.v:22: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_mem_cmd.v:34: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_mem_cmd.v:44: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_mem_cmd.v:47: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_mem_cmd.v:49: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_mem_cmd.v:66: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_mem_cmd.v:68: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_mem_cmd.v:74: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_mem_cmd.v:78: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_mem_cmd.v:102: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_me/src/v/wormhole/bp_me_wormhole_packet_encode_mem_cmd.v:103: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_mmio_node.v:19: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_mmio_node.v:22: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_mmio_node.v:25: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_mmio_node.v:30: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_mmio_node.v:35: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_mmio_node.v:38: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_mmio_node.v:49: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_mmio_node.v:77: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_mmio_node.v:94: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_mmio_node.v:101: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_mmio_node.v:145: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_mmio_node.v:172: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./bp_top/src/v/bp_mem_complex.v:17: UHDM coverage pointing to empty source line.
 
@@ -5853,29 +5867,133 @@ UHDM HTML COVERAGE REPORT: ../../../build/tests/BlackParrot/slpp_all//surelog.uh
 
 [ERR:UH0704] ./bp_top/src/v/bp_mem_complex.v:176: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_mmio_node.v:19: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_common/src/v/bp_addr_map.v:12: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_mmio_node.v:22: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_common/src/v/bp_addr_map.v:15: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_mmio_node.v:25: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_common/src/v/bp_addr_map.v:23: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_mmio_node.v:30: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_common/src/v/bp_addr_map.v:25: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_mmio_node.v:35: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_common/src/v/bp_addr_map.v:35: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_mmio_node.v:38: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:25: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_mmio_node.v:49: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:30: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_mmio_node.v:77: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:32: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_mmio_node.v:94: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:39: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_mmio_node.v:101: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:44: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_mmio_node.v:145: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:48: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./bp_top/src/v/bp_mmio_node.v:172: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:51: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:54: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:57: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:60: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:70: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:73: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:77: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:81: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:85: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:95: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:103: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:113: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:118: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:121: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:146: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:149: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:153: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:157: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:161: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:165: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:181: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:185: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:190: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:194: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:199: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:204: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:208: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:213: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:217: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:228: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:232: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:236: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:255: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:259: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:280: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:284: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:287: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:293: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:310: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:314: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:385: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:389: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:405: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:408: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:425: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:428: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:448: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:451: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:461: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:465: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:469: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:475: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./bp_top/src/v/bp_tile.v:478: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./bp_top/src/v/bp_mmio_enclave.v:21: UHDM coverage pointing to empty source line.
 
@@ -6040,124 +6158,6 @@ UHDM HTML COVERAGE REPORT: ../../../build/tests/BlackParrot/slpp_all//surelog.uh
 [ERR:UH0704] ./bp_top/src/v/bp_tile_node.v:442: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./bp_top/src/v/bp_tile_node.v:445: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:25: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:30: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:32: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:39: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:44: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:48: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:51: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:54: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:57: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:60: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:70: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:73: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:77: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:81: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:85: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:95: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:103: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:113: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:118: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:121: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:146: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:149: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:153: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:157: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:161: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:165: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:181: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:185: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:190: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:194: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:199: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:204: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:208: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:213: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:217: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:228: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:232: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:236: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:255: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:259: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:280: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:284: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:287: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:293: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:310: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:314: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:385: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:389: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:405: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:408: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:425: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:428: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:448: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:451: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:461: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:465: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:469: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:475: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./bp_top/src/v/bp_tile.v:478: UHDM coverage pointing to empty source line.
 
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/third_party/tests/CoresSweRV/CoresSweRV.log
+++ b/third_party/tests/CoresSweRV/CoresSweRV.log
@@ -4580,21 +4580,17 @@ there are 4 more instances of this message.
 [NTE:EL0511] Nb leaf instances: 53.
 
 UHDM HTML COVERAGE REPORT: ../../../build/tests/CoresSweRV/slpp_all//surelog.uhdm.chk.html
-[ERR:UH0704] ./design/swerv_wrapper.sv:35: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./design/swerv_wrapper.sv:43: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./design/swerv_wrapper.sv:45: UHDM coverage pointing to empty source line.
-
 [ERR:UH0704] ./design/mem.sv:35: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./design/mem.sv:36: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./design/mem.sv:40: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./design/swerv.sv:40: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./design/swerv_wrapper.sv:35: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./design/swerv.sv:379: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ./design/swerv_wrapper.sv:43: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./design/swerv_wrapper.sv:45: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./design/pic_ctrl.sv:17: UHDM coverage pointing to empty source line.
 
@@ -4621,6 +4617,10 @@ UHDM HTML COVERAGE REPORT: ../../../build/tests/CoresSweRV/slpp_all//surelog.uhd
 [ERR:UH0704] ./design/pic_ctrl.sv:166: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./design/pic_ctrl.sv:172: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./design/swerv.sv:40: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./design/swerv.sv:379: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./design/dma_ctrl.sv:23: UHDM coverage pointing to empty source line.
 
@@ -4746,6 +4746,20 @@ UHDM HTML COVERAGE REPORT: ../../../build/tests/CoresSweRV/slpp_all//surelog.uhd
 
 [ERR:UH0704] ./design/ifu/ifu_ic_mem.sv:40: UHDM coverage pointing to empty source line.
 
+[ERR:UH0704] ./design/ifu/ifu_iccm_mem.sv:21: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./design/ifu/ifu_iccm_mem.sv:24: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./design/ifu/ifu_iccm_mem.sv:29: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./design/ifu/ifu_iccm_mem.sv:33: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./design/ifu/ifu_iccm_mem.sv:40: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./design/ifu/ifu_iccm_mem.sv:42: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./design/ifu/ifu_iccm_mem.sv:45: UHDM coverage pointing to empty source line.
+
 [ERR:UH0704] ./design/ifu/ifu_bp_ctl.sv:886: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./design/ifu/ifu_bp_ctl.sv:896: UHDM coverage pointing to empty source line.
@@ -4850,20 +4864,6 @@ UHDM HTML COVERAGE REPORT: ../../../build/tests/CoresSweRV/slpp_all//surelog.uhd
 
 [ERR:UH0704] ./design/ifu/ifu_bp_ctl.sv:1736: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./design/ifu/ifu_iccm_mem.sv:21: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./design/ifu/ifu_iccm_mem.sv:24: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./design/ifu/ifu_iccm_mem.sv:29: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./design/ifu/ifu_iccm_mem.sv:33: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./design/ifu/ifu_iccm_mem.sv:40: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./design/ifu/ifu_iccm_mem.sv:42: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./design/ifu/ifu_iccm_mem.sv:45: UHDM coverage pointing to empty source line.
-
 [ERR:UH0704] ./design/ifu/ifu_mem_ctl.sv:18: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./design/ifu/ifu_mem_ctl.sv:23: UHDM coverage pointing to empty source line.
@@ -4956,6 +4956,12 @@ UHDM HTML COVERAGE REPORT: ../../../build/tests/CoresSweRV/slpp_all//surelog.uhd
 
 [ERR:UH0704] ./design/lsu/lsu.sv:49: UHDM coverage pointing to empty source line.
 
+[ERR:UH0704] ./design/lsu/lsu_addrcheck.sv:31: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./design/lsu/lsu_addrcheck.sv:36: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./design/lsu/lsu_addrcheck.sv:43: UHDM coverage pointing to empty source line.
+
 [ERR:UH0704] ./design/lsu/lsu_stbuf.sv:28: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./design/lsu/lsu_stbuf.sv:29: UHDM coverage pointing to empty source line.
@@ -4966,12 +4972,6 @@ UHDM HTML COVERAGE REPORT: ../../../build/tests/CoresSweRV/slpp_all//surelog.uhd
 
 [ERR:UH0704] ./design/lsu/lsu_stbuf.sv:42: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ./design/lsu/lsu_addrcheck.sv:31: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./design/lsu/lsu_addrcheck.sv:36: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./design/lsu/lsu_addrcheck.sv:43: UHDM coverage pointing to empty source line.
-
 [ERR:UH0704] ./design/lsu/lsu_bus_buffer.sv:29: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./design/lsu/lsu_bus_buffer.sv:34: UHDM coverage pointing to empty source line.
@@ -4979,12 +4979,6 @@ UHDM HTML COVERAGE REPORT: ../../../build/tests/CoresSweRV/slpp_all//surelog.uhd
 [ERR:UH0704] ./design/lsu/lsu_bus_buffer.sv:37: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./design/lsu/lsu_bus_buffer.sv:38: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./design/lsu/lsu_ecc.sv:31: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./design/lsu/lsu_ecc.sv:37: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ./design/lsu/lsu_ecc.sv:45: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./design/lsu/lsu_dccm_ctl.sv:28: UHDM coverage pointing to empty source line.
 
@@ -4995,6 +4989,12 @@ UHDM HTML COVERAGE REPORT: ../../../build/tests/CoresSweRV/slpp_all//surelog.uhd
 [ERR:UH0704] ./design/lsu/lsu_dccm_mem.sv:46: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./design/lsu/lsu_dccm_mem.sv:49: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./design/lsu/lsu_ecc.sv:31: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./design/lsu/lsu_ecc.sv:37: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ./design/lsu/lsu_ecc.sv:45: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ./design/dbg/dbg.sv:38: UHDM coverage pointing to empty source line.
 

--- a/third_party/tests/Earlgrey_Verilator_0_1/sim-verilator/Earlgrey_Verilator_0_1.log
+++ b/third_party/tests/Earlgrey_Verilator_0_1/sim-verilator/Earlgrey_Verilator_0_1.log
@@ -12008,75 +12008,13 @@ there are 1 more instances of this message.
 [NTE:EL0511] Nb leaf instances: 297.
 
 UHDM HTML COVERAGE REPORT: ../../../../build/tests/Earlgrey_Verilator_0_1/slpp_all//surelog.uhdm.chk.html
-[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:347: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ../src/lowrisc_prim_generic_ram_2p_0/rtl/prim_generic_ram_2p.sv:49: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:352: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:378: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:392: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:396: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:399: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:408: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:412: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:421: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:444: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:451: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:467: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:475: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:496: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:520: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:528: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:531: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:540: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:554: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:573: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:580: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:591: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:601: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:608: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:615: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:630: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:634: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:646: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:664: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:672: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:685: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ../src/lowrisc_prim_generic_ram_2p_0/rtl/prim_generic_ram_2p.sv:50: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ../src/lowrisc_prim_generic_ram_1p_0/rtl/prim_generic_ram_1p.sv:30: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ../src/lowrisc_prim_generic_ram_1p_0/rtl/prim_generic_ram_1p.sv:33: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ../src/lowrisc_prim_generic_ram_2p_0/rtl/prim_generic_ram_2p.sv:49: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ../src/lowrisc_prim_generic_ram_2p_0/rtl/prim_generic_ram_2p.sv:50: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ../src/lowrisc_prim_generic_rom_0/rtl/prim_generic_rom.sv:21: UHDM coverage pointing to empty source line.
 
@@ -12277,6 +12215,68 @@ UHDM HTML COVERAGE REPORT: ../../../../build/tests/Earlgrey_Verilator_0_1/slpp_a
 [ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_controller.sv:784: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_controller.sv:791: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:347: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:352: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:378: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:392: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:396: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:399: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:408: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:412: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:421: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:444: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:451: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:467: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:475: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:496: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:520: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:528: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:531: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:540: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:554: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:573: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:580: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:591: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:601: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:608: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:615: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:630: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:634: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:646: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:664: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:672: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_id_stage.sv:685: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ../src/lowrisc_ibex_ibex_core_0.1/rtl/ibex_core.sv:811: UHDM coverage pointing to empty source line.
 

--- a/third_party/tests/ariane/Ariane.log
+++ b/third_party/tests/ariane/Ariane.log
@@ -3638,128 +3638,6 @@ there are 1 more instances of this message.
 UHDM HTML COVERAGE REPORT: work-ver/slpp_all//surelog.uhdm.chk.html
 [ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/ariane.sv:743: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:147: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:160: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:174: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:182: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:185: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:207: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:216: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:225: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:232: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:238: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:274: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:279: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:293: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:296: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:315: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:320: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:323: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:328: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:337: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:348: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:355: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:363: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:367: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:370: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:375: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:410: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:429: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:471: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:479: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:482: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:487: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:489: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:491: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:503: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:528: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:535: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:555: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:564: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:568: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:571: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:575: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:581: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:584: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:602: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:608: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:616: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:620: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:624: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:636: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_divsqrt_multi.sv:126: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_divsqrt_multi.sv:133: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_divsqrt_multi.sv:146: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_divsqrt_multi.sv:166: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_divsqrt_multi.sv:169: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_divsqrt_multi.sv:174: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_divsqrt_multi.sv:184: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_divsqrt_multi.sv:246: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_divsqrt_multi.sv:258: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_divsqrt_multi.sv:278: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_divsqrt_multi.sv:291: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_divsqrt_multi.sv:303: UHDM coverage pointing to empty source line.
-
 [ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:163: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:170: UHDM coverage pointing to empty source line.
@@ -3959,6 +3837,128 @@ UHDM HTML COVERAGE REPORT: work-ver/slpp_all//surelog.uhdm.chk.html
 [ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_opgroup_multifmt_slice.sv:402: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_opgroup_multifmt_slice.sv:404: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_divsqrt_multi.sv:126: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_divsqrt_multi.sv:133: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_divsqrt_multi.sv:146: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_divsqrt_multi.sv:166: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_divsqrt_multi.sv:169: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_divsqrt_multi.sv:174: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_divsqrt_multi.sv:184: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_divsqrt_multi.sv:246: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_divsqrt_multi.sv:258: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_divsqrt_multi.sv:278: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_divsqrt_multi.sv:291: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_divsqrt_multi.sv:303: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:147: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:160: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:174: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:182: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:185: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:207: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:216: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:225: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:232: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:238: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:274: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:279: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:293: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:296: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:315: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:320: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:323: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:328: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:337: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:348: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:355: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:363: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:367: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:370: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:375: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:410: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:429: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:471: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:479: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:482: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:487: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:489: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:491: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:503: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:528: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:535: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:555: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:564: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:568: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:571: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:575: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:581: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:584: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:602: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:608: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:616: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:620: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:624: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:636: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_cast_multi.sv:167: UHDM coverage pointing to empty source line.
 


### PR DESCRIPTION
Fixes #955.
Enum const have little information, they don't have an explicit type field or size, but it can be derived from the value.