### PR TITLE
parameter uniquification (Major change to UHDM)

### DIFF
--- a/src/DesignCompile/CompileHelper.h
+++ b/src/DesignCompile/CompileHelper.h
@@ -285,7 +285,9 @@ public:
   void setParentNoOverride(UHDM::any* obj, UHDM::any* parent);
 
   UHDM::any* getValue(const std::string& name, DesignComponent* component,
-               CompileDesign* compileDesign, ValuedComponentI* instance); 
+               CompileDesign* compileDesign, ValuedComponentI* instance);
+
+  bool isMultidimensional(UHDM::typespec* ts); 
 
 private:
   CompileHelper(const CompileHelper&) = delete;

--- a/src/DesignCompile/CompileModule.cpp
+++ b/src/DesignCompile/CompileModule.cpp
@@ -490,17 +490,20 @@ bool CompileModule::collectModuleObjects_(bool collectDefinitions) {
     if (!id) id = current.m_sibling;
     if (!id) return false;
 
-    // Package imports
-    std::vector<FileCNodeId> pack_imports;
-    // - Local file imports
-    for (auto import : fC->getObjects(VObjectType::slPackage_import_item)) {
-      pack_imports.push_back(import);
-    }
+    if (collectDefinitions) {
+      // Package imports
+      std::vector<FileCNodeId> pack_imports;
+      // - Local file imports
+      for (auto import : fC->getObjects(VObjectType::slPackage_import_item)) {
+        pack_imports.push_back(import);
+      }
 
-    for (auto pack_import : pack_imports) {
-      const FileContent* pack_fC = pack_import.fC;
-      NodeId pack_id = pack_import.nodeId;
-      m_helper.importPackage(m_module, m_design, pack_fC, pack_id, m_compileDesign);
+      for (auto pack_import : pack_imports) {
+        const FileContent* pack_fC = pack_import.fC;
+        NodeId pack_id = pack_import.nodeId;
+        m_helper.importPackage(m_module, m_design, pack_fC, pack_id,
+                               m_compileDesign);
+      }
     }
 
     std::stack<NodeId> stack;
@@ -704,17 +707,20 @@ bool CompileModule::collectInterfaceObjects_(bool collectDefinitions) {
     if (!id) id = current.m_sibling;
     if (!id) return false;
 
-    // Package imports
-    std::vector<FileCNodeId> pack_imports;
-    // - Local file imports
-    for (auto import : fC->getObjects(VObjectType::slPackage_import_item)) {
-      pack_imports.push_back(import);
-    }
+    if (collectDefinitions) {
+      // Package imports
+      std::vector<FileCNodeId> pack_imports;
+      // - Local file imports
+      for (auto import : fC->getObjects(VObjectType::slPackage_import_item)) {
+        pack_imports.push_back(import);
+      }
 
-    for (auto pack_import : pack_imports) {
-      const FileContent* pack_fC = pack_import.fC;
-      NodeId pack_id = pack_import.nodeId;
-      m_helper.importPackage(m_module, m_design, pack_fC, pack_id, m_compileDesign);
+      for (auto pack_import : pack_imports) {
+        const FileContent* pack_fC = pack_import.fC;
+        NodeId pack_id = pack_import.nodeId;
+        m_helper.importPackage(m_module, m_design, pack_fC, pack_id,
+                               m_compileDesign);
+      }
     }
 
     std::stack<NodeId> stack;
@@ -726,203 +732,208 @@ bool CompileModule::collectInterfaceObjects_(bool collectDefinitions) {
       current = fC->Object(id);
       VObjectType type = fC->Type(id);
       switch (type) {
-      case VObjectType::slPackage_import_item:
-      {
-        if (!collectDefinitions) break;
-        m_helper.importPackage(m_module, m_design, fC, id, m_compileDesign);
-        break;
-      }
-      case VObjectType::slAnsi_port_declaration:
-      {
-        if (!collectDefinitions) break;
-        m_helper.compileAnsiPortDeclaration(m_module, fC, id, port_direction);
-        break;
-      }
-      case VObjectType::slNet_declaration:
-      {
-        if (!collectDefinitions) break;
-        m_helper.compileNetDeclaration(m_module, fC, id, true, m_compileDesign);
-        break;
-      }
-      case VObjectType::slData_declaration:
-      {
-        if (!collectDefinitions) break;
-        m_helper.compileDataDeclaration(m_module, fC,id, true, m_compileDesign);
-        break;
-      }
-      case VObjectType::slContinuous_assign:
-      {
-        if (collectDefinitions) break;
-        m_helper.compileContinuousAssignment(m_module, fC, fC->Child(id), m_compileDesign);
-        break;
-      }
-      case VObjectType::slTask_declaration: {
-        if (!collectDefinitions) break;
-        m_helper.compileTask(m_module, fC, id, m_compileDesign);
-        break;
-      }
-      case VObjectType::slFunction_declaration: {
-        if (!collectDefinitions) break;
-        m_helper.compileFunction(m_module, fC, id, m_compileDesign);
-        break;
-      }
-      case VObjectType::slDpi_import_export: {
-        Function* func = m_helper.compileFunctionPrototype(m_module, fC, id, m_compileDesign);
-        m_module->insertFunction(func);
-        break;
-      }
-      case VObjectType::slClocking_declaration:
-        if (!collectDefinitions) break;
-        compileClockingBlock_(fC, id);
-        break;
-      case VObjectType::slGenerate_interface_item:
-      {
-        if (collectDefinitions) break;
-        // TODO: rewrite this rough implementation
-        std::vector<VObjectType> types = {VObjectType::slModport_item};
-        std::vector<NodeId> items = fC->sl_collect_all(id, types);
-        for (auto nodeId : items) {
-          Location loc(m_symbols->registerSymbol(fC->getFileName(nodeId)),
-                  fC->Line(nodeId), 0, 0);
-          Error err(ErrorDefinition::COMP_NO_MODPORT_IN_GENERATE, loc);
-          m_errors->addError(err);
+        case VObjectType::slPackage_import_item: {
+          if (!collectDefinitions) break;
+          m_helper.importPackage(m_module, m_design, fC, id, m_compileDesign);
+          break;
         }
-        break;
-      }
-      case VObjectType::slModport_item:
-        if (!collectDefinitions) break;
-        /*
-         n<tb> u<45> t<StringConst> p<56> s<50> l<43>
-         n<> u<46> t<PortDir_Inp> p<49> s<48> l<43>
-         n<clk> u<47> t<StringConst> p<48> l<43>
-         n<> u<48> t<Modport_simple_port> p<49> c<47> l<43>
-         n<> u<49> t<Modport_simple_ports_declaration> p<50> c<46> l<43>
-         n<> u<50> t<Modport_ports_declaration> p<56> c<49> s<55> l<43>
-         n<> u<51> t<PortDir_Out> p<54> s<53> l<43>
-         n<reset> u<52> t<StringConst> p<53> l<43>
-         n<> u<53> t<Modport_simple_port> p<54> c<52> l<43>
-         n<> u<54> t<Modport_simple_ports_declaration> p<55> c<51> l<43>
-         n<> u<55> t<Modport_ports_declaration> p<56> c<54> l<43>
-         n<> u<56> t<Modport_item> p<57> c<45> l<43>
-         */
-        {
-          NodeId modportname = fC->Child(id);
-          const std::string& modportsymb = fC->SymName(modportname);
-          NodeId modport_ports_declaration = fC->Sibling(modportname);
-          VObjectType port_direction_type = VObjectType::slNoType;
-          while (modport_ports_declaration) {
-            NodeId port_declaration = fC->Child(modport_ports_declaration);
-            VObjectType port_declaration_type = fC->Type(port_declaration);
-            if (port_declaration_type ==
-                VObjectType::slModport_simple_ports_declaration) {
-              NodeId port_direction = fC->Child(port_declaration);
-              port_direction_type = fC->Type(port_direction);
-              NodeId modport_simple_port = fC->Sibling(port_direction);
-              while (modport_simple_port) {
-                NodeId simple_port_name = fC->Child(modport_simple_port);
-                SymbolId port_symbol = fC->Name(simple_port_name);
-                bool port_exists = false;
-                for (auto& port : m_module->m_signals) {
-                  if (fC->Name(port->getNodeId()) == port_symbol) {
-                    port_exists = true;
-                    break;
-                  }
-                }
-                if (!port_exists) {
-                  Location loc(
-                      m_symbols->registerSymbol(
-                          fC->getFileName(simple_port_name)),
-                      fC->Line(simple_port_name), 0,
-                      m_symbols->registerSymbol(fC->SymName(simple_port_name)));
-                  Error err(ErrorDefinition::COMP_MODPORT_UNDEFINED_PORT, loc);
-                  m_errors->addError(err);
-                }
-                Signal signal(fC, simple_port_name,
-                              VObjectType::slData_type_or_implicit,
-                              port_direction_type, 0, false);
-                m_module->insertModPort(modportsymb, signal);
-                modport_simple_port = fC->Sibling(modport_simple_port);
-              }
-            } else if (port_declaration_type ==
-                       VObjectType::slModport_hierarchical_ports_declaration) {
-            } else if (port_declaration_type ==
-                       VObjectType::slModport_tf_ports_declaration) {
-            } else {
-              // CLOCKING
-              NodeId clocking_block_name = port_declaration;
-              SymbolId clocking_block_symbol =
-                  m_symbols->registerSymbol(fC->SymName(clocking_block_name));
-              ClockingBlock* cb =
-                  m_module->getClockingBlock(clocking_block_symbol);
-              if (cb == NULL) {
-                Location loc(m_symbols->registerSymbol(
-                                 fC->getFileName(clocking_block_name)),
-                             fC->Line(clocking_block_name), 0,
-                             clocking_block_symbol);
-                Error err(
-                    ErrorDefinition::COMP_MODPORT_UNDEFINED_CLOCKING_BLOCK,
-                    loc);
-                m_errors->addError(err);
-              } else {
-               m_module->insertModPort(modportsymb, *cb);
-              }
-            }
-            modport_ports_declaration = fC->Sibling(modport_ports_declaration);
+        case VObjectType::slAnsi_port_declaration: {
+          if (!collectDefinitions) break;
+          m_helper.compileAnsiPortDeclaration(m_module, fC, id, port_direction);
+          break;
+        }
+        case VObjectType::slNet_declaration: {
+          if (!collectDefinitions) break;
+          m_helper.compileNetDeclaration(m_module, fC, id, true,
+                                         m_compileDesign);
+          break;
+        }
+        case VObjectType::slData_declaration: {
+          if (!collectDefinitions) break;
+          m_helper.compileDataDeclaration(m_module, fC, id, true,
+                                          m_compileDesign);
+          break;
+        }
+        case VObjectType::slContinuous_assign: {
+          if (collectDefinitions) break;
+          m_helper.compileContinuousAssignment(m_module, fC, fC->Child(id),
+                                               m_compileDesign);
+          break;
+        }
+        case VObjectType::slTask_declaration: {
+          if (!collectDefinitions) break;
+          m_helper.compileTask(m_module, fC, id, m_compileDesign);
+          break;
+        }
+        case VObjectType::slFunction_declaration: {
+          if (!collectDefinitions) break;
+          m_helper.compileFunction(m_module, fC, id, m_compileDesign);
+          break;
+        }
+        case VObjectType::slDpi_import_export: {
+          Function* func = m_helper.compileFunctionPrototype(m_module, fC, id,
+                                                             m_compileDesign);
+          m_module->insertFunction(func);
+          break;
+        }
+        case VObjectType::slClocking_declaration:
+          if (!collectDefinitions) break;
+          compileClockingBlock_(fC, id);
+          break;
+        case VObjectType::slGenerate_interface_item: {
+          if (collectDefinitions) break;
+          // TODO: rewrite this rough implementation
+          std::vector<VObjectType> types = {VObjectType::slModport_item};
+          std::vector<NodeId> items = fC->sl_collect_all(id, types);
+          for (auto nodeId : items) {
+            Location loc(m_symbols->registerSymbol(fC->getFileName(nodeId)),
+                         fC->Line(nodeId), 0, 0);
+            Error err(ErrorDefinition::COMP_NO_MODPORT_IN_GENERATE, loc);
+            m_errors->addError(err);
           }
+          break;
         }
-        break;
-      case VObjectType::slInitial_construct:
-        if (collectDefinitions) break;
-        m_helper.compileInitialBlock(m_module, fC, id, m_compileDesign);
-        break;
-      case VObjectType::slFinal_construct:
-        if (collectDefinitions) break;
-        m_helper.compileFinalBlock(m_module, fC, id, m_compileDesign);
-        break;  
-      case VObjectType::slParameter_declaration: {
-        if (!collectDefinitions) break;
+        case VObjectType::slModport_item:
+          if (!collectDefinitions) break;
+          /*
+           n<tb> u<45> t<StringConst> p<56> s<50> l<43>
+           n<> u<46> t<PortDir_Inp> p<49> s<48> l<43>
+           n<clk> u<47> t<StringConst> p<48> l<43>
+           n<> u<48> t<Modport_simple_port> p<49> c<47> l<43>
+           n<> u<49> t<Modport_simple_ports_declaration> p<50> c<46> l<43>
+           n<> u<50> t<Modport_ports_declaration> p<56> c<49> s<55> l<43>
+           n<> u<51> t<PortDir_Out> p<54> s<53> l<43>
+           n<reset> u<52> t<StringConst> p<53> l<43>
+           n<> u<53> t<Modport_simple_port> p<54> c<52> l<43>
+           n<> u<54> t<Modport_simple_ports_declaration> p<55> c<51> l<43>
+           n<> u<55> t<Modport_ports_declaration> p<56> c<54> l<43>
+           n<> u<56> t<Modport_item> p<57> c<45> l<43>
+           */
+          {
+            NodeId modportname = fC->Child(id);
+            const std::string& modportsymb = fC->SymName(modportname);
+            NodeId modport_ports_declaration = fC->Sibling(modportname);
+            VObjectType port_direction_type = VObjectType::slNoType;
+            while (modport_ports_declaration) {
+              NodeId port_declaration = fC->Child(modport_ports_declaration);
+              VObjectType port_declaration_type = fC->Type(port_declaration);
+              if (port_declaration_type ==
+                  VObjectType::slModport_simple_ports_declaration) {
+                NodeId port_direction = fC->Child(port_declaration);
+                port_direction_type = fC->Type(port_direction);
+                NodeId modport_simple_port = fC->Sibling(port_direction);
+                while (modport_simple_port) {
+                  NodeId simple_port_name = fC->Child(modport_simple_port);
+                  SymbolId port_symbol = fC->Name(simple_port_name);
+                  bool port_exists = false;
+                  for (auto& port : m_module->m_signals) {
+                    if (fC->Name(port->getNodeId()) == port_symbol) {
+                      port_exists = true;
+                      break;
+                    }
+                  }
+                  if (!port_exists) {
+                    Location loc(m_symbols->registerSymbol(
+                                     fC->getFileName(simple_port_name)),
+                                 fC->Line(simple_port_name), 0,
+                                 m_symbols->registerSymbol(
+                                     fC->SymName(simple_port_name)));
+                    Error err(ErrorDefinition::COMP_MODPORT_UNDEFINED_PORT,
+                              loc);
+                    m_errors->addError(err);
+                  }
+                  Signal signal(fC, simple_port_name,
+                                VObjectType::slData_type_or_implicit,
+                                port_direction_type, 0, false);
+                  m_module->insertModPort(modportsymb, signal);
+                  modport_simple_port = fC->Sibling(modport_simple_port);
+                }
+              } else if (port_declaration_type ==
+                         VObjectType::
+                             slModport_hierarchical_ports_declaration) {
+              } else if (port_declaration_type ==
+                         VObjectType::slModport_tf_ports_declaration) {
+              } else {
+                // CLOCKING
+                NodeId clocking_block_name = port_declaration;
+                SymbolId clocking_block_symbol =
+                    m_symbols->registerSymbol(fC->SymName(clocking_block_name));
+                ClockingBlock* cb =
+                    m_module->getClockingBlock(clocking_block_symbol);
+                if (cb == NULL) {
+                  Location loc(m_symbols->registerSymbol(
+                                   fC->getFileName(clocking_block_name)),
+                               fC->Line(clocking_block_name), 0,
+                               clocking_block_symbol);
+                  Error err(
+                      ErrorDefinition::COMP_MODPORT_UNDEFINED_CLOCKING_BLOCK,
+                      loc);
+                  m_errors->addError(err);
+                } else {
+                  m_module->insertModPort(modportsymb, *cb);
+                }
+              }
+              modport_ports_declaration =
+                  fC->Sibling(modport_ports_declaration);
+            }
+          }
+          break;
+        case VObjectType::slInitial_construct:
+          if (collectDefinitions) break;
+          m_helper.compileInitialBlock(m_module, fC, id, m_compileDesign);
+          break;
+        case VObjectType::slFinal_construct:
+          if (collectDefinitions) break;
+          m_helper.compileFinalBlock(m_module, fC, id, m_compileDesign);
+          break;
+        case VObjectType::slParameter_declaration: {
+          if (!collectDefinitions) break;
 
-        NodeId list_of_type_assignments = fC->Child(id);
-        if (fC->Type(list_of_type_assignments) == slList_of_type_assignments) {
-          // Type param
-          m_helper.compileParameterDeclaration(
-              m_module, fC, list_of_type_assignments, m_compileDesign, false, m_instance, m_instance != nullptr);
+          NodeId list_of_type_assignments = fC->Child(id);
+          if (fC->Type(list_of_type_assignments) ==
+              slList_of_type_assignments) {
+            // Type param
+            m_helper.compileParameterDeclaration(
+                m_module, fC, list_of_type_assignments, m_compileDesign, false,
+                m_instance, m_instance != nullptr);
 
-        } else {
-          m_helper.compileParameterDeclaration(m_module, fC, id,
-                                               m_compileDesign, false, m_instance, m_instance != nullptr);
+          } else {
+            m_helper.compileParameterDeclaration(
+                m_module, fC, id, m_compileDesign, false, m_instance,
+                m_instance != nullptr);
+          }
+          break;
         }
-        break;
-      }
-      case VObjectType::slLocal_parameter_declaration: {
-        if (!collectDefinitions) break;
-        NodeId list_of_type_assignments = fC->Child(id);
-        if (fC->Type(list_of_type_assignments) == slList_of_type_assignments) {
-          // Type param
-          m_helper.compileParameterDeclaration(
-              m_module, fC, list_of_type_assignments, m_compileDesign, true,
-              m_instance, m_instance != nullptr);
+        case VObjectType::slLocal_parameter_declaration: {
+          if (!collectDefinitions) break;
+          NodeId list_of_type_assignments = fC->Child(id);
+          if (fC->Type(list_of_type_assignments) ==
+              slList_of_type_assignments) {
+            // Type param
+            m_helper.compileParameterDeclaration(
+                m_module, fC, list_of_type_assignments, m_compileDesign, true,
+                m_instance, m_instance != nullptr);
 
-        } else {
-          m_helper.compileParameterDeclaration(
-              m_module, fC, id, m_compileDesign, true, m_instance,
-              m_instance != nullptr);
+          } else {
+            m_helper.compileParameterDeclaration(
+                m_module, fC, id, m_compileDesign, true, m_instance,
+                m_instance != nullptr);
+          }
+          break;
         }
-        break;
-      }
-      case VObjectType::slConditional_generate_construct:
-      case VObjectType::slGenerate_interface_conditional_statement:
-      case VObjectType::slLoop_generate_construct:
-      case VObjectType::slGenerate_interface_loop_statement:
-      case VObjectType::slParam_assignment:
-      case VObjectType::slDefparam_assignment: {
-        if (!collectDefinitions) break;
-        FileCNodeId fnid(fC, id);
-        m_module->addObject(type, fnid);
-        break;
-      }
-      default:
-        break;
+        case VObjectType::slConditional_generate_construct:
+        case VObjectType::slGenerate_interface_conditional_statement:
+        case VObjectType::slLoop_generate_construct:
+        case VObjectType::slGenerate_interface_loop_statement:
+        case VObjectType::slParam_assignment:
+        case VObjectType::slDefparam_assignment: {
+          if (!collectDefinitions) break;
+          FileCNodeId fnid(fC, id);
+          m_module->addObject(type, fnid);
+          break;
+        }
+        default:
+          break;
       }
 
       if (current.m_sibling) stack.push(current.m_sibling);
@@ -1061,22 +1072,24 @@ void CompileModule::compileClockingBlock_(const FileContent* fC, NodeId id) {
   NodeId clocking_block_name = 0;
   SymbolId clocking_block_symbol = 0;
   ClockingBlock::Type type = ClockingBlock::Regular;
-  if(fC->Type(clocking_block_type) == slDefault)
-    type =  ClockingBlock::Default;
-  else if(fC->Type(clocking_block_type) == slGlobal)
-    type =  ClockingBlock::Global;
-  else if(fC->Type(clocking_block_type) == slStringConst)
-    clocking_block_name = clocking_block_type; 
+  if (fC->Type(clocking_block_type) == slDefault)
+    type = ClockingBlock::Default;
+  else if (fC->Type(clocking_block_type) == slGlobal)
+    type = ClockingBlock::Global;
+  else if (fC->Type(clocking_block_type) == slStringConst)
+    clocking_block_name = clocking_block_type;
   NodeId clocking_event = fC->Sibling(clocking_block_type);
-  if(fC->Type(clocking_event) == slStringConst) {
-    clocking_block_name = clocking_event; 
+  if (fC->Type(clocking_event) == slStringConst) {
+    clocking_block_name = clocking_event;
     clocking_event = fC->Sibling(clocking_block_name);
   }
-  if (clocking_block_name)  
-    clocking_block_symbol = m_symbols->registerSymbol(fC->SymName(clocking_block_name));
+  if (clocking_block_name)
+    clocking_block_symbol =
+        m_symbols->registerSymbol(fC->SymName(clocking_block_name));
   else
-    clocking_block_symbol = m_symbols->registerSymbol("unnamed_clocking_block");  
-  UHDM::clocking_block* cblock = m_helper.compileClockingBlock(m_module, fC, id, m_compileDesign);
+    clocking_block_symbol = m_symbols->registerSymbol("unnamed_clocking_block");
+  UHDM::clocking_block* cblock =
+      m_helper.compileClockingBlock(m_module, fC, id, m_compileDesign);
   ClockingBlock cb(fC, clocking_block_type, clocking_event, type, cblock);
   m_module->addClockingBlock(clocking_block_symbol, cb);
 }

--- a/src/DesignCompile/DesignElaboration.cpp
+++ b/src/DesignCompile/DesignElaboration.cpp
@@ -781,11 +781,12 @@ void DesignElaboration::elaborateInstance_(const FileContent* fC, NodeId nodeId,
 
           def = design->getComponentDefinition(indexedModName);
           if (def == NULL) {
-           def = m_moduleDefFactory->newModuleDefinition(fC, subInstanceId,
+            def = m_moduleDefFactory->newModuleDefinition(fC, subInstanceId,
                                                       indexedModName);
-           if (DesignComponent* defParent = parent->getDefinition())
-             def->setParentScope(defParent);                                           
-           design->addModuleDefinition(indexedModName, (ModuleDefinition*)def);
+            if (DesignComponent* defParent = parent->getDefinition())
+              def->setParentScope(defParent);                                           
+            design->addModuleDefinition(indexedModName, (ModuleDefinition*)def);
+
           }
 
           // Compile generate block

--- a/src/Expression/Value.cpp
+++ b/src/Expression/Value.cpp
@@ -453,15 +453,16 @@ unsigned short LValue::getSize() const {
 
 std::string LValue::uhdmValue() {
   std::string result = "INT:";
-  if (m_type == Type::Binary)
-    result = "BIN:";
-  else if (m_type == Type::Double)
-    result = "REAL:";
-  else if (m_type == Type::Hexadecimal)
-    result = "HEX:";
-  else if (m_type == Type::Octal)
-    result = "OCT:";
-  else if (m_type == Type::Scalar)
+  // The value is encoded in int form.
+  //if (m_type == Type::Binary)
+  //  result = "BIN:";
+  //else if (m_type == Type::Double)
+  //  result = "REAL:";
+  //else if (m_type == Type::Hexadecimal)
+  //  result = "HEX:";
+  //else if (m_type == Type::Octal)
+  //  result = "OCT:";
+  if (m_type == Type::Scalar)
     result = "SCAL:";  
   for (int i = 0; i < m_nbWords; i++) {
     result += std::to_string(m_valueArray[i].m_value);

--- a/tests/BitsOp/BitsOp.log
+++ b/tests/BitsOp/BitsOp.log
@@ -1394,6 +1394,7 @@ design: (work@dut)
       |vpiName:WordByte
       |vpiFullName:work@dut.WordByte
       |vpiLocalParam:1
+      |INT:4
       |vpiTypespec:
       \_int_typespec: (WordByte), line:78, parent:work@dut.WordByte
         |vpiName:WordByte
@@ -1410,6 +1411,7 @@ design: (work@dut)
       |vpiName:DataWidth
       |vpiFullName:work@dut.DataWidth
       |vpiLocalParam:1
+      |INT:32
       |vpiTypespec:
       \_int_typespec: (DataWidth), line:80, parent:work@dut.DataWidth
         |vpiName:DataWidth
@@ -1426,6 +1428,7 @@ design: (work@dut)
       |vpiName:DataBitWidth
       |vpiFullName:work@dut.DataBitWidth
       |vpiLocalParam:1
+      |INT:2
       |vpiTypespec:
       \_int_typespec: (DataBitWidth), line:81, parent:work@dut.DataBitWidth
         |vpiName:DataBitWidth
@@ -1440,6 +1443,7 @@ design: (work@dut)
       |vpiName:EraseBitWidth
       |vpiFullName:work@dut.EraseBitWidth
       |vpiLocalParam:1
+      |INT:1
       |vpiTypespec:
       \_int_typespec: (EraseBitWidth), line:82, parent:work@dut.EraseBitWidth
         |vpiName:EraseBitWidth
@@ -1454,6 +1458,7 @@ design: (work@dut)
       |vpiName:HashWordBits
       |vpiFullName:work@dut.HashWordBits
       |vpiLocalParam:1
+      |INT:5
       |vpiTypespec:
       \_int_typespec: (HashWordBits), line:84, parent:work@dut.HashWordBits
         |vpiName:HashWordBits
@@ -1468,35 +1473,22 @@ design: (work@dut)
       |vpiName:REQFIFO_WIDTH
       |vpiFullName:work@dut.REQFIFO_WIDTH
       |vpiLocalParam:1
+      |INT:10
       |vpiTypespec:
       \_int_typespec: (REQFIFO_WIDTH), line:86, parent:work@dut.REQFIFO_WIDTH
         |vpiName:REQFIFO_WIDTH
   |vpiParameter:
-  \_parameter: (work@dut.DataBitWidth), line:81, parent:work@dut
-    |vpiName:DataBitWidth
-    |vpiFullName:work@dut.DataBitWidth
-    |INT:2
+  \_parameter: (work@dut.WordByte), line:78, parent:work@dut
   |vpiParameter:
   \_parameter: (work@dut.DataWidth), line:80, parent:work@dut
-    |vpiName:DataWidth
-    |vpiFullName:work@dut.DataWidth
-    |INT:32
+  |vpiParameter:
+  \_parameter: (work@dut.DataBitWidth), line:81, parent:work@dut
   |vpiParameter:
   \_parameter: (work@dut.EraseBitWidth), line:82, parent:work@dut
-    |vpiName:EraseBitWidth
-    |vpiFullName:work@dut.EraseBitWidth
   |vpiParameter:
   \_parameter: (work@dut.HashWordBits), line:84, parent:work@dut
-    |vpiName:HashWordBits
-    |vpiFullName:work@dut.HashWordBits
   |vpiParameter:
   \_parameter: (work@dut.REQFIFO_WIDTH), line:86, parent:work@dut
-    |vpiName:REQFIFO_WIDTH
-    |vpiFullName:work@dut.REQFIFO_WIDTH
-  |vpiParameter:
-  \_parameter: (work@dut.WordByte), line:78, parent:work@dut
-    |vpiName:WordByte
-    |vpiFullName:work@dut.WordByte
 |uhdmtopModules:
 \_module: work@dmi_jtag (work@dmi_jtag) dut.sv:104: 
   |vpiDefName:work@dmi_jtag

--- a/tests/CaseFullElab/CaseFullElab.log
+++ b/tests/CaseFullElab/CaseFullElab.log
@@ -1361,8 +1361,6 @@ design: (work@FSM)
       |INT:0
     |vpiLhs:
     \_parameter: (work@FSM.Stop), line:9, parent:work@FSM
-      |vpiName:Stop
-      |vpiFullName:work@FSM.Stop
   |vpiParamAssign:
   \_param_assign: , line:10, parent:work@FSM
     |vpiRhs:
@@ -1373,8 +1371,6 @@ design: (work@FSM)
       |INT:1
     |vpiLhs:
     \_parameter: (work@FSM.Move), line:10, parent:work@FSM
-      |vpiName:Move
-      |vpiFullName:work@FSM.Move
   |vpiParamAssign:
   \_param_assign: , line:11, parent:work@FSM
     |vpiRhs:
@@ -1387,6 +1383,7 @@ design: (work@FSM)
     \_parameter: (work@FSM.Turn), line:11, parent:work@FSM
       |vpiName:Turn
       |vpiFullName:work@FSM.Turn
+      |INT:2
   |vpiParamAssign:
   \_param_assign: , line:12, parent:work@FSM
     |vpiRhs:
@@ -1397,8 +1394,6 @@ design: (work@FSM)
       |INT:3
     |vpiLhs:
     \_parameter: (work@FSM.Slow), line:12, parent:work@FSM
-      |vpiName:Slow
-      |vpiFullName:work@FSM.Slow
   |vpiParamAssign:
   \_param_assign: , line:13, parent:work@FSM
     |vpiRhs:
@@ -1411,6 +1406,7 @@ design: (work@FSM)
     \_parameter: (work@FSM.Medium), line:13, parent:work@FSM
       |vpiName:Medium
       |vpiFullName:work@FSM.Medium
+      |INT:4
   |vpiParamAssign:
   \_param_assign: , line:14, parent:work@FSM
     |vpiRhs:
@@ -1423,6 +1419,7 @@ design: (work@FSM)
     \_parameter: (work@FSM.Fast), line:14, parent:work@FSM
       |vpiName:Fast
       |vpiFullName:work@FSM.Fast
+      |INT:5
   |vpiParamAssign:
   \_param_assign: , line:15, parent:work@FSM
     |vpiRhs:
@@ -1433,31 +1430,20 @@ design: (work@FSM)
       |INT:6
     |vpiLhs:
     \_parameter: (work@FSM.Faster), line:15, parent:work@FSM
-      |vpiName:Faster
-      |vpiFullName:work@FSM.Faster
-  |vpiParameter:
-  \_parameter: (work@FSM.Fast), line:14, parent:work@FSM
-    |vpiName:Fast
-    |vpiFullName:work@FSM.Fast
-    |INT:5
-  |vpiParameter:
-  \_parameter: (work@FSM.Faster), line:15, parent:work@FSM
-  |vpiParameter:
-  \_parameter: (work@FSM.Medium), line:13, parent:work@FSM
-    |vpiName:Medium
-    |vpiFullName:work@FSM.Medium
-    |INT:4
-  |vpiParameter:
-  \_parameter: (work@FSM.Move), line:10, parent:work@FSM
-  |vpiParameter:
-  \_parameter: (work@FSM.Slow), line:12, parent:work@FSM
   |vpiParameter:
   \_parameter: (work@FSM.Stop), line:9, parent:work@FSM
   |vpiParameter:
+  \_parameter: (work@FSM.Move), line:10, parent:work@FSM
+  |vpiParameter:
   \_parameter: (work@FSM.Turn), line:11, parent:work@FSM
-    |vpiName:Turn
-    |vpiFullName:work@FSM.Turn
-    |INT:2
+  |vpiParameter:
+  \_parameter: (work@FSM.Slow), line:12, parent:work@FSM
+  |vpiParameter:
+  \_parameter: (work@FSM.Medium), line:13, parent:work@FSM
+  |vpiParameter:
+  \_parameter: (work@FSM.Fast), line:14, parent:work@FSM
+  |vpiParameter:
+  \_parameter: (work@FSM.Faster), line:15, parent:work@FSM
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/CastTypespec/CastTypespec.log
+++ b/tests/CastTypespec/CastTypespec.log
@@ -1350,11 +1350,9 @@ design: (work@tlul_adapter_host)
       |vpiName:HartSelLen
       |vpiFullName:work@top.HartSelLen
       |vpiLocalParam:1
+      |INT:2
   |vpiParameter:
   \_parameter: (work@top.HartSelLen), line:35, parent:work@top
-    |vpiName:HartSelLen
-    |vpiFullName:work@top.HartSelLen
-    |INT:2
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/CastUnsigned/CastUnsigned.log
+++ b/tests/CastUnsigned/CastUnsigned.log
@@ -513,11 +513,9 @@ design: (work@top)
     \_parameter: (work@top.INIT), line:4, parent:work@top
       |vpiName:INIT
       |vpiFullName:work@top.INIT
+      |INT:0
   |vpiParameter:
   \_parameter: (work@top.INIT), line:4, parent:work@top
-    |vpiName:INIT
-    |vpiFullName:work@top.INIT
-    |SCAL:0
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/ClogCast/ClogCast.log
+++ b/tests/ClogCast/ClogCast.log
@@ -1014,7 +1014,11 @@ design: (work@debug_rom)
                         \_parameter: (work@debug_rom.RomSize), line:10, parent:work@debug_rom
                           |vpiName:RomSize
                           |vpiFullName:work@debug_rom.RomSize
+                          |vpiLocalParam:1
                           |INT:19
+                          |vpiTypespec:
+                          \_int_typespec: (RomSize), line:10, parent:work@debug_rom.RomSize
+                            |vpiName:RomSize
                     |vpiOperand:
                     \_constant: , line:38
                       |vpiConstType:7
@@ -1339,12 +1343,6 @@ design: (work@debug_rom)
       |INT:19
     |vpiLhs:
     \_parameter: (work@debug_rom.RomSize), line:10, parent:work@debug_rom
-      |vpiName:RomSize
-      |vpiFullName:work@debug_rom.RomSize
-      |vpiLocalParam:1
-      |vpiTypespec:
-      \_int_typespec: (RomSize), line:10, parent:work@debug_rom.RomSize
-        |vpiName:RomSize
   |vpiParameter:
   \_parameter: (work@debug_rom.RomSize), line:10, parent:work@debug_rom
 ===================

--- a/tests/ConcatVal/ConcatVal.log
+++ b/tests/ConcatVal/ConcatVal.log
@@ -702,6 +702,37 @@ design: (work@dut)
         \_parameter: (work@dut.PRESENT_SBOX4), line:2, parent:work@dut
           |vpiName:PRESENT_SBOX4
           |vpiFullName:work@dut.PRESENT_SBOX4
+          |vpiTypespec:
+          \_logic_typespec: (PRESENT_SBOX4), line:2, parent:work@dut.PRESENT_SBOX4
+            |vpiName:PRESENT_SBOX4
+            |vpiRange:
+            \_range: , line:2, parent:PRESENT_SBOX4
+              |vpiLeftRange:
+              \_constant: , line:2
+                |vpiConstType:7
+                |vpiDecompile:15
+                |vpiSize:32
+                |INT:15
+              |vpiRightRange:
+              \_constant: , line:2
+                |vpiConstType:7
+                |vpiDecompile:0
+                |vpiSize:32
+                |INT:0
+            |vpiRange:
+            \_range: , line:2, parent:PRESENT_SBOX4
+              |vpiLeftRange:
+              \_constant: , line:2
+                |vpiConstType:7
+                |vpiDecompile:3
+                |vpiSize:32
+                |INT:3
+              |vpiRightRange:
+              \_constant: , line:2
+                |vpiConstType:7
+                |vpiDecompile:0
+                |vpiSize:32
+                |INT:0
     |vpiLhs:
     \_ref_obj: (work@dut.data_state_sbox), line:14
       |vpiName:data_state_sbox
@@ -837,39 +868,6 @@ design: (work@dut)
         |HEX:1
     |vpiLhs:
     \_parameter: (work@dut.PRESENT_SBOX4), line:2, parent:work@dut
-      |vpiName:PRESENT_SBOX4
-      |vpiFullName:work@dut.PRESENT_SBOX4
-      |vpiTypespec:
-      \_logic_typespec: (PRESENT_SBOX4), line:2, parent:work@dut.PRESENT_SBOX4
-        |vpiName:PRESENT_SBOX4
-        |vpiRange:
-        \_range: , line:2
-          |vpiLeftRange:
-          \_constant: , line:2
-            |vpiConstType:7
-            |vpiDecompile:15
-            |vpiSize:32
-            |INT:15
-          |vpiRightRange:
-          \_constant: , line:2
-            |vpiConstType:7
-            |vpiDecompile:0
-            |vpiSize:32
-            |INT:0
-        |vpiRange:
-        \_range: , line:2
-          |vpiLeftRange:
-          \_constant: , line:2
-            |vpiConstType:7
-            |vpiDecompile:3
-            |vpiSize:32
-            |INT:3
-          |vpiRightRange:
-          \_constant: , line:2
-            |vpiConstType:7
-            |vpiDecompile:0
-            |vpiSize:32
-            |INT:0
   |vpiParameter:
   \_parameter: (work@dut.PRESENT_SBOX4), line:2, parent:work@dut
 ===================

--- a/tests/ConcatWidth/ConcatWidth.log
+++ b/tests/ConcatWidth/ConcatWidth.log
@@ -610,6 +610,9 @@ design: (work@top)
                     |vpiName:CounterWidth
                     |vpiFullName:work@top.CounterWidth
                     |INT:32
+                    |vpiTypespec:
+                    \_int_typespec: (CounterWidth), line:2, parent:work@top.CounterWidth
+                      |vpiName:CounterWidth
                 |vpiOperand:
                 \_constant: , line:14
                   |vpiConstType:7
@@ -827,6 +830,9 @@ design: (work@top)
                     |vpiName:CounterWidth
                     |vpiFullName:work@top.CounterWidth
                     |INT:32
+                    |vpiTypespec:
+                    \_int_typespec: (CounterWidth), line:2, parent:work@top.CounterWidth
+                      |vpiName:CounterWidth
                 |vpiOperand:
                 \_constant: , line:14
                   |vpiConstType:7
@@ -940,11 +946,6 @@ design: (work@top)
       |INT:32
     |vpiLhs:
     \_parameter: (work@top.CounterWidth), line:2, parent:work@top
-      |vpiName:CounterWidth
-      |vpiFullName:work@top.CounterWidth
-      |vpiTypespec:
-      \_int_typespec: (CounterWidth), line:2, parent:work@top.CounterWidth
-        |vpiName:CounterWidth
   |vpiParameter:
   \_parameter: (work@top.CounterWidth), line:2, parent:work@top
 ===================

--- a/tests/ConditionalOp/ConditionalOp.log
+++ b/tests/ConditionalOp/ConditionalOp.log
@@ -767,7 +767,11 @@ design: (work@top)
         \_parameter: (work@ibex_register_file.ADDR_WIDTH), line:18, parent:work@ibex_register_file
           |vpiName:ADDR_WIDTH
           |vpiFullName:work@ibex_register_file.ADDR_WIDTH
+          |vpiLocalParam:1
           |INT:5
+          |vpiTypespec:
+          \_int_typespec: (ADDR_WIDTH), line:18, parent:work@ibex_register_file.ADDR_WIDTH
+            |vpiName:ADDR_WIDTH
     |vpiLhs:
     \_parameter: (work@ibex_register_file.NUM_WORDS), line:19, parent:work@ibex_register_file
       |vpiName:NUM_WORDS
@@ -958,6 +962,7 @@ design: (work@top)
       |vpiName:NrHarts
       |vpiFullName:work@top.NrHarts
       |vpiLocalParam:1
+      |INT:1
       |vpiTypespec:
       \_int_typespec: (NrHarts), line:2, parent:work@top.NrHarts
         |vpiName:NrHarts
@@ -974,6 +979,7 @@ design: (work@top)
       |vpiName:NrHarts2
       |vpiFullName:work@top.NrHarts2
       |vpiLocalParam:1
+      |INT:8
       |vpiTypespec:
       \_int_typespec: (NrHarts2), line:4, parent:work@top.NrHarts2
         |vpiName:NrHarts2
@@ -990,6 +996,7 @@ design: (work@top)
       |vpiName:HartSelLen1
       |vpiFullName:work@top.HartSelLen1
       |vpiLocalParam:1
+      |INT:1
       |vpiTypespec:
       \_int_typespec: (HartSelLen1), line:6, parent:work@top.HartSelLen1
         |vpiName:HartSelLen1
@@ -1006,6 +1013,7 @@ design: (work@top)
       |vpiName:HartSelLen2
       |vpiFullName:work@top.HartSelLen2
       |vpiLocalParam:1
+      |INT:1
       |vpiTypespec:
       \_int_typespec: (HartSelLen2), line:8, parent:work@top.HartSelLen2
         |vpiName:HartSelLen2
@@ -1022,34 +1030,20 @@ design: (work@top)
       |vpiName:HartSelLen3
       |vpiFullName:work@top.HartSelLen3
       |vpiLocalParam:1
+      |INT:1
       |vpiTypespec:
       \_int_typespec: (HartSelLen3), line:10, parent:work@top.HartSelLen3
         |vpiName:HartSelLen3
   |vpiParameter:
-  \_parameter: (work@top.HartSelLen1), line:6, parent:work@top
-    |vpiName:HartSelLen1
-    |vpiFullName:work@top.HartSelLen1
-    |INT:1
-  |vpiParameter:
-  \_parameter: (work@top.HartSelLen2), line:8, parent:work@top
-    |vpiName:HartSelLen2
-    |vpiFullName:work@top.HartSelLen2
-    |INT:1
-  |vpiParameter:
-  \_parameter: (work@top.HartSelLen3), line:10, parent:work@top
-    |vpiName:HartSelLen3
-    |vpiFullName:work@top.HartSelLen3
-    |INT:1
-  |vpiParameter:
   \_parameter: (work@top.NrHarts), line:2, parent:work@top
-    |vpiName:NrHarts
-    |vpiFullName:work@top.NrHarts
-    |INT:1
   |vpiParameter:
   \_parameter: (work@top.NrHarts2), line:4, parent:work@top
-    |vpiName:NrHarts2
-    |vpiFullName:work@top.NrHarts2
-    |INT:8
+  |vpiParameter:
+  \_parameter: (work@top.HartSelLen1), line:6, parent:work@top
+  |vpiParameter:
+  \_parameter: (work@top.HartSelLen2), line:8, parent:work@top
+  |vpiParameter:
+  \_parameter: (work@top.HartSelLen3), line:10, parent:work@top
 |uhdmtopModules:
 \_module: work@ibex_register_file (work@ibex_register_file) dut.sv:14: 
   |vpiDefName:work@ibex_register_file
@@ -1151,6 +1145,7 @@ design: (work@top)
     \_parameter: (work@ibex_register_file.RV32E), line:15, parent:work@ibex_register_file
       |vpiName:RV32E
       |vpiFullName:work@ibex_register_file.RV32E
+      |INT:0
       |vpiTypespec:
       \_bit_typespec: (RV32E), line:15, parent:work@ibex_register_file.RV32E
         |vpiName:RV32E
@@ -1166,6 +1161,7 @@ design: (work@top)
     \_parameter: (work@ibex_register_file.DataWidth), line:16, parent:work@ibex_register_file
       |vpiName:DataWidth
       |vpiFullName:work@ibex_register_file.DataWidth
+      |INT:32
       |vpiTypespec:
       \_int_typespec: (DataWidth), line:16, parent:work@ibex_register_file.DataWidth
         |vpiName:DataWidth
@@ -1182,6 +1178,7 @@ design: (work@top)
       |vpiName:ADDR_WIDTH
       |vpiFullName:work@ibex_register_file.ADDR_WIDTH
       |vpiLocalParam:1
+      |INT:5
       |vpiTypespec:
       \_int_typespec: (ADDR_WIDTH), line:18, parent:work@ibex_register_file.ADDR_WIDTH
         |vpiName:ADDR_WIDTH
@@ -1198,29 +1195,18 @@ design: (work@top)
       |vpiName:NUM_WORDS
       |vpiFullName:work@ibex_register_file.NUM_WORDS
       |vpiLocalParam:1
+      |INT:32
       |vpiTypespec:
       \_int_typespec: (NUM_WORDS), line:19, parent:work@ibex_register_file.NUM_WORDS
         |vpiName:NUM_WORDS
   |vpiParameter:
-  \_parameter: (work@ibex_register_file.ADDR_WIDTH), line:18, parent:work@ibex_register_file
-    |vpiName:ADDR_WIDTH
-    |vpiFullName:work@ibex_register_file.ADDR_WIDTH
-    |INT:5
+  \_parameter: (work@ibex_register_file.RV32E), line:15, parent:work@ibex_register_file
   |vpiParameter:
   \_parameter: (work@ibex_register_file.DataWidth), line:16, parent:work@ibex_register_file
-    |vpiName:DataWidth
-    |vpiFullName:work@ibex_register_file.DataWidth
-    |INT:32
+  |vpiParameter:
+  \_parameter: (work@ibex_register_file.ADDR_WIDTH), line:18, parent:work@ibex_register_file
   |vpiParameter:
   \_parameter: (work@ibex_register_file.NUM_WORDS), line:19, parent:work@ibex_register_file
-    |vpiName:NUM_WORDS
-    |vpiFullName:work@ibex_register_file.NUM_WORDS
-    |INT:32
-  |vpiParameter:
-  \_parameter: (work@ibex_register_file.RV32E), line:15, parent:work@ibex_register_file
-    |vpiName:RV32E
-    |vpiFullName:work@ibex_register_file.RV32E
-    |INT:0
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/DollarRoot/DollarRoot.log
+++ b/tests/DollarRoot/DollarRoot.log
@@ -6818,6 +6818,7 @@ design: (work@top)
               \_parameter: (work@test_program.MAX_BURST), line:20, parent:work@test_program
                 |vpiName:MAX_BURST
                 |vpiFullName:work@test_program.MAX_BURST
+                |vpiLocalParam:1
                 |INT:8
           |vpiForInitStmt:
           \_assign_stmt: , parent:work@test_program
@@ -8311,6 +8312,7 @@ design: (work@top)
                     \_parameter: (work@test_program.NUM_SYMBOLS), line:16, parent:work@test_program
                       |vpiName:NUM_SYMBOLS
                       |vpiFullName:work@test_program.NUM_SYMBOLS
+                      |vpiLocalParam:1
                       |INT:4
                   |vpiOperand:
                   \_operation: , line:591, parent:work@test_program.create_command
@@ -8498,6 +8500,7 @@ design: (work@top)
             \_parameter: (work@test_program.SLAVE_SPAN), line:22, parent:work@test_program
               |vpiName:SLAVE_SPAN
               |vpiFullName:work@test_program.SLAVE_SPAN
+              |vpiLocalParam:1
               |INT:4096
       |vpiStmt:
       \_assignment: , line:615, parent:work@test_program.generate_random_aligned_address
@@ -9424,6 +9427,7 @@ design: (work@top)
               \_parameter: (work@test_program.ADDR_W), line:13, parent:work@test_program
                 |vpiName:ADDR_W
                 |vpiFullName:work@test_program.ADDR_W
+                |vpiLocalParam:1
                 |INT:13
             |vpiOperand:
             \_constant: , line:49
@@ -9455,6 +9459,7 @@ design: (work@top)
               \_parameter: (work@test_program.DATA_W), line:17, parent:work@test_program
                 |vpiName:DATA_W
                 |vpiFullName:work@test_program.DATA_W
+                |vpiLocalParam:1
                 |INT:32
             |vpiOperand:
             \_constant: , line:50
@@ -9673,6 +9678,7 @@ design: (work@top)
         \_parameter: (work@test_program.SYMBOL_W), line:15, parent:work@test_program
           |vpiName:SYMBOL_W
           |vpiFullName:work@test_program.SYMBOL_W
+          |vpiLocalParam:1
           |INT:8
     |vpiLhs:
     \_parameter: (work@test_program.DATA_W), line:17, parent:work@test_program
@@ -10052,6 +10058,7 @@ design: (work@top)
               \_parameter: (work@test_program.MAX_BURST), line:20, parent:work@test_program
                 |vpiName:MAX_BURST
                 |vpiFullName:work@test_program.MAX_BURST
+                |vpiLocalParam:1
                 |INT:8
           |vpiForInitStmt:
           \_assign_stmt: , parent:work@test_program
@@ -10100,6 +10107,7 @@ design: (work@top)
                   \_parameter: (work@test_program.MAX_COMMAND_BACKPRESSURE), line:25, parent:work@test_program
                     |vpiName:MAX_COMMAND_BACKPRESSURE
                     |vpiFullName:work@test_program.MAX_COMMAND_BACKPRESSURE
+                    |vpiLocalParam:1
                     |INT:2
             |vpiStmt:
             \_func_call: ($root.tb.dut.slave_0.set_interface_wait_time), line:292, parent:work@test_program
@@ -10304,6 +10312,7 @@ design: (work@top)
                                 \_parameter: (work@test_program.DATA_W), line:17, parent:work@test_program
                                   |vpiName:DATA_W
                                   |vpiFullName:work@test_program.DATA_W
+                                  |vpiLocalParam:1
                                   |INT:32
                               |vpiOperand:
                               \_constant: , line:59
@@ -11700,6 +11709,7 @@ design: (work@top)
             \_parameter: (work@test_program.MAX_COMMAND_IDLE), line:24, parent:work@test_program
               |vpiName:MAX_COMMAND_IDLE
               |vpiFullName:work@test_program.MAX_COMMAND_IDLE
+              |vpiLocalParam:1
               |INT:5
       |vpiStmt:
       \_if_else: , line:588, parent:work@test_program.create_command
@@ -11804,6 +11814,7 @@ design: (work@top)
                     \_parameter: (work@test_program.NUM_SYMBOLS), line:16, parent:work@test_program
                       |vpiName:NUM_SYMBOLS
                       |vpiFullName:work@test_program.NUM_SYMBOLS
+                      |vpiLocalParam:1
                       |INT:4
                   |vpiOperand:
                   \_operation: , line:591
@@ -11843,6 +11854,7 @@ design: (work@top)
                     \_parameter: (work@test_program.MAX_DATA_IDLE), line:26, parent:work@test_program
                       |vpiName:MAX_DATA_IDLE
                       |vpiFullName:work@test_program.MAX_DATA_IDLE
+                      |vpiLocalParam:1
                       |INT:3
         |vpiElseStmt:
         \_begin: (work@test_program.create_command), line:594
@@ -12010,6 +12022,7 @@ design: (work@top)
             \_parameter: (work@test_program.SLAVE_SPAN), line:22, parent:work@test_program
               |vpiName:SLAVE_SPAN
               |vpiFullName:work@test_program.SLAVE_SPAN
+              |vpiLocalParam:1
               |INT:4096
       |vpiStmt:
       \_assignment: , line:615, parent:work@test_program.generate_random_aligned_address
@@ -12561,6 +12574,7 @@ design: (work@top)
                                       \_parameter: (work@test_program.ADDR_W), line:13, parent:work@test_program
                                         |vpiName:ADDR_W
                                         |vpiFullName:work@test_program.ADDR_W
+                                        |vpiLocalParam:1
                                         |INT:13
                                     |vpiOperand:
                                     \_constant: , line:49
@@ -13313,6 +13327,7 @@ design: (work@top)
           \_parameter: (work@test_program.BURST_W), line:19, parent:work@test_program
             |vpiName:BURST_W
             |vpiFullName:work@test_program.BURST_W
+            |vpiLocalParam:1
             |INT:4
         |vpiOperand:
         \_constant: , line:31
@@ -13667,9 +13682,6 @@ design: (work@top)
       |INT:13
     |vpiLhs:
     \_parameter: (work@test_program.ADDR_W), line:13, parent:work@test_program
-      |vpiName:ADDR_W
-      |vpiFullName:work@test_program.ADDR_W
-      |vpiLocalParam:1
   |vpiParamAssign:
   \_param_assign: , line:15, parent:work@test_program
     |vpiRhs:
@@ -13683,6 +13695,7 @@ design: (work@top)
       |vpiName:SYMBOL_W
       |vpiFullName:work@test_program.SYMBOL_W
       |vpiLocalParam:1
+      |INT:8
   |vpiParamAssign:
   \_param_assign: , line:16, parent:work@test_program
     |vpiRhs:
@@ -13693,9 +13706,6 @@ design: (work@top)
       |INT:4
     |vpiLhs:
     \_parameter: (work@test_program.NUM_SYMBOLS), line:16, parent:work@test_program
-      |vpiName:NUM_SYMBOLS
-      |vpiFullName:work@test_program.NUM_SYMBOLS
-      |vpiLocalParam:1
   |vpiParamAssign:
   \_param_assign: , line:17, parent:work@test_program
     |vpiRhs:
@@ -13706,9 +13716,6 @@ design: (work@top)
       |INT:32
     |vpiLhs:
     \_parameter: (work@test_program.DATA_W), line:17, parent:work@test_program
-      |vpiName:DATA_W
-      |vpiFullName:work@test_program.DATA_W
-      |vpiLocalParam:1
   |vpiParamAssign:
   \_param_assign: , line:19, parent:work@test_program
     |vpiRhs:
@@ -13719,9 +13726,6 @@ design: (work@top)
       |INT:4
     |vpiLhs:
     \_parameter: (work@test_program.BURST_W), line:19, parent:work@test_program
-      |vpiName:BURST_W
-      |vpiFullName:work@test_program.BURST_W
-      |vpiLocalParam:1
   |vpiParamAssign:
   \_param_assign: , line:20, parent:work@test_program
     |vpiRhs:
@@ -13732,9 +13736,6 @@ design: (work@top)
       |INT:8
     |vpiLhs:
     \_parameter: (work@test_program.MAX_BURST), line:20, parent:work@test_program
-      |vpiName:MAX_BURST
-      |vpiFullName:work@test_program.MAX_BURST
-      |vpiLocalParam:1
   |vpiParamAssign:
   \_param_assign: , line:22, parent:work@test_program
     |vpiRhs:
@@ -13745,9 +13746,6 @@ design: (work@top)
       |INT:4096
     |vpiLhs:
     \_parameter: (work@test_program.SLAVE_SPAN), line:22, parent:work@test_program
-      |vpiName:SLAVE_SPAN
-      |vpiFullName:work@test_program.SLAVE_SPAN
-      |vpiLocalParam:1
   |vpiParamAssign:
   \_param_assign: , line:24, parent:work@test_program
     |vpiRhs:
@@ -13758,9 +13756,6 @@ design: (work@top)
       |INT:5
     |vpiLhs:
     \_parameter: (work@test_program.MAX_COMMAND_IDLE), line:24, parent:work@test_program
-      |vpiName:MAX_COMMAND_IDLE
-      |vpiFullName:work@test_program.MAX_COMMAND_IDLE
-      |vpiLocalParam:1
   |vpiParamAssign:
   \_param_assign: , line:25, parent:work@test_program
     |vpiRhs:
@@ -13771,9 +13766,6 @@ design: (work@top)
       |INT:2
     |vpiLhs:
     \_parameter: (work@test_program.MAX_COMMAND_BACKPRESSURE), line:25, parent:work@test_program
-      |vpiName:MAX_COMMAND_BACKPRESSURE
-      |vpiFullName:work@test_program.MAX_COMMAND_BACKPRESSURE
-      |vpiLocalParam:1
   |vpiParamAssign:
   \_param_assign: , line:26, parent:work@test_program
     |vpiRhs:
@@ -13784,32 +13776,26 @@ design: (work@top)
       |INT:3
     |vpiLhs:
     \_parameter: (work@test_program.MAX_DATA_IDLE), line:26, parent:work@test_program
-      |vpiName:MAX_DATA_IDLE
-      |vpiFullName:work@test_program.MAX_DATA_IDLE
-      |vpiLocalParam:1
   |vpiParameter:
   \_parameter: (work@test_program.ADDR_W), line:13, parent:work@test_program
   |vpiParameter:
-  \_parameter: (work@test_program.BURST_W), line:19, parent:work@test_program
-  |vpiParameter:
-  \_parameter: (work@test_program.DATA_W), line:17, parent:work@test_program
-  |vpiParameter:
-  \_parameter: (work@test_program.MAX_BURST), line:20, parent:work@test_program
-  |vpiParameter:
-  \_parameter: (work@test_program.MAX_COMMAND_BACKPRESSURE), line:25, parent:work@test_program
-  |vpiParameter:
-  \_parameter: (work@test_program.MAX_COMMAND_IDLE), line:24, parent:work@test_program
-  |vpiParameter:
-  \_parameter: (work@test_program.MAX_DATA_IDLE), line:26, parent:work@test_program
+  \_parameter: (work@test_program.SYMBOL_W), line:15, parent:work@test_program
   |vpiParameter:
   \_parameter: (work@test_program.NUM_SYMBOLS), line:16, parent:work@test_program
   |vpiParameter:
+  \_parameter: (work@test_program.DATA_W), line:17, parent:work@test_program
+  |vpiParameter:
+  \_parameter: (work@test_program.BURST_W), line:19, parent:work@test_program
+  |vpiParameter:
+  \_parameter: (work@test_program.MAX_BURST), line:20, parent:work@test_program
+  |vpiParameter:
   \_parameter: (work@test_program.SLAVE_SPAN), line:22, parent:work@test_program
   |vpiParameter:
-  \_parameter: (work@test_program.SYMBOL_W), line:15, parent:work@test_program
-    |vpiName:SYMBOL_W
-    |vpiFullName:work@test_program.SYMBOL_W
-    |INT:8
+  \_parameter: (work@test_program.MAX_COMMAND_IDLE), line:24, parent:work@test_program
+  |vpiParameter:
+  \_parameter: (work@test_program.MAX_COMMAND_BACKPRESSURE), line:25, parent:work@test_program
+  |vpiParameter:
+  \_parameter: (work@test_program.MAX_DATA_IDLE), line:26, parent:work@test_program
 |uhdmtopModules:
 \_module: work@test_program1 (work@test_program1) dut.sv:800: 
   |vpiDefName:work@test_program1

--- a/tests/ElabCParam/ElabCParam.log
+++ b/tests/ElabCParam/ElabCParam.log
@@ -1255,17 +1255,15 @@ design: (work@socket_1n)
               |vpiSize:64
               |INT:0
             |vpiLhs:
-            \_parameter: (work@prim_fifo_sync.Depth), line:3, parent:work@prim_fifo_sync
+            \_parameter: (work@socket_1n.gen_dfifo[0].fifo_d.reqfifo.Depth), line:3, parent:work@socket_1n.gen_dfifo[0].fifo_d.reqfifo
               |vpiName:Depth
-              |vpiFullName:work@prim_fifo_sync.Depth
+              |vpiFullName:work@socket_1n.gen_dfifo[0].fifo_d.reqfifo.Depth
+              |INT:0
               |vpiTypespec:
-              \_int_typespec: (Depth), line:3, parent:work@prim_fifo_sync.Depth
+              \_int_typespec: (Depth), line:3, parent:work@socket_1n.gen_dfifo[0].fifo_d.reqfifo.Depth
                 |vpiName:Depth
           |vpiParameter:
-          \_parameter: (work@socket_1n.gen_dfifo[0].fifo_d.reqfifo.Depth), line:30, parent:work@socket_1n.gen_dfifo[0].fifo_d.reqfifo
-            |vpiName:Depth
-            |vpiFullName:work@socket_1n.gen_dfifo[0].fifo_d.reqfifo.Depth
-            |INT:0
+          \_parameter: (work@socket_1n.gen_dfifo[0].fifo_d.reqfifo.Depth), line:3, parent:work@socket_1n.gen_dfifo[0].fifo_d.reqfifo
         |vpiParamAssign:
         \_param_assign: , line:25, parent:work@socket_1n.gen_dfifo[0].fifo_d
           |vpiRhs:
@@ -1274,16 +1272,15 @@ design: (work@socket_1n)
             |vpiSize:4
             |INT:0
           |vpiLhs:
-          \_parameter: (work@fifo_sync.ReqDepth), line:25, parent:work@fifo_sync
+          \_parameter: (work@socket_1n.gen_dfifo[0].fifo_d.ReqDepth), line:25, parent:work@socket_1n.gen_dfifo[0].fifo_d
             |vpiName:ReqDepth
-            |vpiFullName:work@fifo_sync.ReqDepth
+            |vpiFullName:work@socket_1n.gen_dfifo[0].fifo_d.ReqDepth
+            |INT:0
             |vpiTypespec:
-            \_int_typespec: (ReqDepth), line:25, parent:work@fifo_sync.ReqDepth
+            \_int_typespec: (ReqDepth), line:25, parent:work@socket_1n.gen_dfifo[0].fifo_d.ReqDepth
               |vpiName:ReqDepth
         |vpiParameter:
-        \_parameter: (work@socket_1n.gen_dfifo[0].fifo_d.ReqDepth), line:46, parent:work@socket_1n.gen_dfifo[0].fifo_d
-          |vpiName:ReqDepth
-          |vpiFullName:work@socket_1n.gen_dfifo[0].fifo_d.ReqDepth
+        \_parameter: (work@socket_1n.gen_dfifo[0].fifo_d.ReqDepth), line:25, parent:work@socket_1n.gen_dfifo[0].fifo_d
       |vpiParameter:
       \_parameter: (work@socket_1n.gen_dfifo[0].i), line:44, parent:work@socket_1n.gen_dfifo[0]
         |vpiName:i
@@ -1314,24 +1311,22 @@ design: (work@socket_1n)
             \_gen_scope: (work@socket_1n.gen_dfifo[1].fifo_d.reqfifo.gen_normal), parent:work@socket_1n.gen_dfifo[1].fifo_d.reqfifo.gen_normal
               |vpiFullName:work@socket_1n.gen_dfifo[1].fifo_d.reqfifo.gen_normal
               |vpiParamAssign:
-              \_param_assign: , line:18
+              \_param_assign: , line:18, parent:work@socket_1n.gen_dfifo[1].fifo_d.reqfifo.gen_normal
                 |vpiRhs:
                 \_constant: , line:18
                   |vpiDecompile:18446744073709551615
                   |INT:-1
                 |vpiLhs:
-                \_parameter: (PTRV_W), line:18
+                \_parameter: (work@socket_1n.gen_dfifo[1].fifo_d.reqfifo.gen_normal.PTRV_W), line:18, parent:work@socket_1n.gen_dfifo[1].fifo_d.reqfifo.gen_normal
                   |vpiName:PTRV_W
+                  |vpiFullName:work@socket_1n.gen_dfifo[1].fifo_d.reqfifo.gen_normal.PTRV_W
                   |vpiLocalParam:1
+                  |INT:-1
                   |vpiTypespec:
-                  \_int_typespec: (PTRV_W), line:18, parent:PTRV_W
+                  \_int_typespec: (PTRV_W), line:18, parent:work@socket_1n.gen_dfifo[1].fifo_d.reqfifo.gen_normal.PTRV_W
                     |vpiName:PTRV_W
               |vpiParameter:
               \_parameter: (work@socket_1n.gen_dfifo[1].fifo_d.reqfifo.gen_normal.PTRV_W), line:18, parent:work@socket_1n.gen_dfifo[1].fifo_d.reqfifo.gen_normal
-                |vpiName:PTRV_W
-                |vpiFullName:work@socket_1n.gen_dfifo[1].fifo_d.reqfifo.gen_normal.PTRV_W
-              |vpiParameter:
-              \_parameter: (PTRV_W), line:18
           |vpiInstance:
           \_module: work@fifo_sync (work@socket_1n.gen_dfifo[1].fifo_d) dut.sv:45: , parent:work@socket_1n.gen_dfifo[1]
           |vpiParamAssign:
@@ -1343,12 +1338,15 @@ design: (work@socket_1n)
               |vpiSize:64
               |INT:2
             |vpiLhs:
-            \_parameter: (work@prim_fifo_sync.Depth), line:3, parent:work@prim_fifo_sync
+            \_parameter: (work@socket_1n.gen_dfifo[1].fifo_d.reqfifo.Depth), line:3, parent:work@socket_1n.gen_dfifo[1].fifo_d.reqfifo
+              |vpiName:Depth
+              |vpiFullName:work@socket_1n.gen_dfifo[1].fifo_d.reqfifo.Depth
+              |INT:2
+              |vpiTypespec:
+              \_int_typespec: (Depth), line:3, parent:work@socket_1n.gen_dfifo[1].fifo_d.reqfifo.Depth
+                |vpiName:Depth
           |vpiParameter:
-          \_parameter: (work@socket_1n.gen_dfifo[1].fifo_d.reqfifo.Depth), line:30, parent:work@socket_1n.gen_dfifo[1].fifo_d.reqfifo
-            |vpiName:Depth
-            |vpiFullName:work@socket_1n.gen_dfifo[1].fifo_d.reqfifo.Depth
-            |INT:2
+          \_parameter: (work@socket_1n.gen_dfifo[1].fifo_d.reqfifo.Depth), line:3, parent:work@socket_1n.gen_dfifo[1].fifo_d.reqfifo
         |vpiParamAssign:
         \_param_assign: , line:25, parent:work@socket_1n.gen_dfifo[1].fifo_d
           |vpiRhs:
@@ -1357,11 +1355,15 @@ design: (work@socket_1n)
             |vpiSize:4
             |INT:2
           |vpiLhs:
-          \_parameter: (work@fifo_sync.ReqDepth), line:25, parent:work@fifo_sync
+          \_parameter: (work@socket_1n.gen_dfifo[1].fifo_d.ReqDepth), line:25, parent:work@socket_1n.gen_dfifo[1].fifo_d
+            |vpiName:ReqDepth
+            |vpiFullName:work@socket_1n.gen_dfifo[1].fifo_d.ReqDepth
+            |INT:2
+            |vpiTypespec:
+            \_int_typespec: (ReqDepth), line:25, parent:work@socket_1n.gen_dfifo[1].fifo_d.ReqDepth
+              |vpiName:ReqDepth
         |vpiParameter:
-        \_parameter: (work@socket_1n.gen_dfifo[1].fifo_d.ReqDepth), line:46, parent:work@socket_1n.gen_dfifo[1].fifo_d
-          |vpiName:ReqDepth
-          |vpiFullName:work@socket_1n.gen_dfifo[1].fifo_d.ReqDepth
+        \_parameter: (work@socket_1n.gen_dfifo[1].fifo_d.ReqDepth), line:25, parent:work@socket_1n.gen_dfifo[1].fifo_d
       |vpiParameter:
       \_parameter: (work@socket_1n.gen_dfifo[1].i), line:44, parent:work@socket_1n.gen_dfifo[1]
         |vpiName:i
@@ -1379,6 +1381,7 @@ design: (work@socket_1n)
     \_parameter: (work@socket_1n.N), line:39, parent:work@socket_1n
       |vpiName:N
       |vpiFullName:work@socket_1n.N
+      |INT:2
       |vpiTypespec:
       \_int_typespec: (N), line:39, parent:work@socket_1n.N
         |vpiName:N
@@ -1394,11 +1397,12 @@ design: (work@socket_1n)
     \_parameter: (work@socket_1n.DReqDepth), line:40, parent:work@socket_1n
       |vpiName:DReqDepth
       |vpiFullName:work@socket_1n.DReqDepth
+      |INT:34
       |vpiTypespec:
       \_bit_typespec: (DReqDepth), line:40, parent:work@socket_1n.DReqDepth
         |vpiName:DReqDepth
         |vpiRange:
-        \_range: , line:40
+        \_range: , line:40, parent:DReqDepth
           |vpiLeftRange:
           \_constant: , line:40
             |vpiConstType:7
@@ -1421,11 +1425,12 @@ design: (work@socket_1n)
     \_parameter: (work@socket_1n.AA), line:41, parent:work@socket_1n
       |vpiName:AA
       |vpiFullName:work@socket_1n.AA
+      |INT:68
       |vpiTypespec:
       \_bit_typespec: (AA), line:41, parent:work@socket_1n.AA
         |vpiName:AA
         |vpiRange:
-        \_range: , line:41
+        \_range: , line:41, parent:AA
           |vpiLeftRange:
           \_constant: , line:41
             |vpiConstType:7
@@ -1449,11 +1454,12 @@ design: (work@socket_1n)
     \_parameter: (work@socket_1n.BB), line:42, parent:work@socket_1n
       |vpiName:BB
       |vpiFullName:work@socket_1n.BB
+      |INT:2
       |vpiTypespec:
       \_bit_typespec: (BB), line:42, parent:work@socket_1n.BB
         |vpiName:BB
         |vpiRange:
-        \_range: , line:42
+        \_range: , line:42, parent:BB
           |vpiLeftRange:
           \_constant: , line:42
             |vpiConstType:7
@@ -1467,22 +1473,13 @@ design: (work@socket_1n)
             |vpiSize:32
             |INT:0
   |vpiParameter:
-  \_parameter: (work@socket_1n.AA), line:41, parent:work@socket_1n
-    |vpiName:AA
-    |vpiFullName:work@socket_1n.AA
-  |vpiParameter:
-  \_parameter: (work@socket_1n.BB), line:42, parent:work@socket_1n
-    |vpiName:BB
-    |vpiFullName:work@socket_1n.BB
+  \_parameter: (work@socket_1n.N), line:39, parent:work@socket_1n
   |vpiParameter:
   \_parameter: (work@socket_1n.DReqDepth), line:40, parent:work@socket_1n
-    |vpiName:DReqDepth
-    |vpiFullName:work@socket_1n.DReqDepth
   |vpiParameter:
-  \_parameter: (work@socket_1n.N), line:39, parent:work@socket_1n
-    |vpiName:N
-    |vpiFullName:work@socket_1n.N
-    |INT:2
+  \_parameter: (work@socket_1n.AA), line:41, parent:work@socket_1n
+  |vpiParameter:
+  \_parameter: (work@socket_1n.BB), line:42, parent:work@socket_1n
 |uhdmtopModules:
 \_module: work@all_zero (work@all_zero) dut.sv:54: 
   |vpiDefName:work@all_zero
@@ -1534,12 +1531,15 @@ design: (work@socket_1n)
               |vpiSize:64
               |INT:0
             |vpiLhs:
-            \_parameter: (work@prim_fifo_sync.Depth), line:3, parent:work@prim_fifo_sync
+            \_parameter: (work@all_zero.gen_dfifo[0].fifo_d.reqfifo.Depth), line:3, parent:work@all_zero.gen_dfifo[0].fifo_d.reqfifo
+              |vpiName:Depth
+              |vpiFullName:work@all_zero.gen_dfifo[0].fifo_d.reqfifo.Depth
+              |INT:0
+              |vpiTypespec:
+              \_int_typespec: (Depth), line:3, parent:work@all_zero.gen_dfifo[0].fifo_d.reqfifo.Depth
+                |vpiName:Depth
           |vpiParameter:
-          \_parameter: (work@all_zero.gen_dfifo[0].fifo_d.reqfifo.Depth), line:30, parent:work@all_zero.gen_dfifo[0].fifo_d.reqfifo
-            |vpiName:Depth
-            |vpiFullName:work@all_zero.gen_dfifo[0].fifo_d.reqfifo.Depth
-            |INT:0
+          \_parameter: (work@all_zero.gen_dfifo[0].fifo_d.reqfifo.Depth), line:3, parent:work@all_zero.gen_dfifo[0].fifo_d.reqfifo
         |vpiParamAssign:
         \_param_assign: , line:25, parent:work@all_zero.gen_dfifo[0].fifo_d
           |vpiRhs:
@@ -1548,11 +1548,15 @@ design: (work@socket_1n)
             |vpiSize:4
             |INT:0
           |vpiLhs:
-          \_parameter: (work@fifo_sync.ReqDepth), line:25, parent:work@fifo_sync
+          \_parameter: (work@all_zero.gen_dfifo[0].fifo_d.ReqDepth), line:25, parent:work@all_zero.gen_dfifo[0].fifo_d
+            |vpiName:ReqDepth
+            |vpiFullName:work@all_zero.gen_dfifo[0].fifo_d.ReqDepth
+            |INT:0
+            |vpiTypespec:
+            \_int_typespec: (ReqDepth), line:25, parent:work@all_zero.gen_dfifo[0].fifo_d.ReqDepth
+              |vpiName:ReqDepth
         |vpiParameter:
-        \_parameter: (work@all_zero.gen_dfifo[0].fifo_d.ReqDepth), line:62, parent:work@all_zero.gen_dfifo[0].fifo_d
-          |vpiName:ReqDepth
-          |vpiFullName:work@all_zero.gen_dfifo[0].fifo_d.ReqDepth
+        \_parameter: (work@all_zero.gen_dfifo[0].fifo_d.ReqDepth), line:25, parent:work@all_zero.gen_dfifo[0].fifo_d
       |vpiParameter:
       \_parameter: (work@all_zero.gen_dfifo[0].i), line:60, parent:work@all_zero.gen_dfifo[0]
         |vpiName:i
@@ -1605,12 +1609,15 @@ design: (work@socket_1n)
               |vpiSize:64
               |INT:0
             |vpiLhs:
-            \_parameter: (work@prim_fifo_sync.Depth), line:3, parent:work@prim_fifo_sync
+            \_parameter: (work@all_zero.gen_dfifo[1].fifo_d.reqfifo.Depth), line:3, parent:work@all_zero.gen_dfifo[1].fifo_d.reqfifo
+              |vpiName:Depth
+              |vpiFullName:work@all_zero.gen_dfifo[1].fifo_d.reqfifo.Depth
+              |INT:0
+              |vpiTypespec:
+              \_int_typespec: (Depth), line:3, parent:work@all_zero.gen_dfifo[1].fifo_d.reqfifo.Depth
+                |vpiName:Depth
           |vpiParameter:
-          \_parameter: (work@all_zero.gen_dfifo[1].fifo_d.reqfifo.Depth), line:30, parent:work@all_zero.gen_dfifo[1].fifo_d.reqfifo
-            |vpiName:Depth
-            |vpiFullName:work@all_zero.gen_dfifo[1].fifo_d.reqfifo.Depth
-            |INT:0
+          \_parameter: (work@all_zero.gen_dfifo[1].fifo_d.reqfifo.Depth), line:3, parent:work@all_zero.gen_dfifo[1].fifo_d.reqfifo
         |vpiParamAssign:
         \_param_assign: , line:25, parent:work@all_zero.gen_dfifo[1].fifo_d
           |vpiRhs:
@@ -1619,11 +1626,15 @@ design: (work@socket_1n)
             |vpiSize:4
             |INT:0
           |vpiLhs:
-          \_parameter: (work@fifo_sync.ReqDepth), line:25, parent:work@fifo_sync
+          \_parameter: (work@all_zero.gen_dfifo[1].fifo_d.ReqDepth), line:25, parent:work@all_zero.gen_dfifo[1].fifo_d
+            |vpiName:ReqDepth
+            |vpiFullName:work@all_zero.gen_dfifo[1].fifo_d.ReqDepth
+            |INT:0
+            |vpiTypespec:
+            \_int_typespec: (ReqDepth), line:25, parent:work@all_zero.gen_dfifo[1].fifo_d.ReqDepth
+              |vpiName:ReqDepth
         |vpiParameter:
-        \_parameter: (work@all_zero.gen_dfifo[1].fifo_d.ReqDepth), line:62, parent:work@all_zero.gen_dfifo[1].fifo_d
-          |vpiName:ReqDepth
-          |vpiFullName:work@all_zero.gen_dfifo[1].fifo_d.ReqDepth
+        \_parameter: (work@all_zero.gen_dfifo[1].fifo_d.ReqDepth), line:25, parent:work@all_zero.gen_dfifo[1].fifo_d
       |vpiParameter:
       \_parameter: (work@all_zero.gen_dfifo[1].i), line:60, parent:work@all_zero.gen_dfifo[1]
         |vpiName:i
@@ -1641,6 +1652,7 @@ design: (work@socket_1n)
     \_parameter: (work@all_zero.N), line:55, parent:work@all_zero
       |vpiName:N
       |vpiFullName:work@all_zero.N
+      |INT:2
       |vpiTypespec:
       \_int_typespec: (N), line:55, parent:work@all_zero.N
         |vpiName:N
@@ -1656,11 +1668,12 @@ design: (work@socket_1n)
     \_parameter: (work@all_zero.DReqDepth), line:56, parent:work@all_zero
       |vpiName:DReqDepth
       |vpiFullName:work@all_zero.DReqDepth
+      |INT:0
       |vpiTypespec:
       \_bit_typespec: (DReqDepth), line:56, parent:work@all_zero.DReqDepth
         |vpiName:DReqDepth
         |vpiRange:
-        \_range: , line:56
+        \_range: , line:56, parent:DReqDepth
           |vpiLeftRange:
           \_constant: , line:56
             |vpiConstType:7
@@ -1683,11 +1696,12 @@ design: (work@socket_1n)
     \_parameter: (work@all_zero.AA), line:57, parent:work@all_zero
       |vpiName:AA
       |vpiFullName:work@all_zero.AA
+      |INT:0
       |vpiTypespec:
       \_bit_typespec: (AA), line:57, parent:work@all_zero.AA
         |vpiName:AA
         |vpiRange:
-        \_range: , line:57
+        \_range: , line:57, parent:AA
           |vpiLeftRange:
           \_constant: , line:57
             |vpiConstType:7
@@ -1711,11 +1725,12 @@ design: (work@socket_1n)
     \_parameter: (work@all_zero.BB), line:58, parent:work@all_zero
       |vpiName:BB
       |vpiFullName:work@all_zero.BB
+      |INT:0
       |vpiTypespec:
       \_bit_typespec: (BB), line:58, parent:work@all_zero.BB
         |vpiName:BB
         |vpiRange:
-        \_range: , line:58
+        \_range: , line:58, parent:BB
           |vpiLeftRange:
           \_constant: , line:58
             |vpiConstType:7
@@ -1729,22 +1744,13 @@ design: (work@socket_1n)
             |vpiSize:32
             |INT:0
   |vpiParameter:
-  \_parameter: (work@all_zero.AA), line:57, parent:work@all_zero
-    |vpiName:AA
-    |vpiFullName:work@all_zero.AA
-  |vpiParameter:
-  \_parameter: (work@all_zero.BB), line:58, parent:work@all_zero
-    |vpiName:BB
-    |vpiFullName:work@all_zero.BB
+  \_parameter: (work@all_zero.N), line:55, parent:work@all_zero
   |vpiParameter:
   \_parameter: (work@all_zero.DReqDepth), line:56, parent:work@all_zero
-    |vpiName:DReqDepth
-    |vpiFullName:work@all_zero.DReqDepth
   |vpiParameter:
-  \_parameter: (work@all_zero.N), line:55, parent:work@all_zero
-    |vpiName:N
-    |vpiFullName:work@all_zero.N
-    |INT:2
+  \_parameter: (work@all_zero.AA), line:57, parent:work@all_zero
+  |vpiParameter:
+  \_parameter: (work@all_zero.BB), line:58, parent:work@all_zero
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/FSM2Always/FSM2Always.log
+++ b/tests/FSM2Always/FSM2Always.log
@@ -2715,6 +2715,7 @@ design: (work@fsm_using_always)
     \_parameter: (work@fsm_using_always.SIZE), line:23, parent:work@fsm_using_always
       |vpiName:SIZE
       |vpiFullName:work@fsm_using_always.SIZE
+      |INT:3
   |vpiParamAssign:
   \_param_assign: , line:24, parent:work@fsm_using_always
     |vpiRhs:
@@ -2725,8 +2726,6 @@ design: (work@fsm_using_always)
       |INT:1
     |vpiLhs:
     \_parameter: (work@fsm_using_always.IDLE), line:24, parent:work@fsm_using_always
-      |vpiName:IDLE
-      |vpiFullName:work@fsm_using_always.IDLE
   |vpiParamAssign:
   \_param_assign: , line:24, parent:work@fsm_using_always
     |vpiRhs:
@@ -2737,8 +2736,6 @@ design: (work@fsm_using_always)
       |INT:2
     |vpiLhs:
     \_parameter: (work@fsm_using_always.GNT0), line:24, parent:work@fsm_using_always
-      |vpiName:GNT0
-      |vpiFullName:work@fsm_using_always.GNT0
   |vpiParamAssign:
   \_param_assign: , line:24, parent:work@fsm_using_always
     |vpiRhs:
@@ -2749,19 +2746,14 @@ design: (work@fsm_using_always)
       |INT:4
     |vpiLhs:
     \_parameter: (work@fsm_using_always.GNT1), line:24, parent:work@fsm_using_always
-      |vpiName:GNT1
-      |vpiFullName:work@fsm_using_always.GNT1
+  |vpiParameter:
+  \_parameter: (work@fsm_using_always.SIZE), line:23, parent:work@fsm_using_always
+  |vpiParameter:
+  \_parameter: (work@fsm_using_always.IDLE), line:24, parent:work@fsm_using_always
   |vpiParameter:
   \_parameter: (work@fsm_using_always.GNT0), line:24, parent:work@fsm_using_always
   |vpiParameter:
   \_parameter: (work@fsm_using_always.GNT1), line:24, parent:work@fsm_using_always
-  |vpiParameter:
-  \_parameter: (work@fsm_using_always.IDLE), line:24, parent:work@fsm_using_always
-  |vpiParameter:
-  \_parameter: (work@fsm_using_always.SIZE), line:23, parent:work@fsm_using_always
-    |vpiName:SIZE
-    |vpiFullName:work@fsm_using_always.SIZE
-    |INT:3
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/FSMBsp13/FSMBsp13.log
+++ b/tests/FSMBsp13/FSMBsp13.log
@@ -6295,6 +6295,23 @@ design: (work@top)
                 |vpiName:ST_Read
                 |vpiFullName:work@top.F1.ST_Read
                 |INT:0
+                |vpiTypespec:
+                \_bit_typespec: (ST_Read), line:7, parent:work@top.F1.ST_Read
+                  |vpiName:ST_Read
+                  |vpiRange:
+                  \_range: , line:7, parent:ST_Read
+                    |vpiLeftRange:
+                    \_constant: , line:7
+                      |vpiConstType:7
+                      |vpiDecompile:3
+                      |vpiSize:32
+                      |INT:3
+                    |vpiRightRange:
+                    \_constant: , line:7
+                      |vpiConstType:7
+                      |vpiDecompile:0
+                      |vpiSize:32
+                      |INT:0
           |vpiElseStmt:
           \_assignment: , line:18
             |vpiOpType:82
@@ -6548,6 +6565,23 @@ design: (work@top)
                       |vpiName:ST_Hold
                       |vpiFullName:work@top.F1.ST_Hold
                       |INT:4
+                      |vpiTypespec:
+                      \_bit_typespec: (ST_Hold), line:7, parent:work@top.F1.ST_Hold
+                        |vpiName:ST_Hold
+                        |vpiRange:
+                        \_range: , line:7, parent:ST_Hold
+                          |vpiLeftRange:
+                          \_constant: , line:7
+                            |vpiConstType:7
+                            |vpiDecompile:3
+                            |vpiSize:32
+                            |INT:3
+                          |vpiRightRange:
+                          \_constant: , line:7
+                            |vpiConstType:7
+                            |vpiDecompile:0
+                            |vpiSize:32
+                            |INT:0
                 |vpiElseStmt:
                 \_if_else: , line:37
                   |vpiCondition:
@@ -6582,6 +6616,23 @@ design: (work@top)
                         |vpiName:ST_Block
                         |vpiFullName:work@top.F1.ST_Block
                         |INT:5
+                        |vpiTypespec:
+                        \_bit_typespec: (ST_Block), line:7, parent:work@top.F1.ST_Block
+                          |vpiName:ST_Block
+                          |vpiRange:
+                          \_range: , line:7, parent:ST_Block
+                            |vpiLeftRange:
+                            \_constant: , line:7
+                              |vpiConstType:7
+                              |vpiDecompile:3
+                              |vpiSize:32
+                              |INT:3
+                            |vpiRightRange:
+                            \_constant: , line:7
+                              |vpiConstType:7
+                              |vpiDecompile:0
+                              |vpiSize:32
+                              |INT:0
                   |vpiElseStmt:
                   \_if_else: , line:38
                     |vpiCondition:
@@ -6616,6 +6667,23 @@ design: (work@top)
                           |vpiName:ST_Wait
                           |vpiFullName:work@top.F1.ST_Wait
                           |INT:6
+                          |vpiTypespec:
+                          \_bit_typespec: (ST_Wait), line:7, parent:work@top.F1.ST_Wait
+                            |vpiName:ST_Wait
+                            |vpiRange:
+                            \_range: , line:7, parent:ST_Wait
+                              |vpiLeftRange:
+                              \_constant: , line:7
+                                |vpiConstType:7
+                                |vpiDecompile:3
+                                |vpiSize:32
+                                |INT:3
+                              |vpiRightRange:
+                              \_constant: , line:7
+                                |vpiConstType:7
+                                |vpiDecompile:0
+                                |vpiSize:32
+                                |INT:0
                     |vpiElseStmt:
                     \_if_else: , line:39
                       |vpiCondition:
@@ -6650,6 +6718,23 @@ design: (work@top)
                             |vpiName:ST_Turn
                             |vpiFullName:work@top.F1.ST_Turn
                             |INT:7
+                            |vpiTypespec:
+                            \_bit_typespec: (ST_Turn), line:7, parent:work@top.F1.ST_Turn
+                              |vpiName:ST_Turn
+                              |vpiRange:
+                              \_range: , line:7, parent:ST_Turn
+                                |vpiLeftRange:
+                                \_constant: , line:7
+                                  |vpiConstType:7
+                                  |vpiDecompile:3
+                                  |vpiSize:32
+                                  |INT:3
+                                |vpiRightRange:
+                                \_constant: , line:7
+                                  |vpiConstType:7
+                                  |vpiDecompile:0
+                                  |vpiSize:32
+                                  |INT:0
                       |vpiElseStmt:
                       \_if_else: , line:40
                         |vpiCondition:
@@ -6684,6 +6769,23 @@ design: (work@top)
                               |vpiName:ST_Quit
                               |vpiFullName:work@top.F1.ST_Quit
                               |INT:8
+                              |vpiTypespec:
+                              \_bit_typespec: (ST_Quit), line:7, parent:work@top.F1.ST_Quit
+                                |vpiName:ST_Quit
+                                |vpiRange:
+                                \_range: , line:7, parent:ST_Quit
+                                  |vpiLeftRange:
+                                  \_constant: , line:7
+                                    |vpiConstType:7
+                                    |vpiDecompile:3
+                                    |vpiSize:32
+                                    |INT:3
+                                  |vpiRightRange:
+                                  \_constant: , line:7
+                                    |vpiConstType:7
+                                    |vpiDecompile:0
+                                    |vpiSize:32
+                                    |INT:0
                         |vpiElseStmt:
                         \_assignment: , line:41
                           |vpiOpType:82
@@ -7168,6 +7270,23 @@ design: (work@top)
                             |vpiName:ST_Done
                             |vpiFullName:work@top.F1.ST_Done
                             |INT:10
+                            |vpiTypespec:
+                            \_bit_typespec: (ST_Done), line:7, parent:work@top.F1.ST_Done
+                              |vpiName:ST_Done
+                              |vpiRange:
+                              \_range: , line:7, parent:ST_Done
+                                |vpiLeftRange:
+                                \_constant: , line:7
+                                  |vpiConstType:7
+                                  |vpiDecompile:3
+                                  |vpiSize:32
+                                  |INT:3
+                                |vpiRightRange:
+                                \_constant: , line:7
+                                  |vpiConstType:7
+                                  |vpiDecompile:0
+                                  |vpiSize:32
+                                  |INT:0
                       |vpiElseStmt:
                       \_if_else: , line:66
                         |vpiCondition:
@@ -7202,6 +7321,23 @@ design: (work@top)
                               |vpiName:ST_Exit
                               |vpiFullName:work@top.F1.ST_Exit
                               |INT:9
+                              |vpiTypespec:
+                              \_bit_typespec: (ST_Exit), line:7, parent:work@top.F1.ST_Exit
+                                |vpiName:ST_Exit
+                                |vpiRange:
+                                \_range: , line:7, parent:ST_Exit
+                                  |vpiLeftRange:
+                                  \_constant: , line:7
+                                    |vpiConstType:7
+                                    |vpiDecompile:3
+                                    |vpiSize:32
+                                    |INT:3
+                                  |vpiRightRange:
+                                  \_constant: , line:7
+                                    |vpiConstType:7
+                                    |vpiDecompile:0
+                                    |vpiSize:32
+                                    |INT:0
                         |vpiElseStmt:
                         \_assignment: , line:67
                           |vpiOpType:82
@@ -7500,6 +7636,23 @@ design: (work@top)
                       |vpiName:ST_Write
                       |vpiFullName:work@top.F1.ST_Write
                       |INT:1
+                      |vpiTypespec:
+                      \_bit_typespec: (ST_Write), line:7, parent:work@top.F1.ST_Write
+                        |vpiName:ST_Write
+                        |vpiRange:
+                        \_range: , line:7, parent:ST_Write
+                          |vpiLeftRange:
+                          \_constant: , line:7
+                            |vpiConstType:7
+                            |vpiDecompile:3
+                            |vpiSize:32
+                            |INT:3
+                          |vpiRightRange:
+                          \_constant: , line:7
+                            |vpiConstType:7
+                            |vpiDecompile:0
+                            |vpiSize:32
+                            |INT:0
                 |vpiElseStmt:
                 \_if_else: , line:86
                   |vpiCondition:
@@ -8235,6 +8388,23 @@ design: (work@top)
                       |vpiName:ST_Delay
                       |vpiFullName:work@top.F1.ST_Delay
                       |INT:2
+                      |vpiTypespec:
+                      \_bit_typespec: (ST_Delay), line:7, parent:work@top.F1.ST_Delay
+                        |vpiName:ST_Delay
+                        |vpiRange:
+                        \_range: , line:7, parent:ST_Delay
+                          |vpiLeftRange:
+                          \_constant: , line:7
+                            |vpiConstType:7
+                            |vpiDecompile:3
+                            |vpiSize:32
+                            |INT:3
+                          |vpiRightRange:
+                          \_constant: , line:7
+                            |vpiConstType:7
+                            |vpiDecompile:0
+                            |vpiSize:32
+                            |INT:0
                 |vpiElseStmt:
                 \_assignment: , line:136
                   |vpiOpType:82
@@ -9056,6 +9226,23 @@ design: (work@top)
               |vpiName:ST0
               |vpiFullName:work@top.F2.ST0
               |INT:0
+              |vpiTypespec:
+              \_bit_typespec: (ST0), line:6, parent:work@top.F2.ST0
+                |vpiName:ST0
+                |vpiRange:
+                \_range: , line:6, parent:ST0
+                  |vpiLeftRange:
+                  \_constant: , line:6
+                    |vpiConstType:7
+                    |vpiDecompile:3
+                    |vpiSize:32
+                    |INT:3
+                  |vpiRightRange:
+                  \_constant: , line:6
+                    |vpiConstType:7
+                    |vpiDecompile:0
+                    |vpiSize:32
+                    |INT:0
         |vpiStmt:
         \_case_stmt: , line:38, parent:work@FSM2.COMB
           |vpiCaseType:1
@@ -9091,6 +9278,23 @@ design: (work@top)
                     |vpiName:ST1
                     |vpiFullName:work@top.F2.ST1
                     |INT:1
+                    |vpiTypespec:
+                    \_bit_typespec: (ST1), line:6, parent:work@top.F2.ST1
+                      |vpiName:ST1
+                      |vpiRange:
+                      \_range: , line:6, parent:ST1
+                        |vpiLeftRange:
+                        \_constant: , line:6
+                          |vpiConstType:7
+                          |vpiDecompile:3
+                          |vpiSize:32
+                          |INT:3
+                        |vpiRightRange:
+                        \_constant: , line:6
+                          |vpiConstType:7
+                          |vpiDecompile:0
+                          |vpiSize:32
+                          |INT:0
               |vpiStmt:
               \_task_call: (SwitchCtrl), line:41, parent:work@FSM2.COMB
                 |vpiName:SwitchCtrl
@@ -9130,6 +9334,23 @@ design: (work@top)
                       |vpiName:ST2
                       |vpiFullName:work@top.F2.ST2
                       |INT:2
+                      |vpiTypespec:
+                      \_bit_typespec: (ST2), line:6, parent:work@top.F2.ST2
+                        |vpiName:ST2
+                        |vpiRange:
+                        \_range: , line:6, parent:ST2
+                          |vpiLeftRange:
+                          \_constant: , line:6
+                            |vpiConstType:7
+                            |vpiDecompile:3
+                            |vpiSize:32
+                            |INT:3
+                          |vpiRightRange:
+                          \_constant: , line:6
+                            |vpiConstType:7
+                            |vpiDecompile:0
+                            |vpiSize:32
+                            |INT:0
                 |vpiElseStmt:
                 \_assignment: , line:48
                   |vpiOpType:82
@@ -9149,6 +9370,23 @@ design: (work@top)
                       |vpiName:ST3
                       |vpiFullName:work@top.F2.ST3
                       |INT:3
+                      |vpiTypespec:
+                      \_bit_typespec: (ST3), line:6, parent:work@top.F2.ST3
+                        |vpiName:ST3
+                        |vpiRange:
+                        \_range: , line:6, parent:ST3
+                          |vpiLeftRange:
+                          \_constant: , line:6
+                            |vpiConstType:7
+                            |vpiDecompile:3
+                            |vpiSize:32
+                            |INT:3
+                          |vpiRightRange:
+                          \_constant: , line:6
+                            |vpiConstType:7
+                            |vpiDecompile:0
+                            |vpiSize:32
+                            |INT:0
               |vpiStmt:
               \_task_call: (SwitchCtrl), line:49, parent:work@FSM2.COMB
                 |vpiName:SwitchCtrl
@@ -9242,6 +9480,23 @@ design: (work@top)
                     |vpiName:ST5
                     |vpiFullName:work@top.F2.ST5
                     |INT:5
+                    |vpiTypespec:
+                    \_bit_typespec: (ST5), line:6, parent:work@top.F2.ST5
+                      |vpiName:ST5
+                      |vpiRange:
+                      \_range: , line:6, parent:ST5
+                        |vpiLeftRange:
+                        \_constant: , line:6
+                          |vpiConstType:7
+                          |vpiDecompile:3
+                          |vpiSize:32
+                          |INT:3
+                        |vpiRightRange:
+                        \_constant: , line:6
+                          |vpiConstType:7
+                          |vpiDecompile:0
+                          |vpiSize:32
+                          |INT:0
           |vpiCaseItem:
           \_case_item: , line:66
             |vpiExpr:
@@ -9270,6 +9525,23 @@ design: (work@top)
                     |vpiName:ST10
                     |vpiFullName:work@top.F2.ST10
                     |INT:10
+                    |vpiTypespec:
+                    \_bit_typespec: (ST10), line:6, parent:work@top.F2.ST10
+                      |vpiName:ST10
+                      |vpiRange:
+                      \_range: , line:6, parent:ST10
+                        |vpiLeftRange:
+                        \_constant: , line:6
+                          |vpiConstType:7
+                          |vpiDecompile:3
+                          |vpiSize:32
+                          |INT:3
+                        |vpiRightRange:
+                        \_constant: , line:6
+                          |vpiConstType:7
+                          |vpiDecompile:0
+                          |vpiSize:32
+                          |INT:0
               |vpiStmt:
               \_task_call: (SwitchCtrl), line:68, parent:work@FSM2.COMB
                 |vpiName:SwitchCtrl
@@ -9344,6 +9616,23 @@ design: (work@top)
                       |vpiName:ST8
                       |vpiFullName:work@top.F2.ST8
                       |INT:8
+                      |vpiTypespec:
+                      \_bit_typespec: (ST8), line:6, parent:work@top.F2.ST8
+                        |vpiName:ST8
+                        |vpiRange:
+                        \_range: , line:6, parent:ST8
+                          |vpiLeftRange:
+                          \_constant: , line:6
+                            |vpiConstType:7
+                            |vpiDecompile:3
+                            |vpiSize:32
+                            |INT:3
+                          |vpiRightRange:
+                          \_constant: , line:6
+                            |vpiConstType:7
+                            |vpiDecompile:0
+                            |vpiSize:32
+                            |INT:0
                 |vpiElseStmt:
                 \_if_else: , line:79
                   |vpiCondition:
@@ -9369,6 +9658,23 @@ design: (work@top)
                         |vpiName:ST4
                         |vpiFullName:work@top.F2.ST4
                         |INT:4
+                        |vpiTypespec:
+                        \_bit_typespec: (ST4), line:6, parent:work@top.F2.ST4
+                          |vpiName:ST4
+                          |vpiRange:
+                          \_range: , line:6, parent:ST4
+                            |vpiLeftRange:
+                            \_constant: , line:6
+                              |vpiConstType:7
+                              |vpiDecompile:3
+                              |vpiSize:32
+                              |INT:3
+                            |vpiRightRange:
+                            \_constant: , line:6
+                              |vpiConstType:7
+                              |vpiDecompile:0
+                              |vpiSize:32
+                              |INT:0
                   |vpiElseStmt:
                   \_if_else: , line:80
                     |vpiCondition:
@@ -9733,6 +10039,23 @@ design: (work@top)
                       |vpiName:ST7
                       |vpiFullName:work@top.F2.ST7
                       |INT:7
+                      |vpiTypespec:
+                      \_bit_typespec: (ST7), line:6, parent:work@top.F2.ST7
+                        |vpiName:ST7
+                        |vpiRange:
+                        \_range: , line:6, parent:ST7
+                          |vpiLeftRange:
+                          \_constant: , line:6
+                            |vpiConstType:7
+                            |vpiDecompile:3
+                            |vpiSize:32
+                            |INT:3
+                          |vpiRightRange:
+                          \_constant: , line:6
+                            |vpiConstType:7
+                            |vpiDecompile:0
+                            |vpiSize:32
+                            |INT:0
                 |vpiElseStmt:
                 \_assignment: , line:103
                   |vpiOpType:82
@@ -9788,6 +10111,23 @@ design: (work@top)
                       |vpiName:ST6
                       |vpiFullName:work@top.F2.ST6
                       |INT:6
+                      |vpiTypespec:
+                      \_bit_typespec: (ST6), line:6, parent:work@top.F2.ST6
+                        |vpiName:ST6
+                        |vpiRange:
+                        \_range: , line:6, parent:ST6
+                          |vpiLeftRange:
+                          \_constant: , line:6
+                            |vpiConstType:7
+                            |vpiDecompile:3
+                            |vpiSize:32
+                            |INT:3
+                          |vpiRightRange:
+                          \_constant: , line:6
+                            |vpiConstType:7
+                            |vpiDecompile:0
+                            |vpiSize:32
+                            |INT:0
                 |vpiElseStmt:
                 \_assignment: , line:109
                   |vpiOpType:82
@@ -14070,6 +14410,23 @@ design: (work@top)
                   |vpiName:ST_Read
                   |vpiFullName:work@top.F1.ST_Read
                   |INT:0
+                  |vpiTypespec:
+                  \_bit_typespec: (ST_Read), line:7, parent:work@top.F1.ST_Read
+                    |vpiName:ST_Read
+                    |vpiRange:
+                    \_range: , line:7, parent:ST_Read
+                      |vpiLeftRange:
+                      \_constant: , line:7
+                        |vpiConstType:7
+                        |vpiDecompile:3
+                        |vpiSize:32
+                        |INT:3
+                      |vpiRightRange:
+                      \_constant: , line:7
+                        |vpiConstType:7
+                        |vpiDecompile:0
+                        |vpiSize:32
+                        |INT:0
             |vpiElseStmt:
             \_assignment: , line:18
               |vpiOpType:82
@@ -14219,6 +14576,23 @@ design: (work@top)
                   |vpiName:ST_Trx
                   |vpiFullName:work@top.F1.ST_Trx
                   |INT:3
+                  |vpiTypespec:
+                  \_bit_typespec: (ST_Trx), line:7, parent:work@top.F1.ST_Trx
+                    |vpiName:ST_Trx
+                    |vpiRange:
+                    \_range: , line:7, parent:ST_Trx
+                      |vpiLeftRange:
+                      \_constant: , line:7
+                        |vpiConstType:7
+                        |vpiDecompile:3
+                        |vpiSize:32
+                        |INT:3
+                      |vpiRightRange:
+                      \_constant: , line:7
+                        |vpiConstType:7
+                        |vpiDecompile:0
+                        |vpiSize:32
+                        |INT:0
               |vpiStmt:
               \_begin: (work@top.F1.COMB), line:31
                 |vpiFullName:work@top.F1.COMB
@@ -14334,6 +14708,23 @@ design: (work@top)
                         |vpiName:ST_Hold
                         |vpiFullName:work@top.F1.ST_Hold
                         |INT:4
+                        |vpiTypespec:
+                        \_bit_typespec: (ST_Hold), line:7, parent:work@top.F1.ST_Hold
+                          |vpiName:ST_Hold
+                          |vpiRange:
+                          \_range: , line:7, parent:ST_Hold
+                            |vpiLeftRange:
+                            \_constant: , line:7
+                              |vpiConstType:7
+                              |vpiDecompile:3
+                              |vpiSize:32
+                              |INT:3
+                            |vpiRightRange:
+                            \_constant: , line:7
+                              |vpiConstType:7
+                              |vpiDecompile:0
+                              |vpiSize:32
+                              |INT:0
                   |vpiElseStmt:
                   \_if_else: , line:37
                     |vpiCondition:
@@ -14370,6 +14761,23 @@ design: (work@top)
                           |vpiName:ST_Block
                           |vpiFullName:work@top.F1.ST_Block
                           |INT:5
+                          |vpiTypespec:
+                          \_bit_typespec: (ST_Block), line:7, parent:work@top.F1.ST_Block
+                            |vpiName:ST_Block
+                            |vpiRange:
+                            \_range: , line:7, parent:ST_Block
+                              |vpiLeftRange:
+                              \_constant: , line:7
+                                |vpiConstType:7
+                                |vpiDecompile:3
+                                |vpiSize:32
+                                |INT:3
+                              |vpiRightRange:
+                              \_constant: , line:7
+                                |vpiConstType:7
+                                |vpiDecompile:0
+                                |vpiSize:32
+                                |INT:0
                     |vpiElseStmt:
                     \_if_else: , line:38
                       |vpiCondition:
@@ -14408,6 +14816,23 @@ design: (work@top)
                             |vpiName:ST_Wait
                             |vpiFullName:work@top.F1.ST_Wait
                             |INT:6
+                            |vpiTypespec:
+                            \_bit_typespec: (ST_Wait), line:7, parent:work@top.F1.ST_Wait
+                              |vpiName:ST_Wait
+                              |vpiRange:
+                              \_range: , line:7, parent:ST_Wait
+                                |vpiLeftRange:
+                                \_constant: , line:7
+                                  |vpiConstType:7
+                                  |vpiDecompile:3
+                                  |vpiSize:32
+                                  |INT:3
+                                |vpiRightRange:
+                                \_constant: , line:7
+                                  |vpiConstType:7
+                                  |vpiDecompile:0
+                                  |vpiSize:32
+                                  |INT:0
                       |vpiElseStmt:
                       \_if_else: , line:39
                         |vpiCondition:
@@ -14444,6 +14869,23 @@ design: (work@top)
                               |vpiName:ST_Turn
                               |vpiFullName:work@top.F1.ST_Turn
                               |INT:7
+                              |vpiTypespec:
+                              \_bit_typespec: (ST_Turn), line:7, parent:work@top.F1.ST_Turn
+                                |vpiName:ST_Turn
+                                |vpiRange:
+                                \_range: , line:7, parent:ST_Turn
+                                  |vpiLeftRange:
+                                  \_constant: , line:7
+                                    |vpiConstType:7
+                                    |vpiDecompile:3
+                                    |vpiSize:32
+                                    |INT:3
+                                  |vpiRightRange:
+                                  \_constant: , line:7
+                                    |vpiConstType:7
+                                    |vpiDecompile:0
+                                    |vpiSize:32
+                                    |INT:0
                         |vpiElseStmt:
                         \_if_else: , line:40
                           |vpiCondition:
@@ -14480,6 +14922,23 @@ design: (work@top)
                                 |vpiName:ST_Quit
                                 |vpiFullName:work@top.F1.ST_Quit
                                 |INT:8
+                                |vpiTypespec:
+                                \_bit_typespec: (ST_Quit), line:7, parent:work@top.F1.ST_Quit
+                                  |vpiName:ST_Quit
+                                  |vpiRange:
+                                  \_range: , line:7, parent:ST_Quit
+                                    |vpiLeftRange:
+                                    \_constant: , line:7
+                                      |vpiConstType:7
+                                      |vpiDecompile:3
+                                      |vpiSize:32
+                                      |INT:3
+                                    |vpiRightRange:
+                                    \_constant: , line:7
+                                      |vpiConstType:7
+                                      |vpiDecompile:0
+                                      |vpiSize:32
+                                      |INT:0
                           |vpiElseStmt:
                           \_assignment: , line:41
                             |vpiOpType:82
@@ -14986,6 +15445,23 @@ design: (work@top)
                               |vpiName:ST_Done
                               |vpiFullName:work@top.F1.ST_Done
                               |INT:10
+                              |vpiTypespec:
+                              \_bit_typespec: (ST_Done), line:7, parent:work@top.F1.ST_Done
+                                |vpiName:ST_Done
+                                |vpiRange:
+                                \_range: , line:7, parent:ST_Done
+                                  |vpiLeftRange:
+                                  \_constant: , line:7
+                                    |vpiConstType:7
+                                    |vpiDecompile:3
+                                    |vpiSize:32
+                                    |INT:3
+                                  |vpiRightRange:
+                                  \_constant: , line:7
+                                    |vpiConstType:7
+                                    |vpiDecompile:0
+                                    |vpiSize:32
+                                    |INT:0
                         |vpiElseStmt:
                         \_if_else: , line:66
                           |vpiCondition:
@@ -15022,6 +15498,23 @@ design: (work@top)
                                 |vpiName:ST_Exit
                                 |vpiFullName:work@top.F1.ST_Exit
                                 |INT:9
+                                |vpiTypespec:
+                                \_bit_typespec: (ST_Exit), line:7, parent:work@top.F1.ST_Exit
+                                  |vpiName:ST_Exit
+                                  |vpiRange:
+                                  \_range: , line:7, parent:ST_Exit
+                                    |vpiLeftRange:
+                                    \_constant: , line:7
+                                      |vpiConstType:7
+                                      |vpiDecompile:3
+                                      |vpiSize:32
+                                      |INT:3
+                                    |vpiRightRange:
+                                    \_constant: , line:7
+                                      |vpiConstType:7
+                                      |vpiDecompile:0
+                                      |vpiSize:32
+                                      |INT:0
                           |vpiElseStmt:
                           \_assignment: , line:67
                             |vpiOpType:82
@@ -15330,6 +15823,23 @@ design: (work@top)
                         |vpiName:ST_Write
                         |vpiFullName:work@top.F1.ST_Write
                         |INT:1
+                        |vpiTypespec:
+                        \_bit_typespec: (ST_Write), line:7, parent:work@top.F1.ST_Write
+                          |vpiName:ST_Write
+                          |vpiRange:
+                          \_range: , line:7, parent:ST_Write
+                            |vpiLeftRange:
+                            \_constant: , line:7
+                              |vpiConstType:7
+                              |vpiDecompile:3
+                              |vpiSize:32
+                              |INT:3
+                            |vpiRightRange:
+                            \_constant: , line:7
+                              |vpiConstType:7
+                              |vpiDecompile:0
+                              |vpiSize:32
+                              |INT:0
                   |vpiElseStmt:
                   \_if_else: , line:86
                     |vpiCondition:
@@ -16091,6 +16601,23 @@ design: (work@top)
                         |vpiName:ST_Delay
                         |vpiFullName:work@top.F1.ST_Delay
                         |INT:2
+                        |vpiTypespec:
+                        \_bit_typespec: (ST_Delay), line:7, parent:work@top.F1.ST_Delay
+                          |vpiName:ST_Delay
+                          |vpiRange:
+                          \_range: , line:7, parent:ST_Delay
+                            |vpiLeftRange:
+                            \_constant: , line:7
+                              |vpiConstType:7
+                              |vpiDecompile:3
+                              |vpiSize:32
+                              |INT:3
+                            |vpiRightRange:
+                            \_constant: , line:7
+                              |vpiConstType:7
+                              |vpiDecompile:0
+                              |vpiSize:32
+                              |INT:0
                   |vpiElseStmt:
                   \_assignment: , line:136
                     |vpiOpType:82
@@ -16395,26 +16922,7 @@ design: (work@top)
         |vpiSize:64
         |INT:0
       |vpiLhs:
-      \_parameter: (work@FSM1.ST_Read), line:7, parent:work@FSM1
-        |vpiName:ST_Read
-        |vpiFullName:work@FSM1.ST_Read
-        |vpiTypespec:
-        \_bit_typespec: (ST_Read), line:7, parent:work@FSM1.ST_Read
-          |vpiName:ST_Read
-          |vpiRange:
-          \_range: , line:7
-            |vpiLeftRange:
-            \_constant: , line:7
-              |vpiConstType:7
-              |vpiDecompile:3
-              |vpiSize:32
-              |INT:3
-            |vpiRightRange:
-            \_constant: , line:7
-              |vpiConstType:7
-              |vpiDecompile:0
-              |vpiSize:32
-              |INT:0
+      \_parameter: (work@top.F1.ST_Read), line:7, parent:work@top.F1
     |vpiParamAssign:
     \_param_assign: , line:7, parent:work@top.F1
       |vpiRhs:
@@ -16424,26 +16932,7 @@ design: (work@top)
         |vpiSize:64
         |INT:1
       |vpiLhs:
-      \_parameter: (work@FSM1.ST_Write), line:7, parent:work@FSM1
-        |vpiName:ST_Write
-        |vpiFullName:work@FSM1.ST_Write
-        |vpiTypespec:
-        \_bit_typespec: (ST_Write), line:7, parent:work@FSM1.ST_Write
-          |vpiName:ST_Write
-          |vpiRange:
-          \_range: , line:7
-            |vpiLeftRange:
-            \_constant: , line:7
-              |vpiConstType:7
-              |vpiDecompile:3
-              |vpiSize:32
-              |INT:3
-            |vpiRightRange:
-            \_constant: , line:7
-              |vpiConstType:7
-              |vpiDecompile:0
-              |vpiSize:32
-              |INT:0
+      \_parameter: (work@top.F1.ST_Write), line:7, parent:work@top.F1
     |vpiParamAssign:
     \_param_assign: , line:7, parent:work@top.F1
       |vpiRhs:
@@ -16453,26 +16942,7 @@ design: (work@top)
         |vpiSize:64
         |INT:2
       |vpiLhs:
-      \_parameter: (work@FSM1.ST_Delay), line:7, parent:work@FSM1
-        |vpiName:ST_Delay
-        |vpiFullName:work@FSM1.ST_Delay
-        |vpiTypespec:
-        \_bit_typespec: (ST_Delay), line:7, parent:work@FSM1.ST_Delay
-          |vpiName:ST_Delay
-          |vpiRange:
-          \_range: , line:7
-            |vpiLeftRange:
-            \_constant: , line:7
-              |vpiConstType:7
-              |vpiDecompile:3
-              |vpiSize:32
-              |INT:3
-            |vpiRightRange:
-            \_constant: , line:7
-              |vpiConstType:7
-              |vpiDecompile:0
-              |vpiSize:32
-              |INT:0
+      \_parameter: (work@top.F1.ST_Delay), line:7, parent:work@top.F1
     |vpiParamAssign:
     \_param_assign: , line:8, parent:work@top.F1
       |vpiRhs:
@@ -16482,26 +16952,7 @@ design: (work@top)
         |vpiSize:64
         |INT:3
       |vpiLhs:
-      \_parameter: (work@FSM1.ST_Trx), line:8, parent:work@FSM1
-        |vpiName:ST_Trx
-        |vpiFullName:work@FSM1.ST_Trx
-        |vpiTypespec:
-        \_bit_typespec: (ST_Trx), line:7, parent:work@FSM1.ST_Trx
-          |vpiName:ST_Trx
-          |vpiRange:
-          \_range: , line:7
-            |vpiLeftRange:
-            \_constant: , line:7
-              |vpiConstType:7
-              |vpiDecompile:3
-              |vpiSize:32
-              |INT:3
-            |vpiRightRange:
-            \_constant: , line:7
-              |vpiConstType:7
-              |vpiDecompile:0
-              |vpiSize:32
-              |INT:0
+      \_parameter: (work@top.F1.ST_Trx), line:8, parent:work@top.F1
     |vpiParamAssign:
     \_param_assign: , line:8, parent:work@top.F1
       |vpiRhs:
@@ -16511,26 +16962,7 @@ design: (work@top)
         |vpiSize:64
         |INT:4
       |vpiLhs:
-      \_parameter: (work@FSM1.ST_Hold), line:8, parent:work@FSM1
-        |vpiName:ST_Hold
-        |vpiFullName:work@FSM1.ST_Hold
-        |vpiTypespec:
-        \_bit_typespec: (ST_Hold), line:7, parent:work@FSM1.ST_Hold
-          |vpiName:ST_Hold
-          |vpiRange:
-          \_range: , line:7
-            |vpiLeftRange:
-            \_constant: , line:7
-              |vpiConstType:7
-              |vpiDecompile:3
-              |vpiSize:32
-              |INT:3
-            |vpiRightRange:
-            \_constant: , line:7
-              |vpiConstType:7
-              |vpiDecompile:0
-              |vpiSize:32
-              |INT:0
+      \_parameter: (work@top.F1.ST_Hold), line:8, parent:work@top.F1
     |vpiParamAssign:
     \_param_assign: , line:8, parent:work@top.F1
       |vpiRhs:
@@ -16540,26 +16972,7 @@ design: (work@top)
         |vpiSize:64
         |INT:5
       |vpiLhs:
-      \_parameter: (work@FSM1.ST_Block), line:8, parent:work@FSM1
-        |vpiName:ST_Block
-        |vpiFullName:work@FSM1.ST_Block
-        |vpiTypespec:
-        \_bit_typespec: (ST_Block), line:7, parent:work@FSM1.ST_Block
-          |vpiName:ST_Block
-          |vpiRange:
-          \_range: , line:7
-            |vpiLeftRange:
-            \_constant: , line:7
-              |vpiConstType:7
-              |vpiDecompile:3
-              |vpiSize:32
-              |INT:3
-            |vpiRightRange:
-            \_constant: , line:7
-              |vpiConstType:7
-              |vpiDecompile:0
-              |vpiSize:32
-              |INT:0
+      \_parameter: (work@top.F1.ST_Block), line:8, parent:work@top.F1
     |vpiParamAssign:
     \_param_assign: , line:9, parent:work@top.F1
       |vpiRhs:
@@ -16569,26 +16982,7 @@ design: (work@top)
         |vpiSize:64
         |INT:6
       |vpiLhs:
-      \_parameter: (work@FSM1.ST_Wait), line:9, parent:work@FSM1
-        |vpiName:ST_Wait
-        |vpiFullName:work@FSM1.ST_Wait
-        |vpiTypespec:
-        \_bit_typespec: (ST_Wait), line:7, parent:work@FSM1.ST_Wait
-          |vpiName:ST_Wait
-          |vpiRange:
-          \_range: , line:7
-            |vpiLeftRange:
-            \_constant: , line:7
-              |vpiConstType:7
-              |vpiDecompile:3
-              |vpiSize:32
-              |INT:3
-            |vpiRightRange:
-            \_constant: , line:7
-              |vpiConstType:7
-              |vpiDecompile:0
-              |vpiSize:32
-              |INT:0
+      \_parameter: (work@top.F1.ST_Wait), line:9, parent:work@top.F1
     |vpiParamAssign:
     \_param_assign: , line:9, parent:work@top.F1
       |vpiRhs:
@@ -16598,26 +16992,7 @@ design: (work@top)
         |vpiSize:64
         |INT:7
       |vpiLhs:
-      \_parameter: (work@FSM1.ST_Turn), line:9, parent:work@FSM1
-        |vpiName:ST_Turn
-        |vpiFullName:work@FSM1.ST_Turn
-        |vpiTypespec:
-        \_bit_typespec: (ST_Turn), line:7, parent:work@FSM1.ST_Turn
-          |vpiName:ST_Turn
-          |vpiRange:
-          \_range: , line:7
-            |vpiLeftRange:
-            \_constant: , line:7
-              |vpiConstType:7
-              |vpiDecompile:3
-              |vpiSize:32
-              |INT:3
-            |vpiRightRange:
-            \_constant: , line:7
-              |vpiConstType:7
-              |vpiDecompile:0
-              |vpiSize:32
-              |INT:0
+      \_parameter: (work@top.F1.ST_Turn), line:9, parent:work@top.F1
     |vpiParamAssign:
     \_param_assign: , line:9, parent:work@top.F1
       |vpiRhs:
@@ -16627,26 +17002,7 @@ design: (work@top)
         |vpiSize:64
         |INT:8
       |vpiLhs:
-      \_parameter: (work@FSM1.ST_Quit), line:9, parent:work@FSM1
-        |vpiName:ST_Quit
-        |vpiFullName:work@FSM1.ST_Quit
-        |vpiTypespec:
-        \_bit_typespec: (ST_Quit), line:7, parent:work@FSM1.ST_Quit
-          |vpiName:ST_Quit
-          |vpiRange:
-          \_range: , line:7
-            |vpiLeftRange:
-            \_constant: , line:7
-              |vpiConstType:7
-              |vpiDecompile:3
-              |vpiSize:32
-              |INT:3
-            |vpiRightRange:
-            \_constant: , line:7
-              |vpiConstType:7
-              |vpiDecompile:0
-              |vpiSize:32
-              |INT:0
+      \_parameter: (work@top.F1.ST_Quit), line:9, parent:work@top.F1
     |vpiParamAssign:
     \_param_assign: , line:10, parent:work@top.F1
       |vpiRhs:
@@ -16656,26 +17012,7 @@ design: (work@top)
         |vpiSize:64
         |INT:9
       |vpiLhs:
-      \_parameter: (work@FSM1.ST_Exit), line:10, parent:work@FSM1
-        |vpiName:ST_Exit
-        |vpiFullName:work@FSM1.ST_Exit
-        |vpiTypespec:
-        \_bit_typespec: (ST_Exit), line:7, parent:work@FSM1.ST_Exit
-          |vpiName:ST_Exit
-          |vpiRange:
-          \_range: , line:7
-            |vpiLeftRange:
-            \_constant: , line:7
-              |vpiConstType:7
-              |vpiDecompile:3
-              |vpiSize:32
-              |INT:3
-            |vpiRightRange:
-            \_constant: , line:7
-              |vpiConstType:7
-              |vpiDecompile:0
-              |vpiSize:32
-              |INT:0
+      \_parameter: (work@top.F1.ST_Exit), line:10, parent:work@top.F1
     |vpiParamAssign:
     \_param_assign: , line:10, parent:work@top.F1
       |vpiRhs:
@@ -16685,48 +17022,29 @@ design: (work@top)
         |vpiSize:64
         |INT:10
       |vpiLhs:
-      \_parameter: (work@FSM1.ST_Done), line:10, parent:work@FSM1
-        |vpiName:ST_Done
-        |vpiFullName:work@FSM1.ST_Done
-        |vpiTypespec:
-        \_bit_typespec: (ST_Done), line:7, parent:work@FSM1.ST_Done
-          |vpiName:ST_Done
-          |vpiRange:
-          \_range: , line:7
-            |vpiLeftRange:
-            \_constant: , line:7
-              |vpiConstType:7
-              |vpiDecompile:3
-              |vpiSize:32
-              |INT:3
-            |vpiRightRange:
-            \_constant: , line:7
-              |vpiConstType:7
-              |vpiDecompile:0
-              |vpiSize:32
-              |INT:0
-    |vpiParameter:
-    \_parameter: (work@top.F1.ST_Block), line:8, parent:work@top.F1
-    |vpiParameter:
-    \_parameter: (work@top.F1.ST_Delay), line:7, parent:work@top.F1
-    |vpiParameter:
-    \_parameter: (work@top.F1.ST_Done), line:10, parent:work@top.F1
-    |vpiParameter:
-    \_parameter: (work@top.F1.ST_Exit), line:10, parent:work@top.F1
-    |vpiParameter:
-    \_parameter: (work@top.F1.ST_Hold), line:8, parent:work@top.F1
-    |vpiParameter:
-    \_parameter: (work@top.F1.ST_Quit), line:9, parent:work@top.F1
+      \_parameter: (work@top.F1.ST_Done), line:10, parent:work@top.F1
     |vpiParameter:
     \_parameter: (work@top.F1.ST_Read), line:7, parent:work@top.F1
     |vpiParameter:
+    \_parameter: (work@top.F1.ST_Write), line:7, parent:work@top.F1
+    |vpiParameter:
+    \_parameter: (work@top.F1.ST_Delay), line:7, parent:work@top.F1
+    |vpiParameter:
     \_parameter: (work@top.F1.ST_Trx), line:8, parent:work@top.F1
     |vpiParameter:
-    \_parameter: (work@top.F1.ST_Turn), line:9, parent:work@top.F1
+    \_parameter: (work@top.F1.ST_Hold), line:8, parent:work@top.F1
+    |vpiParameter:
+    \_parameter: (work@top.F1.ST_Block), line:8, parent:work@top.F1
     |vpiParameter:
     \_parameter: (work@top.F1.ST_Wait), line:9, parent:work@top.F1
     |vpiParameter:
-    \_parameter: (work@top.F1.ST_Write), line:7, parent:work@top.F1
+    \_parameter: (work@top.F1.ST_Turn), line:9, parent:work@top.F1
+    |vpiParameter:
+    \_parameter: (work@top.F1.ST_Quit), line:9, parent:work@top.F1
+    |vpiParameter:
+    \_parameter: (work@top.F1.ST_Exit), line:10, parent:work@top.F1
+    |vpiParameter:
+    \_parameter: (work@top.F1.ST_Done), line:10, parent:work@top.F1
   |vpiModule:
   \_module: work@FSM2 (work@top.F2) top.v:17: , parent:work@top
     |vpiDefName:work@FSM2
@@ -16949,6 +17267,23 @@ design: (work@top)
                 |vpiName:ST0
                 |vpiFullName:work@top.F2.ST0
                 |INT:0
+                |vpiTypespec:
+                \_bit_typespec: (ST0), line:6, parent:work@top.F2.ST0
+                  |vpiName:ST0
+                  |vpiRange:
+                  \_range: , line:6, parent:ST0
+                    |vpiLeftRange:
+                    \_constant: , line:6
+                      |vpiConstType:7
+                      |vpiDecompile:3
+                      |vpiSize:32
+                      |INT:3
+                    |vpiRightRange:
+                    \_constant: , line:6
+                      |vpiConstType:7
+                      |vpiDecompile:0
+                      |vpiSize:32
+                      |INT:0
           |vpiStmt:
           \_case_stmt: , line:38, parent:work@top.F2.COMB
             |vpiCaseType:1
@@ -16988,6 +17323,23 @@ design: (work@top)
                       |vpiName:ST1
                       |vpiFullName:work@top.F2.ST1
                       |INT:1
+                      |vpiTypespec:
+                      \_bit_typespec: (ST1), line:6, parent:work@top.F2.ST1
+                        |vpiName:ST1
+                        |vpiRange:
+                        \_range: , line:6, parent:ST1
+                          |vpiLeftRange:
+                          \_constant: , line:6
+                            |vpiConstType:7
+                            |vpiDecompile:3
+                            |vpiSize:32
+                            |INT:3
+                          |vpiRightRange:
+                          \_constant: , line:6
+                            |vpiConstType:7
+                            |vpiDecompile:0
+                            |vpiSize:32
+                            |INT:0
                 |vpiStmt:
                 \_task_call: (SwitchCtrl), line:41, parent:work@top.F2.COMB
                   |vpiName:SwitchCtrl
@@ -17031,6 +17383,23 @@ design: (work@top)
                         |vpiName:ST2
                         |vpiFullName:work@top.F2.ST2
                         |INT:2
+                        |vpiTypespec:
+                        \_bit_typespec: (ST2), line:6, parent:work@top.F2.ST2
+                          |vpiName:ST2
+                          |vpiRange:
+                          \_range: , line:6, parent:ST2
+                            |vpiLeftRange:
+                            \_constant: , line:6
+                              |vpiConstType:7
+                              |vpiDecompile:3
+                              |vpiSize:32
+                              |INT:3
+                            |vpiRightRange:
+                            \_constant: , line:6
+                              |vpiConstType:7
+                              |vpiDecompile:0
+                              |vpiSize:32
+                              |INT:0
                   |vpiElseStmt:
                   \_assignment: , line:48
                     |vpiOpType:82
@@ -17050,6 +17419,23 @@ design: (work@top)
                         |vpiName:ST3
                         |vpiFullName:work@top.F2.ST3
                         |INT:3
+                        |vpiTypespec:
+                        \_bit_typespec: (ST3), line:6, parent:work@top.F2.ST3
+                          |vpiName:ST3
+                          |vpiRange:
+                          \_range: , line:6, parent:ST3
+                            |vpiLeftRange:
+                            \_constant: , line:6
+                              |vpiConstType:7
+                              |vpiDecompile:3
+                              |vpiSize:32
+                              |INT:3
+                            |vpiRightRange:
+                            \_constant: , line:6
+                              |vpiConstType:7
+                              |vpiDecompile:0
+                              |vpiSize:32
+                              |INT:0
                 |vpiStmt:
                 \_task_call: (SwitchCtrl), line:49, parent:work@top.F2.COMB
                   |vpiName:SwitchCtrl
@@ -17125,6 +17511,23 @@ design: (work@top)
                   |vpiName:ST4
                   |vpiFullName:work@top.F2.ST4
                   |INT:4
+                  |vpiTypespec:
+                  \_bit_typespec: (ST4), line:6, parent:work@top.F2.ST4
+                    |vpiName:ST4
+                    |vpiRange:
+                    \_range: , line:6, parent:ST4
+                      |vpiLeftRange:
+                      \_constant: , line:6
+                        |vpiConstType:7
+                        |vpiDecompile:3
+                        |vpiSize:32
+                        |INT:3
+                      |vpiRightRange:
+                      \_constant: , line:6
+                        |vpiConstType:7
+                        |vpiDecompile:0
+                        |vpiSize:32
+                        |INT:0
               |vpiStmt:
               \_begin: (work@top.F2.COMB), line:61
                 |vpiFullName:work@top.F2.COMB
@@ -17152,6 +17555,23 @@ design: (work@top)
                       |vpiName:ST5
                       |vpiFullName:work@top.F2.ST5
                       |INT:5
+                      |vpiTypespec:
+                      \_bit_typespec: (ST5), line:6, parent:work@top.F2.ST5
+                        |vpiName:ST5
+                        |vpiRange:
+                        \_range: , line:6, parent:ST5
+                          |vpiLeftRange:
+                          \_constant: , line:6
+                            |vpiConstType:7
+                            |vpiDecompile:3
+                            |vpiSize:32
+                            |INT:3
+                          |vpiRightRange:
+                          \_constant: , line:6
+                            |vpiConstType:7
+                            |vpiDecompile:0
+                            |vpiSize:32
+                            |INT:0
             |vpiCaseItem:
             \_case_item: , line:66
               |vpiExpr:
@@ -17182,6 +17602,23 @@ design: (work@top)
                       |vpiName:ST10
                       |vpiFullName:work@top.F2.ST10
                       |INT:10
+                      |vpiTypespec:
+                      \_bit_typespec: (ST10), line:6, parent:work@top.F2.ST10
+                        |vpiName:ST10
+                        |vpiRange:
+                        \_range: , line:6, parent:ST10
+                          |vpiLeftRange:
+                          \_constant: , line:6
+                            |vpiConstType:7
+                            |vpiDecompile:3
+                            |vpiSize:32
+                            |INT:3
+                          |vpiRightRange:
+                          \_constant: , line:6
+                            |vpiConstType:7
+                            |vpiDecompile:0
+                            |vpiSize:32
+                            |INT:0
                 |vpiStmt:
                 \_task_call: (SwitchCtrl), line:68, parent:work@top.F2.COMB
                   |vpiName:SwitchCtrl
@@ -17198,6 +17635,23 @@ design: (work@top)
                   |vpiName:ST6
                   |vpiFullName:work@top.F2.ST6
                   |INT:6
+                  |vpiTypespec:
+                  \_bit_typespec: (ST6), line:6, parent:work@top.F2.ST6
+                    |vpiName:ST6
+                    |vpiRange:
+                    \_range: , line:6, parent:ST6
+                      |vpiLeftRange:
+                      \_constant: , line:6
+                        |vpiConstType:7
+                        |vpiDecompile:3
+                        |vpiSize:32
+                        |INT:3
+                      |vpiRightRange:
+                      \_constant: , line:6
+                        |vpiConstType:7
+                        |vpiDecompile:0
+                        |vpiSize:32
+                        |INT:0
               |vpiStmt:
               \_begin: (work@top.F2.COMB), line:71
                 |vpiFullName:work@top.F2.COMB
@@ -17233,6 +17687,23 @@ design: (work@top)
                   |vpiName:ST7
                   |vpiFullName:work@top.F2.ST7
                   |INT:7
+                  |vpiTypespec:
+                  \_bit_typespec: (ST7), line:6, parent:work@top.F2.ST7
+                    |vpiName:ST7
+                    |vpiRange:
+                    \_range: , line:6, parent:ST7
+                      |vpiLeftRange:
+                      \_constant: , line:6
+                        |vpiConstType:7
+                        |vpiDecompile:3
+                        |vpiSize:32
+                        |INT:3
+                      |vpiRightRange:
+                      \_constant: , line:6
+                        |vpiConstType:7
+                        |vpiDecompile:0
+                        |vpiSize:32
+                        |INT:0
               |vpiStmt:
               \_begin: (work@top.F2.COMB), line:76
                 |vpiFullName:work@top.F2.COMB
@@ -17268,6 +17739,23 @@ design: (work@top)
                         |vpiName:ST8
                         |vpiFullName:work@top.F2.ST8
                         |INT:8
+                        |vpiTypespec:
+                        \_bit_typespec: (ST8), line:6, parent:work@top.F2.ST8
+                          |vpiName:ST8
+                          |vpiRange:
+                          \_range: , line:6, parent:ST8
+                            |vpiLeftRange:
+                            \_constant: , line:6
+                              |vpiConstType:7
+                              |vpiDecompile:3
+                              |vpiSize:32
+                              |INT:3
+                            |vpiRightRange:
+                            \_constant: , line:6
+                              |vpiConstType:7
+                              |vpiDecompile:0
+                              |vpiSize:32
+                              |INT:0
                   |vpiElseStmt:
                   \_if_else: , line:79
                     |vpiCondition:
@@ -17648,6 +18136,23 @@ design: (work@top)
                   |vpiName:ST9
                   |vpiFullName:work@top.F2.ST9
                   |INT:9
+                  |vpiTypespec:
+                  \_bit_typespec: (ST9), line:6, parent:work@top.F2.ST9
+                    |vpiName:ST9
+                    |vpiRange:
+                    \_range: , line:6, parent:ST9
+                      |vpiLeftRange:
+                      \_constant: , line:6
+                        |vpiConstType:7
+                        |vpiDecompile:3
+                        |vpiSize:32
+                        |INT:3
+                      |vpiRightRange:
+                      \_constant: , line:6
+                        |vpiConstType:7
+                        |vpiDecompile:0
+                        |vpiSize:32
+                        |INT:0
               |vpiStmt:
               \_begin: (work@top.F2.COMB), line:100
                 |vpiFullName:work@top.F2.COMB
@@ -18228,26 +18733,7 @@ design: (work@top)
         |vpiSize:64
         |INT:0
       |vpiLhs:
-      \_parameter: (work@FSM2.ST0), line:6, parent:work@FSM2
-        |vpiName:ST0
-        |vpiFullName:work@FSM2.ST0
-        |vpiTypespec:
-        \_bit_typespec: (ST0), line:6, parent:work@FSM2.ST0
-          |vpiName:ST0
-          |vpiRange:
-          \_range: , line:6
-            |vpiLeftRange:
-            \_constant: , line:6
-              |vpiConstType:7
-              |vpiDecompile:3
-              |vpiSize:32
-              |INT:3
-            |vpiRightRange:
-            \_constant: , line:6
-              |vpiConstType:7
-              |vpiDecompile:0
-              |vpiSize:32
-              |INT:0
+      \_parameter: (work@top.F2.ST0), line:6, parent:work@top.F2
     |vpiParamAssign:
     \_param_assign: , line:6, parent:work@top.F2
       |vpiRhs:
@@ -18257,26 +18743,7 @@ design: (work@top)
         |vpiSize:64
         |INT:1
       |vpiLhs:
-      \_parameter: (work@FSM2.ST1), line:6, parent:work@FSM2
-        |vpiName:ST1
-        |vpiFullName:work@FSM2.ST1
-        |vpiTypespec:
-        \_bit_typespec: (ST1), line:6, parent:work@FSM2.ST1
-          |vpiName:ST1
-          |vpiRange:
-          \_range: , line:6
-            |vpiLeftRange:
-            \_constant: , line:6
-              |vpiConstType:7
-              |vpiDecompile:3
-              |vpiSize:32
-              |INT:3
-            |vpiRightRange:
-            \_constant: , line:6
-              |vpiConstType:7
-              |vpiDecompile:0
-              |vpiSize:32
-              |INT:0
+      \_parameter: (work@top.F2.ST1), line:6, parent:work@top.F2
     |vpiParamAssign:
     \_param_assign: , line:6, parent:work@top.F2
       |vpiRhs:
@@ -18286,26 +18753,7 @@ design: (work@top)
         |vpiSize:64
         |INT:2
       |vpiLhs:
-      \_parameter: (work@FSM2.ST2), line:6, parent:work@FSM2
-        |vpiName:ST2
-        |vpiFullName:work@FSM2.ST2
-        |vpiTypespec:
-        \_bit_typespec: (ST2), line:6, parent:work@FSM2.ST2
-          |vpiName:ST2
-          |vpiRange:
-          \_range: , line:6
-            |vpiLeftRange:
-            \_constant: , line:6
-              |vpiConstType:7
-              |vpiDecompile:3
-              |vpiSize:32
-              |INT:3
-            |vpiRightRange:
-            \_constant: , line:6
-              |vpiConstType:7
-              |vpiDecompile:0
-              |vpiSize:32
-              |INT:0
+      \_parameter: (work@top.F2.ST2), line:6, parent:work@top.F2
     |vpiParamAssign:
     \_param_assign: , line:6, parent:work@top.F2
       |vpiRhs:
@@ -18315,26 +18763,7 @@ design: (work@top)
         |vpiSize:64
         |INT:3
       |vpiLhs:
-      \_parameter: (work@FSM2.ST3), line:6, parent:work@FSM2
-        |vpiName:ST3
-        |vpiFullName:work@FSM2.ST3
-        |vpiTypespec:
-        \_bit_typespec: (ST3), line:6, parent:work@FSM2.ST3
-          |vpiName:ST3
-          |vpiRange:
-          \_range: , line:6
-            |vpiLeftRange:
-            \_constant: , line:6
-              |vpiConstType:7
-              |vpiDecompile:3
-              |vpiSize:32
-              |INT:3
-            |vpiRightRange:
-            \_constant: , line:6
-              |vpiConstType:7
-              |vpiDecompile:0
-              |vpiSize:32
-              |INT:0
+      \_parameter: (work@top.F2.ST3), line:6, parent:work@top.F2
     |vpiParamAssign:
     \_param_assign: , line:6, parent:work@top.F2
       |vpiRhs:
@@ -18344,26 +18773,7 @@ design: (work@top)
         |vpiSize:64
         |INT:4
       |vpiLhs:
-      \_parameter: (work@FSM2.ST4), line:6, parent:work@FSM2
-        |vpiName:ST4
-        |vpiFullName:work@FSM2.ST4
-        |vpiTypespec:
-        \_bit_typespec: (ST4), line:6, parent:work@FSM2.ST4
-          |vpiName:ST4
-          |vpiRange:
-          \_range: , line:6
-            |vpiLeftRange:
-            \_constant: , line:6
-              |vpiConstType:7
-              |vpiDecompile:3
-              |vpiSize:32
-              |INT:3
-            |vpiRightRange:
-            \_constant: , line:6
-              |vpiConstType:7
-              |vpiDecompile:0
-              |vpiSize:32
-              |INT:0
+      \_parameter: (work@top.F2.ST4), line:6, parent:work@top.F2
     |vpiParamAssign:
     \_param_assign: , line:6, parent:work@top.F2
       |vpiRhs:
@@ -18373,26 +18783,7 @@ design: (work@top)
         |vpiSize:64
         |INT:5
       |vpiLhs:
-      \_parameter: (work@FSM2.ST5), line:6, parent:work@FSM2
-        |vpiName:ST5
-        |vpiFullName:work@FSM2.ST5
-        |vpiTypespec:
-        \_bit_typespec: (ST5), line:6, parent:work@FSM2.ST5
-          |vpiName:ST5
-          |vpiRange:
-          \_range: , line:6
-            |vpiLeftRange:
-            \_constant: , line:6
-              |vpiConstType:7
-              |vpiDecompile:3
-              |vpiSize:32
-              |INT:3
-            |vpiRightRange:
-            \_constant: , line:6
-              |vpiConstType:7
-              |vpiDecompile:0
-              |vpiSize:32
-              |INT:0
+      \_parameter: (work@top.F2.ST5), line:6, parent:work@top.F2
     |vpiParamAssign:
     \_param_assign: , line:6, parent:work@top.F2
       |vpiRhs:
@@ -18402,26 +18793,7 @@ design: (work@top)
         |vpiSize:64
         |INT:6
       |vpiLhs:
-      \_parameter: (work@FSM2.ST6), line:6, parent:work@FSM2
-        |vpiName:ST6
-        |vpiFullName:work@FSM2.ST6
-        |vpiTypespec:
-        \_bit_typespec: (ST6), line:6, parent:work@FSM2.ST6
-          |vpiName:ST6
-          |vpiRange:
-          \_range: , line:6
-            |vpiLeftRange:
-            \_constant: , line:6
-              |vpiConstType:7
-              |vpiDecompile:3
-              |vpiSize:32
-              |INT:3
-            |vpiRightRange:
-            \_constant: , line:6
-              |vpiConstType:7
-              |vpiDecompile:0
-              |vpiSize:32
-              |INT:0
+      \_parameter: (work@top.F2.ST6), line:6, parent:work@top.F2
     |vpiParamAssign:
     \_param_assign: , line:6, parent:work@top.F2
       |vpiRhs:
@@ -18431,26 +18803,7 @@ design: (work@top)
         |vpiSize:64
         |INT:7
       |vpiLhs:
-      \_parameter: (work@FSM2.ST7), line:6, parent:work@FSM2
-        |vpiName:ST7
-        |vpiFullName:work@FSM2.ST7
-        |vpiTypespec:
-        \_bit_typespec: (ST7), line:6, parent:work@FSM2.ST7
-          |vpiName:ST7
-          |vpiRange:
-          \_range: , line:6
-            |vpiLeftRange:
-            \_constant: , line:6
-              |vpiConstType:7
-              |vpiDecompile:3
-              |vpiSize:32
-              |INT:3
-            |vpiRightRange:
-            \_constant: , line:6
-              |vpiConstType:7
-              |vpiDecompile:0
-              |vpiSize:32
-              |INT:0
+      \_parameter: (work@top.F2.ST7), line:6, parent:work@top.F2
     |vpiParamAssign:
     \_param_assign: , line:7, parent:work@top.F2
       |vpiRhs:
@@ -18460,26 +18813,7 @@ design: (work@top)
         |vpiSize:64
         |INT:8
       |vpiLhs:
-      \_parameter: (work@FSM2.ST8), line:7, parent:work@FSM2
-        |vpiName:ST8
-        |vpiFullName:work@FSM2.ST8
-        |vpiTypespec:
-        \_bit_typespec: (ST8), line:6, parent:work@FSM2.ST8
-          |vpiName:ST8
-          |vpiRange:
-          \_range: , line:6
-            |vpiLeftRange:
-            \_constant: , line:6
-              |vpiConstType:7
-              |vpiDecompile:3
-              |vpiSize:32
-              |INT:3
-            |vpiRightRange:
-            \_constant: , line:6
-              |vpiConstType:7
-              |vpiDecompile:0
-              |vpiSize:32
-              |INT:0
+      \_parameter: (work@top.F2.ST8), line:7, parent:work@top.F2
     |vpiParamAssign:
     \_param_assign: , line:7, parent:work@top.F2
       |vpiRhs:
@@ -18489,26 +18823,7 @@ design: (work@top)
         |vpiSize:64
         |INT:9
       |vpiLhs:
-      \_parameter: (work@FSM2.ST9), line:7, parent:work@FSM2
-        |vpiName:ST9
-        |vpiFullName:work@FSM2.ST9
-        |vpiTypespec:
-        \_bit_typespec: (ST9), line:6, parent:work@FSM2.ST9
-          |vpiName:ST9
-          |vpiRange:
-          \_range: , line:6
-            |vpiLeftRange:
-            \_constant: , line:6
-              |vpiConstType:7
-              |vpiDecompile:3
-              |vpiSize:32
-              |INT:3
-            |vpiRightRange:
-            \_constant: , line:6
-              |vpiConstType:7
-              |vpiDecompile:0
-              |vpiSize:32
-              |INT:0
+      \_parameter: (work@top.F2.ST9), line:7, parent:work@top.F2
     |vpiParamAssign:
     \_param_assign: , line:7, parent:work@top.F2
       |vpiRhs:
@@ -18518,32 +18833,11 @@ design: (work@top)
         |vpiSize:64
         |INT:10
       |vpiLhs:
-      \_parameter: (work@FSM2.ST10), line:7, parent:work@FSM2
-        |vpiName:ST10
-        |vpiFullName:work@FSM2.ST10
-        |vpiTypespec:
-        \_bit_typespec: (ST10), line:6, parent:work@FSM2.ST10
-          |vpiName:ST10
-          |vpiRange:
-          \_range: , line:6
-            |vpiLeftRange:
-            \_constant: , line:6
-              |vpiConstType:7
-              |vpiDecompile:3
-              |vpiSize:32
-              |INT:3
-            |vpiRightRange:
-            \_constant: , line:6
-              |vpiConstType:7
-              |vpiDecompile:0
-              |vpiSize:32
-              |INT:0
+      \_parameter: (work@top.F2.ST10), line:7, parent:work@top.F2
     |vpiParameter:
     \_parameter: (work@top.F2.ST0), line:6, parent:work@top.F2
     |vpiParameter:
     \_parameter: (work@top.F2.ST1), line:6, parent:work@top.F2
-    |vpiParameter:
-    \_parameter: (work@top.F2.ST10), line:7, parent:work@top.F2
     |vpiParameter:
     \_parameter: (work@top.F2.ST2), line:6, parent:work@top.F2
     |vpiParameter:
@@ -18560,6 +18854,8 @@ design: (work@top)
     \_parameter: (work@top.F2.ST8), line:7, parent:work@top.F2
     |vpiParameter:
     \_parameter: (work@top.F2.ST9), line:7, parent:work@top.F2
+    |vpiParameter:
+    \_parameter: (work@top.F2.ST10), line:7, parent:work@top.F2
   |vpiModule:
   \_module: work@FSM3 (work@top.F3) top.v:22: , parent:work@top
     |vpiDefName:work@FSM3
@@ -19363,9 +19659,7 @@ design: (work@top)
         |vpiSize:4
         |INT:0
       |vpiLhs:
-      \_parameter: (work@FSM3.Stop), line:8, parent:work@FSM3
-        |vpiName:Stop
-        |vpiFullName:work@FSM3.Stop
+      \_parameter: (work@top.F3.Stop), line:8, parent:work@top.F3
     |vpiParamAssign:
     \_param_assign: , line:9, parent:work@top.F3
       |vpiRhs:
@@ -19375,9 +19669,7 @@ design: (work@top)
         |vpiSize:4
         |INT:1
       |vpiLhs:
-      \_parameter: (work@FSM3.Move), line:9, parent:work@FSM3
-        |vpiName:Move
-        |vpiFullName:work@FSM3.Move
+      \_parameter: (work@top.F3.Move), line:9, parent:work@top.F3
     |vpiParamAssign:
     \_param_assign: , line:10, parent:work@top.F3
       |vpiRhs:
@@ -19387,9 +19679,7 @@ design: (work@top)
         |vpiSize:4
         |INT:2
       |vpiLhs:
-      \_parameter: (work@FSM3.Turn), line:10, parent:work@FSM3
-        |vpiName:Turn
-        |vpiFullName:work@FSM3.Turn
+      \_parameter: (work@top.F3.Turn), line:10, parent:work@top.F3
     |vpiParamAssign:
     \_param_assign: , line:11, parent:work@top.F3
       |vpiRhs:
@@ -19399,9 +19689,7 @@ design: (work@top)
         |vpiSize:4
         |INT:3
       |vpiLhs:
-      \_parameter: (work@FSM3.Slow), line:11, parent:work@FSM3
-        |vpiName:Slow
-        |vpiFullName:work@FSM3.Slow
+      \_parameter: (work@top.F3.Slow), line:11, parent:work@top.F3
     |vpiParamAssign:
     \_param_assign: , line:12, parent:work@top.F3
       |vpiRhs:
@@ -19411,9 +19699,7 @@ design: (work@top)
         |vpiSize:4
         |INT:4
       |vpiLhs:
-      \_parameter: (work@FSM3.Medium), line:12, parent:work@FSM3
-        |vpiName:Medium
-        |vpiFullName:work@FSM3.Medium
+      \_parameter: (work@top.F3.Medium), line:12, parent:work@top.F3
     |vpiParamAssign:
     \_param_assign: , line:13, parent:work@top.F3
       |vpiRhs:
@@ -19423,9 +19709,7 @@ design: (work@top)
         |vpiSize:4
         |INT:5
       |vpiLhs:
-      \_parameter: (work@FSM3.Fast), line:13, parent:work@FSM3
-        |vpiName:Fast
-        |vpiFullName:work@FSM3.Fast
+      \_parameter: (work@top.F3.Fast), line:13, parent:work@top.F3
     |vpiParamAssign:
     \_param_assign: , line:14, parent:work@top.F3
       |vpiRhs:
@@ -19435,23 +19719,21 @@ design: (work@top)
         |vpiSize:4
         |INT:6
       |vpiLhs:
-      \_parameter: (work@FSM3.Faster), line:14, parent:work@FSM3
-        |vpiName:Faster
-        |vpiFullName:work@FSM3.Faster
+      \_parameter: (work@top.F3.Faster), line:14, parent:work@top.F3
+    |vpiParameter:
+    \_parameter: (work@top.F3.Stop), line:8, parent:work@top.F3
+    |vpiParameter:
+    \_parameter: (work@top.F3.Move), line:9, parent:work@top.F3
+    |vpiParameter:
+    \_parameter: (work@top.F3.Turn), line:10, parent:work@top.F3
+    |vpiParameter:
+    \_parameter: (work@top.F3.Slow), line:11, parent:work@top.F3
+    |vpiParameter:
+    \_parameter: (work@top.F3.Medium), line:12, parent:work@top.F3
     |vpiParameter:
     \_parameter: (work@top.F3.Fast), line:13, parent:work@top.F3
     |vpiParameter:
     \_parameter: (work@top.F3.Faster), line:14, parent:work@top.F3
-    |vpiParameter:
-    \_parameter: (work@top.F3.Medium), line:12, parent:work@top.F3
-    |vpiParameter:
-    \_parameter: (work@top.F3.Move), line:9, parent:work@top.F3
-    |vpiParameter:
-    \_parameter: (work@top.F3.Slow), line:11, parent:work@top.F3
-    |vpiParameter:
-    \_parameter: (work@top.F3.Stop), line:8, parent:work@top.F3
-    |vpiParameter:
-    \_parameter: (work@top.F3.Turn), line:10, parent:work@top.F3
   |vpiNet:
   \_logic_net: (work@top.fsm1clk), line:3, parent:work@top
   |vpiNet:

--- a/tests/FSMFunction/FSMFunction.log
+++ b/tests/FSMFunction/FSMFunction.log
@@ -2769,6 +2769,7 @@ design: (work@fsm_using_function)
     \_parameter: (work@fsm_using_function.SIZE), line:23, parent:work@fsm_using_function
       |vpiName:SIZE
       |vpiFullName:work@fsm_using_function.SIZE
+      |INT:3
   |vpiParamAssign:
   \_param_assign: , line:24, parent:work@fsm_using_function
     |vpiRhs:
@@ -2779,8 +2780,6 @@ design: (work@fsm_using_function)
       |INT:1
     |vpiLhs:
     \_parameter: (work@fsm_using_function.IDLE), line:24, parent:work@fsm_using_function
-      |vpiName:IDLE
-      |vpiFullName:work@fsm_using_function.IDLE
   |vpiParamAssign:
   \_param_assign: , line:24, parent:work@fsm_using_function
     |vpiRhs:
@@ -2791,8 +2790,6 @@ design: (work@fsm_using_function)
       |INT:2
     |vpiLhs:
     \_parameter: (work@fsm_using_function.GNT0), line:24, parent:work@fsm_using_function
-      |vpiName:GNT0
-      |vpiFullName:work@fsm_using_function.GNT0
   |vpiParamAssign:
   \_param_assign: , line:24, parent:work@fsm_using_function
     |vpiRhs:
@@ -2803,19 +2800,14 @@ design: (work@fsm_using_function)
       |INT:4
     |vpiLhs:
     \_parameter: (work@fsm_using_function.GNT1), line:24, parent:work@fsm_using_function
-      |vpiName:GNT1
-      |vpiFullName:work@fsm_using_function.GNT1
+  |vpiParameter:
+  \_parameter: (work@fsm_using_function.SIZE), line:23, parent:work@fsm_using_function
+  |vpiParameter:
+  \_parameter: (work@fsm_using_function.IDLE), line:24, parent:work@fsm_using_function
   |vpiParameter:
   \_parameter: (work@fsm_using_function.GNT0), line:24, parent:work@fsm_using_function
   |vpiParameter:
   \_parameter: (work@fsm_using_function.GNT1), line:24, parent:work@fsm_using_function
-  |vpiParameter:
-  \_parameter: (work@fsm_using_function.IDLE), line:24, parent:work@fsm_using_function
-  |vpiParameter:
-  \_parameter: (work@fsm_using_function.SIZE), line:23, parent:work@fsm_using_function
-    |vpiName:SIZE
-    |vpiFullName:work@fsm_using_function.SIZE
-    |INT:3
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/FSMSingleAlways/FSMSingleAlways.log
+++ b/tests/FSMSingleAlways/FSMSingleAlways.log
@@ -2011,6 +2011,7 @@ design: (work@fsm_using_single_always)
     \_parameter: (work@fsm_using_single_always.SIZE), line:24, parent:work@fsm_using_single_always
       |vpiName:SIZE
       |vpiFullName:work@fsm_using_single_always.SIZE
+      |INT:3
   |vpiParamAssign:
   \_param_assign: , line:25, parent:work@fsm_using_single_always
     |vpiRhs:
@@ -2021,8 +2022,6 @@ design: (work@fsm_using_single_always)
       |INT:1
     |vpiLhs:
     \_parameter: (work@fsm_using_single_always.IDLE), line:25, parent:work@fsm_using_single_always
-      |vpiName:IDLE
-      |vpiFullName:work@fsm_using_single_always.IDLE
   |vpiParamAssign:
   \_param_assign: , line:25, parent:work@fsm_using_single_always
     |vpiRhs:
@@ -2033,8 +2032,6 @@ design: (work@fsm_using_single_always)
       |INT:2
     |vpiLhs:
     \_parameter: (work@fsm_using_single_always.GNT0), line:25, parent:work@fsm_using_single_always
-      |vpiName:GNT0
-      |vpiFullName:work@fsm_using_single_always.GNT0
   |vpiParamAssign:
   \_param_assign: , line:25, parent:work@fsm_using_single_always
     |vpiRhs:
@@ -2045,19 +2042,14 @@ design: (work@fsm_using_single_always)
       |INT:4
     |vpiLhs:
     \_parameter: (work@fsm_using_single_always.GNT1), line:25, parent:work@fsm_using_single_always
-      |vpiName:GNT1
-      |vpiFullName:work@fsm_using_single_always.GNT1
+  |vpiParameter:
+  \_parameter: (work@fsm_using_single_always.SIZE), line:24, parent:work@fsm_using_single_always
+  |vpiParameter:
+  \_parameter: (work@fsm_using_single_always.IDLE), line:25, parent:work@fsm_using_single_always
   |vpiParameter:
   \_parameter: (work@fsm_using_single_always.GNT0), line:25, parent:work@fsm_using_single_always
   |vpiParameter:
   \_parameter: (work@fsm_using_single_always.GNT1), line:25, parent:work@fsm_using_single_always
-  |vpiParameter:
-  \_parameter: (work@fsm_using_single_always.IDLE), line:25, parent:work@fsm_using_single_always
-  |vpiParameter:
-  \_parameter: (work@fsm_using_single_always.SIZE), line:24, parent:work@fsm_using_single_always
-    |vpiName:SIZE
-    |vpiFullName:work@fsm_using_single_always.SIZE
-    |INT:3
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/ForElab/ForElab.log
+++ b/tests/ForElab/ForElab.log
@@ -525,50 +525,48 @@ design: (work@tlul_socket_m1)
                     \_ref_obj: (o), line:41
                       |vpiName:o
                 |vpiParamAssign:
-                \_param_assign: , line:39
+                \_param_assign: , line:39, parent:work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[0]
                   |vpiRhs:
                   \_constant: , line:39
+                    |vpiConstType:7
                     |vpiDecompile:0
+                    |vpiSize:64
                     |INT:0
                   |vpiLhs:
-                  \_parameter: (base0), line:39
+                  \_parameter: (work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[0].base0), line:39, parent:work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[0]
                     |vpiName:base0
+                    |vpiFullName:work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[0].base0
                     |vpiLocalParam:1
+                    |INT:0
                     |vpiTypespec:
-                    \_int_typespec: (base0), line:39, parent:base0
+                    \_int_typespec: (base0), line:39, parent:work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[0].base0
                       |vpiName:base0
                 |vpiParamAssign:
-                \_param_assign: , line:40
+                \_param_assign: , line:40, parent:work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[0]
                   |vpiRhs:
                   \_constant: , line:40
+                    |vpiConstType:7
                     |vpiDecompile:1
+                    |vpiSize:64
                     |INT:1
                   |vpiLhs:
-                  \_parameter: (base1), line:40
+                  \_parameter: (work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[0].base1), line:40, parent:work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[0]
                     |vpiName:base1
+                    |vpiFullName:work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[0].base1
                     |vpiLocalParam:1
+                    |INT:1
                     |vpiTypespec:
-                    \_int_typespec: (base1), line:40, parent:base1
+                    \_int_typespec: (base1), line:40, parent:work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[0].base1
                       |vpiName:base1
                 |vpiParameter:
                 \_parameter: (work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[0].base0), line:39, parent:work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[0]
-                  |vpiName:base0
-                  |vpiFullName:work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[0].base0
-                  |INT:0
                 |vpiParameter:
                 \_parameter: (work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[0].base1), line:40, parent:work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[0]
-                  |vpiName:base1
-                  |vpiFullName:work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[0].base1
-                  |INT:1
                 |vpiParameter:
                 \_parameter: (work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[0].level), line:37, parent:work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[0]
                   |vpiName:level
                   |vpiFullName:work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[0].level
                   |INT:0
-                |vpiParameter:
-                \_parameter: (base0), line:39
-                |vpiParameter:
-                \_parameter: (base1), line:40
             |vpiGenScopeArray:
             \_gen_scope_array: (work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[1]), line:37, parent:work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case
               |vpiName:gen_tree[1]
@@ -603,50 +601,48 @@ design: (work@tlul_socket_m1)
                     \_ref_obj: (o), line:41
                       |vpiName:o
                 |vpiParamAssign:
-                \_param_assign: , line:39
+                \_param_assign: , line:39, parent:work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[1]
                   |vpiRhs:
                   \_constant: , line:39
+                    |vpiConstType:7
                     |vpiDecompile:1
+                    |vpiSize:64
                     |INT:1
                   |vpiLhs:
-                  \_parameter: (base0), line:39
+                  \_parameter: (work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[1].base0), line:39, parent:work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[1]
                     |vpiName:base0
+                    |vpiFullName:work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[1].base0
                     |vpiLocalParam:1
+                    |INT:1
                     |vpiTypespec:
-                    \_int_typespec: (base0), line:39, parent:base0
+                    \_int_typespec: (base0), line:39, parent:work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[1].base0
                       |vpiName:base0
                 |vpiParamAssign:
-                \_param_assign: , line:40
+                \_param_assign: , line:40, parent:work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[1]
                   |vpiRhs:
                   \_constant: , line:40
+                    |vpiConstType:7
                     |vpiDecompile:3
+                    |vpiSize:64
                     |INT:3
                   |vpiLhs:
-                  \_parameter: (base1), line:40
+                  \_parameter: (work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[1].base1), line:40, parent:work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[1]
                     |vpiName:base1
+                    |vpiFullName:work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[1].base1
                     |vpiLocalParam:1
+                    |INT:3
                     |vpiTypespec:
-                    \_int_typespec: (base1), line:40, parent:base1
+                    \_int_typespec: (base1), line:40, parent:work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[1].base1
                       |vpiName:base1
                 |vpiParameter:
                 \_parameter: (work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[1].base0), line:39, parent:work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[1]
-                  |vpiName:base0
-                  |vpiFullName:work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[1].base0
-                  |INT:1
                 |vpiParameter:
                 \_parameter: (work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[1].base1), line:40, parent:work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[1]
-                  |vpiName:base1
-                  |vpiFullName:work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[1].base1
-                  |INT:3
                 |vpiParameter:
                 \_parameter: (work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[1].level), line:37, parent:work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[1]
                   |vpiName:level
                   |vpiFullName:work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[1].level
                   |INT:1
-                |vpiParameter:
-                \_parameter: (base0), line:39
-                |vpiParameter:
-                \_parameter: (base1), line:40
             |vpiGenScopeArray:
             \_gen_scope_array: (work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[2]), line:37, parent:work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case
               |vpiName:gen_tree[2]
@@ -681,50 +677,48 @@ design: (work@tlul_socket_m1)
                     \_ref_obj: (o), line:41
                       |vpiName:o
                 |vpiParamAssign:
-                \_param_assign: , line:39
+                \_param_assign: , line:39, parent:work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[2]
                   |vpiRhs:
                   \_constant: , line:39
+                    |vpiConstType:7
                     |vpiDecompile:3
+                    |vpiSize:64
                     |INT:3
                   |vpiLhs:
-                  \_parameter: (base0), line:39
+                  \_parameter: (work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[2].base0), line:39, parent:work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[2]
                     |vpiName:base0
+                    |vpiFullName:work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[2].base0
                     |vpiLocalParam:1
+                    |INT:3
                     |vpiTypespec:
-                    \_int_typespec: (base0), line:39, parent:base0
+                    \_int_typespec: (base0), line:39, parent:work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[2].base0
                       |vpiName:base0
                 |vpiParamAssign:
-                \_param_assign: , line:40
+                \_param_assign: , line:40, parent:work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[2]
                   |vpiRhs:
                   \_constant: , line:40
+                    |vpiConstType:7
                     |vpiDecompile:7
+                    |vpiSize:64
                     |INT:7
                   |vpiLhs:
-                  \_parameter: (base1), line:40
+                  \_parameter: (work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[2].base1), line:40, parent:work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[2]
                     |vpiName:base1
+                    |vpiFullName:work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[2].base1
                     |vpiLocalParam:1
+                    |INT:7
                     |vpiTypespec:
-                    \_int_typespec: (base1), line:40, parent:base1
+                    \_int_typespec: (base1), line:40, parent:work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[2].base1
                       |vpiName:base1
                 |vpiParameter:
                 \_parameter: (work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[2].base0), line:39, parent:work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[2]
-                  |vpiName:base0
-                  |vpiFullName:work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[2].base0
-                  |INT:3
                 |vpiParameter:
                 \_parameter: (work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[2].base1), line:40, parent:work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[2]
-                  |vpiName:base1
-                  |vpiFullName:work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[2].base1
-                  |INT:7
                 |vpiParameter:
                 \_parameter: (work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[2].level), line:37, parent:work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[2]
                   |vpiName:level
                   |vpiFullName:work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.gen_tree[2].level
                   |INT:2
-                |vpiParameter:
-                \_parameter: (base0), line:39
-                |vpiParameter:
-                \_parameter: (base1), line:40
             |vpiVariables:
             \_logic_var: (work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.req), line:35, parent:work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case
               |vpiName:req
@@ -746,25 +740,24 @@ design: (work@tlul_socket_m1)
                   |vpiSize:64
                   |INT:0
             |vpiParamAssign:
-            \_param_assign: , line:34
+            \_param_assign: , line:34, parent:work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case
               |vpiRhs:
               \_constant: , line:34
+                |vpiConstType:7
                 |vpiDecompile:2
+                |vpiSize:64
                 |INT:2
               |vpiLhs:
-              \_parameter: (N_LEVELS), line:34
+              \_parameter: (work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.N_LEVELS), line:34, parent:work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case
                 |vpiName:N_LEVELS
+                |vpiFullName:work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.N_LEVELS
                 |vpiLocalParam:1
+                |INT:2
                 |vpiTypespec:
-                \_int_typespec: (N_LEVELS), line:34, parent:N_LEVELS
+                \_int_typespec: (N_LEVELS), line:34, parent:work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.N_LEVELS
                   |vpiName:N_LEVELS
             |vpiParameter:
             \_parameter: (work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.N_LEVELS), line:34, parent:work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case
-              |vpiName:N_LEVELS
-              |vpiFullName:work@tlul_socket_m1.gen_tree_arb.u_reqarb.gen_normal_case.N_LEVELS
-              |INT:2
-            |vpiParameter:
-            \_parameter: (N_LEVELS), line:34
         |vpiNet:
         \_logic_net: (work@tlul_socket_m1.gen_tree_arb.u_reqarb.clk_i), line:21, parent:work@tlul_socket_m1.gen_tree_arb.u_reqarb
         |vpiNet:
@@ -778,11 +771,12 @@ design: (work@tlul_socket_m1)
             |vpiSize:64
             |INT:4
           |vpiLhs:
-          \_parameter: (work@prim_arbiter_tree.N), line:17, parent:work@prim_arbiter_tree
+          \_parameter: (work@tlul_socket_m1.gen_tree_arb.u_reqarb.N), line:17, parent:work@tlul_socket_m1.gen_tree_arb.u_reqarb
             |vpiName:N
-            |vpiFullName:work@prim_arbiter_tree.N
+            |vpiFullName:work@tlul_socket_m1.gen_tree_arb.u_reqarb.N
+            |INT:4
             |vpiTypespec:
-            \_int_typespec: (N), line:17, parent:work@prim_arbiter_tree.N
+            \_int_typespec: (N), line:17, parent:work@tlul_socket_m1.gen_tree_arb.u_reqarb.N
               |vpiName:N
         |vpiParamAssign:
         \_param_assign: , line:18, parent:work@tlul_socket_m1.gen_tree_arb.u_reqarb
@@ -793,11 +787,12 @@ design: (work@tlul_socket_m1)
             |vpiSize:32
             |INT:32
           |vpiLhs:
-          \_parameter: (work@prim_arbiter_tree.DW), line:18, parent:work@prim_arbiter_tree
+          \_parameter: (work@tlul_socket_m1.gen_tree_arb.u_reqarb.DW), line:18, parent:work@tlul_socket_m1.gen_tree_arb.u_reqarb
             |vpiName:DW
-            |vpiFullName:work@prim_arbiter_tree.DW
+            |vpiFullName:work@tlul_socket_m1.gen_tree_arb.u_reqarb.DW
+            |INT:32
             |vpiTypespec:
-            \_int_typespec: (DW), line:18, parent:work@prim_arbiter_tree.DW
+            \_int_typespec: (DW), line:18, parent:work@tlul_socket_m1.gen_tree_arb.u_reqarb.DW
               |vpiName:DW
         |vpiParamAssign:
         \_param_assign: , line:19, parent:work@tlul_socket_m1.gen_tree_arb.u_reqarb
@@ -808,26 +803,19 @@ design: (work@tlul_socket_m1)
             |vpiSize:1
             |SCAL:1
           |vpiLhs:
-          \_parameter: (work@prim_arbiter_tree.Lock), line:19, parent:work@prim_arbiter_tree
+          \_parameter: (work@tlul_socket_m1.gen_tree_arb.u_reqarb.Lock), line:19, parent:work@tlul_socket_m1.gen_tree_arb.u_reqarb
             |vpiName:Lock
-            |vpiFullName:work@prim_arbiter_tree.Lock
+            |vpiFullName:work@tlul_socket_m1.gen_tree_arb.u_reqarb.Lock
+            |INT:1
             |vpiTypespec:
-            \_bit_typespec: (Lock), line:19, parent:work@prim_arbiter_tree.Lock
+            \_bit_typespec: (Lock), line:19, parent:work@tlul_socket_m1.gen_tree_arb.u_reqarb.Lock
               |vpiName:Lock
         |vpiParameter:
-        \_parameter: (work@tlul_socket_m1.gen_tree_arb.u_reqarb.DW), line:57, parent:work@tlul_socket_m1.gen_tree_arb.u_reqarb
-          |vpiName:DW
-          |vpiFullName:work@tlul_socket_m1.gen_tree_arb.u_reqarb.DW
+        \_parameter: (work@tlul_socket_m1.gen_tree_arb.u_reqarb.N), line:17, parent:work@tlul_socket_m1.gen_tree_arb.u_reqarb
+        |vpiParameter:
+        \_parameter: (work@tlul_socket_m1.gen_tree_arb.u_reqarb.DW), line:18, parent:work@tlul_socket_m1.gen_tree_arb.u_reqarb
         |vpiParameter:
         \_parameter: (work@tlul_socket_m1.gen_tree_arb.u_reqarb.Lock), line:19, parent:work@tlul_socket_m1.gen_tree_arb.u_reqarb
-          |vpiName:Lock
-          |vpiFullName:work@tlul_socket_m1.gen_tree_arb.u_reqarb.Lock
-          |SCAL:1
-        |vpiParameter:
-        \_parameter: (work@tlul_socket_m1.gen_tree_arb.u_reqarb.N), line:56, parent:work@tlul_socket_m1.gen_tree_arb.u_reqarb
-          |vpiName:N
-          |vpiFullName:work@tlul_socket_m1.gen_tree_arb.u_reqarb.N
-          |INT:4
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/GenBlockVar/GenBlockVar.log
+++ b/tests/GenBlockVar/GenBlockVar.log
@@ -399,14 +399,12 @@ design: (work@top)
     \_parameter: (work@top.AsyncOn), line:3, parent:work@top
       |vpiName:AsyncOn
       |vpiFullName:work@top.AsyncOn
+      |INT:0
       |vpiTypespec:
       \_bit_typespec: (AsyncOn), line:3, parent:work@top.AsyncOn
         |vpiName:AsyncOn
   |vpiParameter:
   \_parameter: (work@top.AsyncOn), line:3, parent:work@top
-    |vpiName:AsyncOn
-    |vpiFullName:work@top.AsyncOn
-    |SCAL:0
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/GenerateAssigns/GenerateAssigns.log
+++ b/tests/GenerateAssigns/GenerateAssigns.log
@@ -706,6 +706,7 @@ design: (work@dut)
     \_parameter: (work@dut.p), line:2, parent:work@dut
       |vpiName:p
       |vpiFullName:work@dut.p
+      |INT:2
   |vpiParamAssign:
   \_param_assign: , line:2, parent:work@dut
     |vpiRhs:
@@ -718,16 +719,11 @@ design: (work@dut)
     \_parameter: (work@dut.q), line:2, parent:work@dut
       |vpiName:q
       |vpiFullName:work@dut.q
+      |INT:4
   |vpiParameter:
   \_parameter: (work@dut.p), line:2, parent:work@dut
-    |vpiName:p
-    |vpiFullName:work@dut.p
-    |INT:2
   |vpiParameter:
   \_parameter: (work@dut.q), line:2, parent:work@dut
-    |vpiName:q
-    |vpiFullName:work@dut.q
-    |INT:4
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/GenerateInterface/GenerateInterface.log
+++ b/tests/GenerateInterface/GenerateInterface.log
@@ -1001,11 +1001,6 @@ design: (work@top)
           |INT:0
     |vpiInstance:
     \_module: work@top (work@top) top.sv:16: 
-    |vpiParameter:
-    \_parameter: (work@top.intf.NO_Input), line:1, parent:work@top.intf
-      |vpiName:NO_Input
-      |vpiFullName:work@top.intf.NO_Input
-      |INT:3
 |uhdmtopModules:
 \_module: work@top2 (work@top2) top.sv:34: 
   |vpiDefName:work@top2
@@ -1189,11 +1184,24 @@ design: (work@top)
           |INT:0
     |vpiInstance:
     \_module: work@top2 (work@top2) top.sv:34: 
+    |vpiParamAssign:
+    \_param_assign: , line:22, parent:work@top2.intf
+      |vpiRhs:
+      \_constant: , line:22
+        |vpiConstType:7
+        |vpiDecompile:2
+        |vpiSize:64
+        |INT:2
+      |vpiLhs:
+      \_parameter: (work@top2.intf.Width), line:22, parent:work@top2.intf
+        |vpiName:Width
+        |vpiFullName:work@top2.intf.Width
+        |INT:2
+        |vpiTypespec:
+        \_int_typespec: (Width), line:22, parent:work@top2.intf.Width
+          |vpiName:Width
     |vpiParameter:
-    \_parameter: (work@top2.intf.Width), line:35, parent:work@top2.intf
-      |vpiName:Width
-      |vpiFullName:work@top2.intf.Width
-      |INT:2
+    \_parameter: (work@top2.intf.Width), line:22, parent:work@top2.intf
   |vpiGenScopeArray:
   \_gen_scope_array: (work@top2.each_pin[0]), line:38, parent:work@top2
     |vpiName:each_pin[0]
@@ -1306,14 +1314,12 @@ design: (work@top)
     \_parameter: (work@top2.Width), line:34, parent:work@top2
       |vpiName:Width
       |vpiFullName:work@top2.Width
+      |INT:2
       |vpiTypespec:
       \_int_typespec: (Width), line:34, parent:work@top2.Width
         |vpiName:Width
   |vpiParameter:
   \_parameter: (work@top2.Width), line:34, parent:work@top2
-    |vpiName:Width
-    |vpiFullName:work@top2.Width
-    |INT:2
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/GenerateModule/GenerateModule.log
+++ b/tests/GenerateModule/GenerateModule.log
@@ -1122,11 +1122,9 @@ design: (work@small_test)
     \_parameter: (work@small_test.SIZE), line:3, parent:work@small_test
       |vpiName:SIZE
       |vpiFullName:work@small_test.SIZE
+      |INT:5
   |vpiParameter:
   \_parameter: (work@small_test.SIZE), line:3, parent:work@small_test
-    |vpiName:SIZE
-    |vpiFullName:work@small_test.SIZE
-    |INT:5
 |uhdmtopModules:
 \_module: work@top (work@top) top.v:21: 
   |vpiDefName:work@top
@@ -1318,11 +1316,9 @@ design: (work@small_test)
     \_parameter: (work@top.toto), line:22, parent:work@top
       |vpiName:toto
       |vpiFullName:work@top.toto
+      |INT:1
   |vpiParameter:
   \_parameter: (work@top.toto), line:22, parent:work@top
-    |vpiName:toto
-    |vpiFullName:work@top.toto
-    |SCAL:1
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/GenerateUnnamed/GenerateUnnamed.log
+++ b/tests/GenerateUnnamed/GenerateUnnamed.log
@@ -1254,6 +1254,7 @@ design: (work@test1)
     \_parameter: (work@test1.p), line:2, parent:work@test1
       |vpiName:p
       |vpiFullName:work@test1.p
+      |INT:2
   |vpiParamAssign:
   \_param_assign: , line:2, parent:work@test1
     |vpiRhs:
@@ -1266,16 +1267,11 @@ design: (work@test1)
     \_parameter: (work@test1.q), line:2, parent:work@test1
       |vpiName:q
       |vpiFullName:work@test1.q
+      |INT:4
   |vpiParameter:
   \_parameter: (work@test1.p), line:2, parent:work@test1
-    |vpiName:p
-    |vpiFullName:work@test1.p
-    |INT:2
   |vpiParameter:
   \_parameter: (work@test1.q), line:2, parent:work@test1
-    |vpiName:q
-    |vpiFullName:work@test1.q
-    |INT:4
 |uhdmtopModules:
 \_module: work@test2 (work@test2) top.v:60: 
   |vpiDefName:work@test2
@@ -1379,6 +1375,7 @@ design: (work@test1)
     \_parameter: (work@test2.p), line:61, parent:work@test2
       |vpiName:p
       |vpiFullName:work@test2.p
+      |INT:2
   |vpiParamAssign:
   \_param_assign: , line:61, parent:work@test2
     |vpiRhs:
@@ -1391,16 +1388,11 @@ design: (work@test1)
     \_parameter: (work@test2.q), line:61, parent:work@test2
       |vpiName:q
       |vpiFullName:work@test2.q
+      |INT:4
   |vpiParameter:
   \_parameter: (work@test2.p), line:61, parent:work@test2
-    |vpiName:p
-    |vpiFullName:work@test2.p
-    |INT:2
   |vpiParameter:
   \_parameter: (work@test2.q), line:61, parent:work@test2
-    |vpiName:q
-    |vpiFullName:work@test2.q
-    |INT:4
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/IfGenTypeBinding/IfGenTypeBinding.log
+++ b/tests/IfGenTypeBinding/IfGenTypeBinding.log
@@ -641,6 +641,7 @@ design: (work@top)
     \_parameter: (work@top.PMPEnable), line:13, parent:work@top
       |vpiName:PMPEnable
       |vpiFullName:work@top.PMPEnable
+      |INT:1
       |vpiTypespec:
       \_bit_typespec: (PMPEnable), line:13, parent:work@top.PMPEnable
         |vpiName:PMPEnable
@@ -657,19 +658,14 @@ design: (work@top)
       |vpiName:PMPNumRegions
       |vpiFullName:work@top.PMPNumRegions
       |vpiLocalParam:1
+      |INT:2
       |vpiTypespec:
       \_int_typespec: (PMPNumRegions), line:15, parent:work@top.PMPNumRegions
         |vpiName:PMPNumRegions
   |vpiParameter:
   \_parameter: (work@top.PMPEnable), line:13, parent:work@top
-    |vpiName:PMPEnable
-    |vpiFullName:work@top.PMPEnable
-    |INT:1
   |vpiParameter:
   \_parameter: (work@top.PMPNumRegions), line:15, parent:work@top
-    |vpiName:PMPNumRegions
-    |vpiFullName:work@top.PMPNumRegions
-    |INT:2
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/IndexAssign/IndexAssign.log
+++ b/tests/IndexAssign/IndexAssign.log
@@ -103,7 +103,11 @@ design: (work@t)
           \_parameter: (work@t.I), line:2, parent:work@t
             |vpiName:I
             |vpiFullName:work@t.I
+            |vpiLocalParam:1
             |INT:9
+            |vpiTypespec:
+            \_int_typespec: (I), line:2, parent:work@t.I
+              |vpiName:I
         |vpiOperand:
         \_constant: , line:4
           |vpiConstType:7
@@ -139,12 +143,6 @@ design: (work@t)
       |INT:9
     |vpiLhs:
     \_parameter: (work@t.I), line:2, parent:work@t
-      |vpiName:I
-      |vpiFullName:work@t.I
-      |vpiLocalParam:1
-      |vpiTypespec:
-      \_int_typespec: (I), line:2, parent:work@t.I
-        |vpiName:I
   |vpiParameter:
   \_parameter: (work@t.I), line:2, parent:work@t
 ===================

--- a/tests/LocalParam/LocalParam.log
+++ b/tests/LocalParam/LocalParam.log
@@ -699,9 +699,10 @@ design: (work@top)
         |vpiSize:64
         |INT:0
       |vpiLhs:
-      \_parameter: (work@assigner.invert), line:6, parent:work@assigner
+      \_parameter: (work@top.asgn0.invert), line:6, parent:work@top.asgn0
         |vpiName:invert
-        |vpiFullName:work@assigner.invert
+        |vpiFullName:work@top.asgn0.invert
+        |INT:0
     |vpiParamAssign:
     \_param_assign: , line:7, parent:work@top.asgn0
       |vpiRhs:
@@ -711,23 +712,18 @@ design: (work@top)
         |vpiSize:64
         |INT:0
       |vpiLhs:
-      \_parameter: (work@assigner.do_invert), line:7, parent:work@assigner
+      \_parameter: (work@top.asgn0.do_invert), line:7, parent:work@top.asgn0
         |vpiName:do_invert
-        |vpiFullName:work@assigner.do_invert
+        |vpiFullName:work@top.asgn0.do_invert
         |vpiLocalParam:1
+        |INT:0
         |vpiTypespec:
-        \_int_typespec: (do_invert), line:7, parent:work@assigner.do_invert
+        \_int_typespec: (do_invert), line:7, parent:work@top.asgn0.do_invert
           |vpiName:do_invert
     |vpiParameter:
-    \_parameter: (work@top.asgn0.do_invert), line:7, parent:work@top.asgn0
-      |vpiName:do_invert
-      |vpiFullName:work@top.asgn0.do_invert
-      |INT:0
+    \_parameter: (work@top.asgn0.invert), line:6, parent:work@top.asgn0
     |vpiParameter:
-    \_parameter: (work@top.asgn0.invert), line:2, parent:work@top.asgn0
-      |vpiName:invert
-      |vpiFullName:work@top.asgn0.invert
-      |INT:0
+    \_parameter: (work@top.asgn0.do_invert), line:7, parent:work@top.asgn0
   |vpiModule:
   \_module: work@assigner (work@top.asgn1) dut.sv:3: , parent:work@top
     |vpiDefName:work@assigner
@@ -800,7 +796,10 @@ design: (work@top)
         |vpiSize:64
         |INT:1
       |vpiLhs:
-      \_parameter: (work@assigner.invert), line:6, parent:work@assigner
+      \_parameter: (work@top.asgn1.invert), line:6, parent:work@top.asgn1
+        |vpiName:invert
+        |vpiFullName:work@top.asgn1.invert
+        |INT:1
     |vpiParamAssign:
     \_param_assign: , line:7, parent:work@top.asgn1
       |vpiRhs:
@@ -810,17 +809,18 @@ design: (work@top)
         |vpiSize:64
         |INT:0
       |vpiLhs:
-      \_parameter: (work@assigner.do_invert), line:7, parent:work@assigner
+      \_parameter: (work@top.asgn1.do_invert), line:7, parent:work@top.asgn1
+        |vpiName:do_invert
+        |vpiFullName:work@top.asgn1.do_invert
+        |vpiLocalParam:1
+        |INT:0
+        |vpiTypespec:
+        \_int_typespec: (do_invert), line:7, parent:work@top.asgn1.do_invert
+          |vpiName:do_invert
+    |vpiParameter:
+    \_parameter: (work@top.asgn1.invert), line:6, parent:work@top.asgn1
     |vpiParameter:
     \_parameter: (work@top.asgn1.do_invert), line:7, parent:work@top.asgn1
-      |vpiName:do_invert
-      |vpiFullName:work@top.asgn1.do_invert
-      |INT:0
-    |vpiParameter:
-    \_parameter: (work@top.asgn1.invert), line:3, parent:work@top.asgn1
-      |vpiName:invert
-      |vpiFullName:work@top.asgn1.invert
-      |INT:1
   |vpiNet:
   \_logic_net: (work@top.i), line:1, parent:work@top
   |vpiNet:

--- a/tests/OneNetRange/OneNetRange.log
+++ b/tests/OneNetRange/OneNetRange.log
@@ -597,11 +597,21 @@ design: (work@TOP)
     \_logic_net: (work@TOP.conntb.con_o), line:8, parent:work@TOP.conntb
     |vpiInstance:
     \_module: work@TOP (work@TOP) tb.v:16: 
+    |vpiParamAssign:
+    \_param_assign: , line:8, parent:work@TOP.conntb
+      |vpiRhs:
+      \_constant: , line:8
+        |vpiConstType:7
+        |vpiDecompile:16
+        |vpiSize:64
+        |INT:16
+      |vpiLhs:
+      \_parameter: (work@TOP.conntb.width), line:8, parent:work@TOP.conntb
+        |vpiName:width
+        |vpiFullName:work@TOP.conntb.width
+        |INT:16
     |vpiParameter:
-    \_parameter: (work@TOP.conntb.width), line:20, parent:work@TOP.conntb
-      |vpiName:width
-      |vpiFullName:work@TOP.conntb.width
-      |INT:16
+    \_parameter: (work@TOP.conntb.width), line:8, parent:work@TOP.conntb
   |vpiModule:
   \_module: work@dut (work@TOP.dut1) tb.v:21: , parent:work@TOP
     |vpiDefName:work@dut
@@ -746,11 +756,21 @@ design: (work@TOP)
       \_logic_net: (work@TOP.dut1.conntb.con_o), line:8, parent:work@TOP.dut1.conntb
       |vpiInstance:
       \_module: work@dut (work@TOP.dut1) tb.v:21: , parent:work@TOP
+      |vpiParamAssign:
+      \_param_assign: , line:8, parent:work@TOP.dut1.conntb
+        |vpiRhs:
+        \_constant: , line:8
+          |vpiConstType:7
+          |vpiDecompile:16
+          |vpiSize:64
+          |INT:16
+        |vpiLhs:
+        \_parameter: (work@TOP.dut1.conntb.width), line:8, parent:work@TOP.dut1.conntb
+          |vpiName:width
+          |vpiFullName:work@TOP.dut1.conntb.width
+          |INT:16
       |vpiParameter:
-      \_parameter: (work@TOP.dut1.conntb.width), line:3, parent:work@TOP.dut1.conntb
-        |vpiName:width
-        |vpiFullName:work@TOP.dut1.conntb.width
-        |INT:16
+      \_parameter: (work@TOP.dut1.conntb.width), line:8, parent:work@TOP.dut1.conntb
     |vpiModule:
     \_module: work@middle (work@TOP.dut1.middle1) dut.v:4: , parent:work@TOP.dut1
       |vpiDefName:work@middle
@@ -861,14 +881,12 @@ design: (work@TOP)
             |vpiSize:64
             |INT:16
           |vpiLhs:
-          \_parameter: (work@SUB.width), line:15, parent:work@SUB
+          \_parameter: (work@TOP.dut1.middle1.sub1.width), line:15, parent:work@TOP.dut1.middle1.sub1
             |vpiName:width
-            |vpiFullName:work@SUB.width
+            |vpiFullName:work@TOP.dut1.middle1.sub1.width
+            |INT:16
         |vpiParameter:
-        \_parameter: (work@TOP.dut1.middle1.sub1.width), line:12, parent:work@TOP.dut1.middle1.sub1
-          |vpiName:width
-          |vpiFullName:work@TOP.dut1.middle1.sub1.width
-          |INT:16
+        \_parameter: (work@TOP.dut1.middle1.sub1.width), line:15, parent:work@TOP.dut1.middle1.sub1
       |vpiInstance:
       \_module: work@dut (work@TOP.dut1) tb.v:21: , parent:work@TOP
       |vpiParamAssign:
@@ -880,14 +898,12 @@ design: (work@TOP)
           |vpiSize:64
           |INT:16
         |vpiLhs:
-        \_parameter: (work@middle.width), line:11, parent:work@middle
+        \_parameter: (work@TOP.dut1.middle1.width), line:11, parent:work@TOP.dut1.middle1
           |vpiName:width
-          |vpiFullName:work@middle.width
+          |vpiFullName:work@TOP.dut1.middle1.width
+          |INT:16
       |vpiParameter:
-      \_parameter: (work@TOP.dut1.middle1.width), line:4, parent:work@TOP.dut1.middle1
-        |vpiName:width
-        |vpiFullName:work@TOP.dut1.middle1.width
-        |INT:16
+      \_parameter: (work@TOP.dut1.middle1.width), line:11, parent:work@TOP.dut1.middle1
     |vpiNet:
     \_logic_net: (work@TOP.dut1.i), line:2, parent:work@TOP.dut1
     |vpiNet:
@@ -903,14 +919,12 @@ design: (work@TOP)
         |vpiSize:64
         |INT:16
       |vpiLhs:
-      \_parameter: (work@dut.width), line:2, parent:work@dut
+      \_parameter: (work@TOP.dut1.width), line:2, parent:work@TOP.dut1
         |vpiName:width
-        |vpiFullName:work@dut.width
+        |vpiFullName:work@TOP.dut1.width
+        |INT:16
     |vpiParameter:
-    \_parameter: (work@TOP.dut1.width), line:21, parent:work@TOP.dut1
-      |vpiName:width
-      |vpiFullName:work@TOP.dut1.width
-      |INT:16
+    \_parameter: (work@TOP.dut1.width), line:2, parent:work@TOP.dut1
   |vpiNet:
   \_logic_net: (work@TOP.i), line:18, parent:work@TOP
   |vpiNet:
@@ -1006,11 +1020,9 @@ design: (work@TOP)
     \_parameter: (work@TOP.width), line:17, parent:work@TOP
       |vpiName:width
       |vpiFullName:work@TOP.width
+      |INT:16
   |vpiParameter:
   \_parameter: (work@TOP.width), line:17, parent:work@TOP
-    |vpiName:width
-    |vpiFullName:work@TOP.width
-    |INT:16
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/PackageParam/PackageParam.log
+++ b/tests/PackageParam/PackageParam.log
@@ -384,12 +384,11 @@ design: (unnamed)
       |vpiSize:32
       |INT:2
     |vpiLhs:
-    \_parameter: (otp_ctrl_pkg::NumSramKeyReqSlots), line:22, parent:otp_ctrl_pkg
+    \_parameter: (NumSramKeyReqSlots), line:22
       |vpiName:NumSramKeyReqSlots
-      |vpiFullName:otp_ctrl_pkg::NumSramKeyReqSlots
       |vpiImported:otp_ctrl_reg_pkg
       |vpiTypespec:
-      \_int_typespec: (NumSramKeyReqSlots), line:22, parent:otp_ctrl_pkg::NumSramKeyReqSlots
+      \_int_typespec: (NumSramKeyReqSlots), line:22, parent:NumSramKeyReqSlots
         |vpiName:NumSramKeyReqSlots
   |vpiParamAssign:
   \_param_assign: , line:23, parent:otp_ctrl_pkg
@@ -400,12 +399,11 @@ design: (unnamed)
       |vpiSize:32
       |INT:11
     |vpiLhs:
-    \_parameter: (otp_ctrl_pkg::OtpByteAddrWidth), line:23, parent:otp_ctrl_pkg
+    \_parameter: (OtpByteAddrWidth), line:23
       |vpiName:OtpByteAddrWidth
-      |vpiFullName:otp_ctrl_pkg::OtpByteAddrWidth
       |vpiImported:otp_ctrl_reg_pkg
       |vpiTypespec:
-      \_int_typespec: (OtpByteAddrWidth), line:23, parent:otp_ctrl_pkg::OtpByteAddrWidth
+      \_int_typespec: (OtpByteAddrWidth), line:23, parent:OtpByteAddrWidth
         |vpiName:OtpByteAddrWidth
   |vpiParamAssign:
   \_param_assign: , line:24, parent:otp_ctrl_pkg
@@ -416,12 +414,11 @@ design: (unnamed)
       |vpiSize:32
       |INT:9
     |vpiLhs:
-    \_parameter: (otp_ctrl_pkg::NumErrorEntries), line:24, parent:otp_ctrl_pkg
+    \_parameter: (NumErrorEntries), line:24
       |vpiName:NumErrorEntries
-      |vpiFullName:otp_ctrl_pkg::NumErrorEntries
       |vpiImported:otp_ctrl_reg_pkg
       |vpiTypespec:
-      \_int_typespec: (NumErrorEntries), line:24, parent:otp_ctrl_pkg::NumErrorEntries
+      \_int_typespec: (NumErrorEntries), line:24, parent:NumErrorEntries
         |vpiName:NumErrorEntries
   |vpiParamAssign:
   \_param_assign: , line:34, parent:otp_ctrl_pkg
@@ -452,11 +449,29 @@ design: (unnamed)
       \_int_typespec: (OtpAddrWidth), line:35, parent:otp_ctrl_pkg::OtpAddrWidth
         |vpiName:OtpAddrWidth
   |vpiParameter:
+  \_parameter: (otp_ctrl_pkg::NumErrorEntries), line:24, parent:otp_ctrl_pkg
+    |vpiName:NumErrorEntries
+    |vpiFullName:otp_ctrl_pkg::NumErrorEntries
+    |vpiImported:otp_ctrl_reg_pkg
+    |vpiTypespec:
+    \_int_typespec: (NumErrorEntries), line:24, parent:otp_ctrl_pkg::NumErrorEntries
+      |vpiName:NumErrorEntries
+  |vpiParameter:
   \_parameter: (otp_ctrl_pkg::NumSramKeyReqSlots), line:22, parent:otp_ctrl_pkg
+    |vpiName:NumSramKeyReqSlots
+    |vpiFullName:otp_ctrl_pkg::NumSramKeyReqSlots
+    |vpiImported:otp_ctrl_reg_pkg
+    |vpiTypespec:
+    \_int_typespec: (NumSramKeyReqSlots), line:22, parent:otp_ctrl_pkg::NumSramKeyReqSlots
+      |vpiName:NumSramKeyReqSlots
   |vpiParameter:
   \_parameter: (otp_ctrl_pkg::OtpByteAddrWidth), line:23, parent:otp_ctrl_pkg
-  |vpiParameter:
-  \_parameter: (otp_ctrl_pkg::NumErrorEntries), line:24, parent:otp_ctrl_pkg
+    |vpiName:OtpByteAddrWidth
+    |vpiFullName:otp_ctrl_pkg::OtpByteAddrWidth
+    |vpiImported:otp_ctrl_reg_pkg
+    |vpiTypespec:
+    \_int_typespec: (OtpByteAddrWidth), line:23, parent:otp_ctrl_pkg::OtpByteAddrWidth
+      |vpiName:OtpByteAddrWidth
   |vpiParameter:
   \_parameter: (otp_ctrl_pkg::OtpWidth), line:34, parent:otp_ctrl_pkg
   |vpiParameter:

--- a/tests/PackageValue/PackageValue.log
+++ b/tests/PackageValue/PackageValue.log
@@ -1432,24 +1432,22 @@ design: (work@prim_diff_decode)
     \_parameter: (work@prim_diff_decode.Impl), line:12, parent:work@prim_diff_decode
       |vpiName:Impl
       |vpiFullName:work@prim_diff_decode.Impl
+      |INT:1
       |vpiTypespec:
       \_enum_typespec: (impl_e), line:7, parent:work@prim_diff_decode.Impl
         |vpiName:impl_e
         |vpiBaseTypespec:
-        \_int_typespec: , line:4
+        \_int_typespec: , line:4, parent:impl_e
         |vpiEnumConst:
-        \_enum_const: (ImplGeneric), line:5
+        \_enum_const: (ImplGeneric), line:5, parent:impl_e
           |vpiName:ImplGeneric
           |INT:1
         |vpiEnumConst:
-        \_enum_const: (ImplXilinx), line:6
+        \_enum_const: (ImplXilinx), line:6, parent:impl_e
           |vpiName:ImplXilinx
           |INT:0
   |vpiParameter:
   \_parameter: (work@prim_diff_decode.Impl), line:12, parent:work@prim_diff_decode
-    |vpiName:Impl
-    |vpiFullName:work@prim_diff_decode.Impl
-    |INT:1
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/ParamComplex/ParamComplex.log
+++ b/tests/ParamComplex/ParamComplex.log
@@ -596,17 +596,17 @@ design: (work@top)
         |vpiPacked:1
         |vpiName:complex_t
         |vpiTypespecMember:
-        \_typespec_member: (a), line:3
+        \_typespec_member: (a), line:3, parent:complex_t
           |vpiName:a
           |vpiTypespec:
-          \_logic_typespec: , line:3
+          \_logic_typespec: , line:3, parent:a
         |vpiTypespecMember:
-        \_typespec_member: (b), line:4
+        \_typespec_member: (b), line:4, parent:complex_t
           |vpiName:b
           |vpiTypespec:
-          \_logic_typespec: , line:4
+          \_logic_typespec: , line:4, parent:b
             |vpiRange:
-            \_range: , line:4, parent:complex_t
+            \_range: , line:4
               |vpiLeftRange:
               \_constant: , line:4
                 |vpiConstType:7
@@ -621,6 +621,37 @@ design: (work@top)
                 |INT:0
   |vpiParameter:
   \_parameter: (work@top.init_val), line:10, parent:work@top
+    |vpiName:init_val
+    |vpiFullName:work@top.init_val
+    |vpiLocalParam:1
+    |vpiTypespec:
+    \_struct_typespec: (complex_t), line:2, parent:work@top.init_val
+      |vpiPacked:1
+      |vpiName:complex_t
+      |vpiTypespecMember:
+      \_typespec_member: (a), line:3
+        |vpiName:a
+        |vpiTypespec:
+        \_logic_typespec: , line:3
+      |vpiTypespecMember:
+      \_typespec_member: (b), line:4
+        |vpiName:b
+        |vpiTypespec:
+        \_logic_typespec: , line:4
+          |vpiRange:
+          \_range: , line:4, parent:complex_t
+            |vpiLeftRange:
+            \_constant: , line:4
+              |vpiConstType:7
+              |vpiDecompile:2
+              |vpiSize:32
+              |INT:2
+            |vpiRightRange:
+            \_constant: , line:4
+              |vpiConstType:7
+              |vpiDecompile:0
+              |vpiSize:32
+              |INT:0
 |uhdmtopModules:
 \_module: work@top (work@top) dut.sv:9: 
   |vpiDefName:work@top
@@ -639,11 +670,12 @@ design: (work@top)
         |vpiDecompile:4
         |INT:4
       |vpiLhs:
-      \_parameter: (work@dut.size), line:18, parent:work@dut
+      \_parameter: (work@top.asgn0.size), line:18, parent:work@top.asgn0
         |vpiName:size
-        |vpiFullName:work@dut.size
+        |vpiFullName:work@top.asgn0.size
+        |INT:4
         |vpiTypespec:
-        \_int_typespec: (size), line:18, parent:work@dut.size
+        \_int_typespec: (size), line:18, parent:work@top.asgn0.size
           |vpiName:size
     |vpiParamAssign:
     \_param_assign: , line:19, parent:work@top.asgn0
@@ -675,20 +707,21 @@ design: (work@top)
               |vpiDecompile:'b1
               |BIN:1
       |vpiLhs:
-      \_parameter: (work@dut.init), line:19, parent:work@dut
+      \_parameter: (work@top.asgn0.init), line:19, parent:work@top.asgn0
         |vpiName:init
-        |vpiFullName:work@dut.init
+        |vpiFullName:work@top.asgn0.init
         |vpiTypespec:
-        \_bit_typespec: (init), line:19, parent:work@dut.init
+        \_bit_typespec: (init), line:19, parent:work@top.asgn0.init
           |vpiName:init
           |vpiRange:
-          \_range: , line:19
+          \_range: , line:19, parent:init
             |vpiLeftRange:
             \_operation: , line:19
               |vpiOpType:11
               |vpiOperand:
-              \_ref_obj: (size), line:19
+              \_ref_obj: (work@top.asgn0.init.init.size), line:19
                 |vpiName:size
+                |vpiFullName:work@top.asgn0.init.init.size
               |vpiOperand:
               \_constant: , line:19
                 |vpiConstType:7
@@ -702,13 +735,9 @@ design: (work@top)
               |vpiSize:32
               |INT:0
     |vpiParameter:
-    \_parameter: (work@top.asgn0.init), line:13, parent:work@top.asgn0
-      |vpiName:init
-      |vpiFullName:work@top.asgn0.init
+    \_parameter: (work@top.asgn0.size), line:18, parent:work@top.asgn0
     |vpiParameter:
-    \_parameter: (work@top.asgn0.size), line:12, parent:work@top.asgn0
-      |vpiName:size
-      |vpiFullName:work@top.asgn0.size
+    \_parameter: (work@top.asgn0.init), line:19, parent:work@top.asgn0
   |vpiParamAssign:
   \_param_assign: , line:10, parent:work@top
     |vpiRhs:
@@ -745,17 +774,17 @@ design: (work@top)
         |vpiPacked:1
         |vpiName:complex_t
         |vpiTypespecMember:
-        \_typespec_member: (a), line:3
+        \_typespec_member: (a), line:3, parent:complex_t
           |vpiName:a
           |vpiTypespec:
-          \_logic_typespec: , line:3
+          \_logic_typespec: , line:3, parent:a
         |vpiTypespecMember:
-        \_typespec_member: (b), line:4
+        \_typespec_member: (b), line:4, parent:complex_t
           |vpiName:b
           |vpiTypespec:
-          \_logic_typespec: , line:4
+          \_logic_typespec: , line:4, parent:b
             |vpiRange:
-            \_range: , line:4, parent:complex_t
+            \_range: , line:4
               |vpiLeftRange:
               \_constant: , line:4
                 |vpiConstType:7
@@ -770,8 +799,6 @@ design: (work@top)
                 |INT:0
   |vpiParameter:
   \_parameter: (work@top.init_val), line:10, parent:work@top
-    |vpiName:init_val
-    |vpiFullName:work@top.init_val
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/ParamConcat/ParamConcat.log
+++ b/tests/ParamConcat/ParamConcat.log
@@ -500,8 +500,25 @@ design: (work@top)
       |vpiLocalParam:1
       |vpiTypespec:
       \_struct_typespec: (status_t), line:9, parent:work@top.MSTATUS_RST_VAL
+        |vpiPacked:1
+        |vpiName:status_t
+        |vpiTypespecMember:
+        \_typespec_member: (mie), line:10, parent:status_t
+          |vpiName:mie
+          |vpiTypespec:
+          \_logic_typespec: , line:10, parent:mie
+        |vpiTypespecMember:
+        \_typespec_member: (mpie), line:11, parent:status_t
+          |vpiName:mpie
+          |vpiTypespec:
+          \_logic_typespec: , line:11, parent:mpie
   |vpiParameter:
   \_parameter: (work@top.MSTATUS_RST_VAL), line:14, parent:work@top
+    |vpiName:MSTATUS_RST_VAL
+    |vpiFullName:work@top.MSTATUS_RST_VAL
+    |vpiLocalParam:1
+    |vpiTypespec:
+    \_struct_typespec: (status_t), line:9, parent:work@top.MSTATUS_RST_VAL
 |uhdmtopModules:
 \_module: work@top (work@top) dut.sv:6: 
   |vpiDefName:work@top
@@ -544,14 +561,14 @@ design: (work@top)
               |vpiSize:1
               |BIN:0
       |vpiLhs:
-      \_parameter: (work@ibex_csr.ResetValue), line:2, parent:work@ibex_csr
+      \_parameter: (work@top.u_mstatus_csr.ResetValue), line:2, parent:work@top.u_mstatus_csr
         |vpiName:ResetValue
-        |vpiFullName:work@ibex_csr.ResetValue
+        |vpiFullName:work@top.u_mstatus_csr.ResetValue
         |vpiTypespec:
-        \_bit_typespec: (ResetValue), line:2, parent:work@ibex_csr.ResetValue
+        \_bit_typespec: (ResetValue), line:2, parent:work@top.u_mstatus_csr.ResetValue
           |vpiName:ResetValue
           |vpiRange:
-          \_range: , line:2
+          \_range: , line:2, parent:ResetValue
             |vpiLeftRange:
             \_constant: , line:2
               |vpiConstType:7
@@ -565,9 +582,7 @@ design: (work@top)
               |vpiSize:32
               |INT:0
     |vpiParameter:
-    \_parameter: (work@top.u_mstatus_csr.ResetValue), line:17, parent:work@top.u_mstatus_csr
-      |vpiName:ResetValue
-      |vpiFullName:work@top.u_mstatus_csr.ResetValue
+    \_parameter: (work@top.u_mstatus_csr.ResetValue), line:2, parent:work@top.u_mstatus_csr
   |vpiTypedef:
   \_struct_typespec: (status_t), line:9, parent:work@top
     |vpiPacked:1
@@ -619,19 +634,17 @@ design: (work@top)
         |vpiPacked:1
         |vpiName:status_t
         |vpiTypespecMember:
-        \_typespec_member: (mie), line:10
+        \_typespec_member: (mie), line:10, parent:status_t
           |vpiName:mie
           |vpiTypespec:
-          \_logic_typespec: , line:10
+          \_logic_typespec: , line:10, parent:mie
         |vpiTypespecMember:
-        \_typespec_member: (mpie), line:11
+        \_typespec_member: (mpie), line:11, parent:status_t
           |vpiName:mpie
           |vpiTypespec:
-          \_logic_typespec: , line:11
+          \_logic_typespec: , line:11, parent:mpie
   |vpiParameter:
   \_parameter: (work@top.MSTATUS_RST_VAL), line:14, parent:work@top
-    |vpiName:MSTATUS_RST_VAL
-    |vpiFullName:work@top.MSTATUS_RST_VAL
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/ParamElab/ParamElab.log
+++ b/tests/ParamElab/ParamElab.log
@@ -494,10 +494,13 @@ design: (work@dut)
       \_ref_obj: (DataBitsPerMask), line:12
         |vpiName:DataBitsPerMask
         |vpiActual:
-        \_parameter: (work@dut.t.DataBitsPerMask), line:4, parent:work@dut.t
+        \_parameter: (work@dut.t.DataBitsPerMask), line:10, parent:work@dut.t
           |vpiName:DataBitsPerMask
           |vpiFullName:work@dut.t.DataBitsPerMask
           |INT:8
+          |vpiTypespec:
+          \_int_typespec: (DataBitsPerMask), line:10, parent:work@dut.t.DataBitsPerMask
+            |vpiName:DataBitsPerMask
     |vpiLhs:
     \_parameter: (work@test.MaskWidth), line:12, parent:work@test
       |vpiName:MaskWidth
@@ -600,11 +603,12 @@ design: (work@dut)
         |vpiSize:64
         |INT:32
       |vpiLhs:
-      \_parameter: (work@test.Width), line:9, parent:work@test
+      \_parameter: (work@dut.t.Width), line:9, parent:work@dut.t
         |vpiName:Width
-        |vpiFullName:work@test.Width
+        |vpiFullName:work@dut.t.Width
+        |INT:32
         |vpiTypespec:
-        \_int_typespec: (Width), line:9, parent:work@test.Width
+        \_int_typespec: (Width), line:9, parent:work@dut.t.Width
           |vpiName:Width
     |vpiParamAssign:
     \_param_assign: , line:10, parent:work@dut.t
@@ -615,11 +619,12 @@ design: (work@dut)
         |vpiSize:64
         |INT:8
       |vpiLhs:
-      \_parameter: (work@test.DataBitsPerMask), line:10, parent:work@test
+      \_parameter: (work@dut.t.DataBitsPerMask), line:10, parent:work@dut.t
         |vpiName:DataBitsPerMask
-        |vpiFullName:work@test.DataBitsPerMask
+        |vpiFullName:work@dut.t.DataBitsPerMask
+        |INT:8
         |vpiTypespec:
-        \_int_typespec: (DataBitsPerMask), line:10, parent:work@test.DataBitsPerMask
+        \_int_typespec: (DataBitsPerMask), line:10, parent:work@dut.t.DataBitsPerMask
           |vpiName:DataBitsPerMask
     |vpiParamAssign:
     \_param_assign: , line:12, parent:work@dut.t
@@ -630,28 +635,20 @@ design: (work@dut)
         |vpiSize:64
         |INT:4
       |vpiLhs:
-      \_parameter: (work@test.MaskWidth), line:12, parent:work@test
+      \_parameter: (work@dut.t.MaskWidth), line:12, parent:work@dut.t
         |vpiName:MaskWidth
-        |vpiFullName:work@test.MaskWidth
+        |vpiFullName:work@dut.t.MaskWidth
         |vpiLocalParam:1
+        |INT:4
         |vpiTypespec:
-        \_int_typespec: (MaskWidth), line:12, parent:work@test.MaskWidth
+        \_int_typespec: (MaskWidth), line:12, parent:work@dut.t.MaskWidth
           |vpiName:MaskWidth
     |vpiParameter:
-    \_parameter: (work@dut.t.DataBitsPerMask), line:4, parent:work@dut.t
-      |vpiName:DataBitsPerMask
-      |vpiFullName:work@dut.t.DataBitsPerMask
-      |INT:8
+    \_parameter: (work@dut.t.Width), line:9, parent:work@dut.t
+    |vpiParameter:
+    \_parameter: (work@dut.t.DataBitsPerMask), line:10, parent:work@dut.t
     |vpiParameter:
     \_parameter: (work@dut.t.MaskWidth), line:12, parent:work@dut.t
-      |vpiName:MaskWidth
-      |vpiFullName:work@dut.t.MaskWidth
-      |INT:4
-    |vpiParameter:
-    \_parameter: (work@dut.t.Width), line:3, parent:work@dut.t
-      |vpiName:Width
-      |vpiFullName:work@dut.t.Width
-      |INT:32
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/ParamFile/ParamFile.log
+++ b/tests/ParamFile/ParamFile.log
@@ -414,14 +414,12 @@ design: (work@dut)
         |vpiConstType:7
         |STRING:
       |vpiLhs:
-      \_parameter: (work@ram_1p.MemInitFile), line:13, parent:work@ram_1p
+      \_parameter: (work@dut.u_ram.MemInitFile), line:13, parent:work@dut.u_ram
         |vpiName:MemInitFile
-        |vpiFullName:work@ram_1p.MemInitFile
+        |vpiFullName:work@dut.u_ram.MemInitFile
+        |STRING:
     |vpiParameter:
-    \_parameter: (work@dut.u_ram.MemInitFile), line:6, parent:work@dut.u_ram
-      |vpiName:MemInitFile
-      |vpiFullName:work@dut.u_ram.MemInitFile
-      |STRING:
+    \_parameter: (work@dut.u_ram.MemInitFile), line:13, parent:work@dut.u_ram
   |vpiNet:
   \_logic_net: (work@dut.o), line:3, parent:work@dut
   |vpiParamAssign:
@@ -434,11 +432,9 @@ design: (work@dut)
     \_parameter: (work@dut.SRAMInitFile), line:4, parent:work@dut
       |vpiName:SRAMInitFile
       |vpiFullName:work@dut.SRAMInitFile
+      |STRING:
   |vpiParameter:
   \_parameter: (work@dut.SRAMInitFile), line:4, parent:work@dut
-    |vpiName:SRAMInitFile
-    |vpiFullName:work@dut.SRAMInitFile
-    |STRING:
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/ParamFile/ParamFileOverr.log
+++ b/tests/ParamFile/ParamFileOverr.log
@@ -416,14 +416,12 @@ design: (work@dut)
         |vpiSize:5
         |STRING:/blah
       |vpiLhs:
-      \_parameter: (work@ram_1p.MemInitFile), line:13, parent:work@ram_1p
+      \_parameter: (work@dut.u_ram.MemInitFile), line:13, parent:work@dut.u_ram
         |vpiName:MemInitFile
-        |vpiFullName:work@ram_1p.MemInitFile
+        |vpiFullName:work@dut.u_ram.MemInitFile
+        |STRING:/blah
     |vpiParameter:
-    \_parameter: (work@dut.u_ram.MemInitFile), line:6, parent:work@dut.u_ram
-      |vpiName:MemInitFile
-      |vpiFullName:work@dut.u_ram.MemInitFile
-      |STRING:/blah
+    \_parameter: (work@dut.u_ram.MemInitFile), line:13, parent:work@dut.u_ram
   |vpiNet:
   \_logic_net: (work@dut.o), line:3, parent:work@dut
   |vpiParamAssign:
@@ -438,11 +436,9 @@ design: (work@dut)
     \_parameter: (work@dut.SRAMInitFile), line:4, parent:work@dut
       |vpiName:SRAMInitFile
       |vpiFullName:work@dut.SRAMInitFile
+      |STRING:/blah
   |vpiParameter:
-  \_parameter: (work@dut.SRAMInitFile), parent:work@dut
-    |vpiName:SRAMInitFile
-    |vpiFullName:work@dut.SRAMInitFile
-    |STRING:/blah
+  \_parameter: (work@dut.SRAMInitFile), line:4, parent:work@dut
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/PortPackage/PortPackage.log
+++ b/tests/PortPackage/PortPackage.log
@@ -150,14 +150,12 @@ design: (work@dm_top)
     \_parameter: (work@dm_top.NrHarts), line:11, parent:work@dm_top
       |vpiName:NrHarts
       |vpiFullName:work@dm_top.NrHarts
+      |INT:1
       |vpiTypespec:
       \_int_typespec: (NrHarts), line:11, parent:work@dm_top.NrHarts
         |vpiName:NrHarts
   |vpiParameter:
   \_parameter: (work@dm_top.NrHarts), line:11, parent:work@dm_top
-    |vpiName:NrHarts
-    |vpiFullName:work@dm_top.NrHarts
-    |INT:1
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/PreprocFunc/PreprocFunc.log
+++ b/tests/PreprocFunc/PreprocFunc.log
@@ -958,6 +958,8 @@ design: (work@asym_ram)
         \_parameter: (work@asym_ram.minWIDTH), line:35, parent:work@asym_ram
           |vpiName:minWIDTH
           |vpiFullName:work@asym_ram.minWIDTH
+          |vpiLocalParam:1
+          |INT:0
     |vpiLhs:
     \_parameter: (work@asym_ram.RATIO), line:39, parent:work@asym_ram
       |vpiName:RATIO
@@ -1234,6 +1236,7 @@ design: (work@asym_ram)
     \_parameter: (work@asym_ram.WIDTHB), line:6, parent:work@asym_ram
       |vpiName:WIDTHB
       |vpiFullName:work@asym_ram.WIDTHB
+      |INT:4
   |vpiParamAssign:
   \_param_assign: , line:7, parent:work@asym_ram
     |vpiRhs:
@@ -1246,6 +1249,7 @@ design: (work@asym_ram)
     \_parameter: (work@asym_ram.WIDTHA), line:7, parent:work@asym_ram
       |vpiName:WIDTHA
       |vpiFullName:work@asym_ram.WIDTHA
+      |INT:4
   |vpiParamAssign:
   \_param_assign: , line:30, parent:work@asym_ram
     |vpiRhs:
@@ -1257,6 +1261,7 @@ design: (work@asym_ram)
       |vpiName:maxWIDTH
       |vpiFullName:work@asym_ram.maxWIDTH
       |vpiLocalParam:1
+      |INT:0
   |vpiParamAssign:
   \_param_assign: , line:35, parent:work@asym_ram
     |vpiRhs:
@@ -1268,6 +1273,7 @@ design: (work@asym_ram)
       |vpiName:minWIDTH
       |vpiFullName:work@asym_ram.minWIDTH
       |vpiLocalParam:1
+      |INT:0
   |vpiParamAssign:
   \_param_assign: , line:39, parent:work@asym_ram
     |vpiRhs:
@@ -1297,31 +1303,17 @@ design: (work@asym_ram)
       |vpiFullName:work@asym_ram.log2RATIO
       |vpiLocalParam:1
   |vpiParameter:
-  \_parameter: (work@asym_ram.RATIO), line:39, parent:work@asym_ram
-    |vpiName:RATIO
-    |vpiFullName:work@asym_ram.RATIO
+  \_parameter: (work@asym_ram.WIDTHB), line:6, parent:work@asym_ram
   |vpiParameter:
   \_parameter: (work@asym_ram.WIDTHA), line:7, parent:work@asym_ram
-    |vpiName:WIDTHA
-    |vpiFullName:work@asym_ram.WIDTHA
-    |INT:4
-  |vpiParameter:
-  \_parameter: (work@asym_ram.WIDTHB), line:6, parent:work@asym_ram
-    |vpiName:WIDTHB
-    |vpiFullName:work@asym_ram.WIDTHB
-    |INT:4
-  |vpiParameter:
-  \_parameter: (work@asym_ram.log2RATIO), line:42, parent:work@asym_ram
-    |vpiName:log2RATIO
-    |vpiFullName:work@asym_ram.log2RATIO
   |vpiParameter:
   \_parameter: (work@asym_ram.maxWIDTH), line:30, parent:work@asym_ram
-    |vpiName:maxWIDTH
-    |vpiFullName:work@asym_ram.maxWIDTH
   |vpiParameter:
   \_parameter: (work@asym_ram.minWIDTH), line:35, parent:work@asym_ram
-    |vpiName:minWIDTH
-    |vpiFullName:work@asym_ram.minWIDTH
+  |vpiParameter:
+  \_parameter: (work@asym_ram.RATIO), line:39, parent:work@asym_ram
+  |vpiParameter:
+  \_parameter: (work@asym_ram.log2RATIO), line:42, parent:work@asym_ram
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/Rom/Rom.log
+++ b/tests/Rom/Rom.log
@@ -540,6 +540,53 @@ design: (work@top)
         |vpiName:RhoOffset
   |vpiParameter:
   \_parameter: (work@top.RhoOffset), line:13, parent:work@top
+    |vpiName:RhoOffset
+    |vpiFullName:work@top.RhoOffset
+    |vpiLocalParam:1
+    |vpiSize:1
+    |vpiRange:
+    \_range: , line:13, parent:work@top.RhoOffset
+      |vpiLeftRange:
+      \_constant: , line:13
+        |vpiConstType:7
+        |vpiDecompile:0
+        |vpiSize:1
+        |INT:0
+      |vpiRightRange:
+      \_operation: 
+        |vpiOpType:11
+        |vpiOperand:
+        \_constant: , line:13
+          |vpiConstType:7
+          |vpiDecompile:5
+          |vpiSize:32
+          |INT:5
+        |vpiOperand:
+        \_constant: 
+          |INT:1
+    |vpiRange:
+    \_range: , line:13, parent:work@top.RhoOffset
+      |vpiLeftRange:
+      \_constant: , line:13
+        |vpiConstType:7
+        |vpiDecompile:0
+        |vpiSize:1
+        |INT:0
+      |vpiRightRange:
+      \_operation: 
+        |vpiOpType:11
+        |vpiOperand:
+        \_constant: , line:13
+          |vpiConstType:7
+          |vpiDecompile:5
+          |vpiSize:32
+          |INT:5
+        |vpiOperand:
+        \_constant: 
+          |INT:1
+    |vpiTypespec:
+    \_int_typespec: (RhoOffset), line:13, parent:work@top.RhoOffset
+      |vpiName:RhoOffset
 |uhdmtopModules:
 \_module: work@top (work@top) dut.sv:1: 
   |vpiDefName:work@top
@@ -746,9 +793,6 @@ design: (work@top)
         |vpiName:RhoOffset
   |vpiParameter:
   \_parameter: (work@top.RhoOffset), line:13, parent:work@top
-    |vpiName:RhoOffset
-    |vpiFullName:work@top.RhoOffset
-    |INT:5
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/SignedParam/SignedParam.log
+++ b/tests/SignedParam/SignedParam.log
@@ -348,14 +348,12 @@ design: (work@prim_pad_wrapper)
       |vpiName:AttrDw
       |vpiFullName:work@prim_pad_wrapper.AttrDw
       |vpiSigned:1
+      |INT:6
       |vpiTypespec:
       \_int_typespec: (AttrDw), line:6, parent:work@prim_pad_wrapper.AttrDw
         |vpiName:AttrDw
   |vpiParameter:
   \_parameter: (work@prim_pad_wrapper.AttrDw), line:6, parent:work@prim_pad_wrapper
-    |vpiName:AttrDw
-    |vpiFullName:work@prim_pad_wrapper.AttrDw
-    |INT:6
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/StringParameter/StringParameter.log
+++ b/tests/StringParameter/StringParameter.log
@@ -84,9 +84,10 @@ design: (work@top)
         |vpiSize:13
         |STRING:TOPFIRSTVALUE
       |vpiLhs:
-      \_parameter: (work@parameter_module.FIRSTPARAMETER), line:9, parent:work@parameter_module
+      \_parameter: (work@top.test_module.FIRSTPARAMETER), line:9, parent:work@top.test_module
         |vpiName:FIRSTPARAMETER
-        |vpiFullName:work@parameter_module.FIRSTPARAMETER
+        |vpiFullName:work@top.test_module.FIRSTPARAMETER
+        |STRING:TOPFIRSTVALUE
     |vpiParamAssign:
     \_param_assign: , line:10, parent:work@top.test_module
       |vpiRhs:
@@ -96,19 +97,14 @@ design: (work@top)
         |vpiSize:14
         |STRING:TOPSECONDVALUE
       |vpiLhs:
-      \_parameter: (work@parameter_module.SECONDPARAMETER), line:10, parent:work@parameter_module
+      \_parameter: (work@top.test_module.SECONDPARAMETER), line:10, parent:work@top.test_module
         |vpiName:SECONDPARAMETER
-        |vpiFullName:work@parameter_module.SECONDPARAMETER
+        |vpiFullName:work@top.test_module.SECONDPARAMETER
+        |STRING:TOPSECONDVALUE
     |vpiParameter:
-    \_parameter: (work@top.test_module.FIRSTPARAMETER), line:3, parent:work@top.test_module
-      |vpiName:FIRSTPARAMETER
-      |vpiFullName:work@top.test_module.FIRSTPARAMETER
-      |STRING:TOPFIRSTVALUE
+    \_parameter: (work@top.test_module.FIRSTPARAMETER), line:9, parent:work@top.test_module
     |vpiParameter:
-    \_parameter: (work@top.test_module.SECONDPARAMETER), line:4, parent:work@top.test_module
-      |vpiName:SECONDPARAMETER
-      |vpiFullName:work@top.test_module.SECONDPARAMETER
-      |STRING:TOPSECONDVALUE
+    \_parameter: (work@top.test_module.SECONDPARAMETER), line:10, parent:work@top.test_module
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/StructVarImp/StructVarImp.log
+++ b/tests/StructVarImp/StructVarImp.log
@@ -742,12 +742,11 @@ design: (work@top)
       |vpiSize:32
       |INT:2
     |vpiLhs:
-    \_parameter: (work@top.NBanks), line:4, parent:work@top
+    \_parameter: (NBanks), line:4
       |vpiName:NBanks
-      |vpiFullName:work@top.NBanks
       |vpiImported:flash_ctrl_reg_pkg
       |vpiTypespec:
-      \_int_typespec: (NBanks), line:4, parent:work@top.NBanks
+      \_int_typespec: (NBanks), line:4, parent:NBanks
         |vpiName:NBanks
   |vpiParamAssign:
   \_param_assign: , line:5, parent:work@top
@@ -758,17 +757,28 @@ design: (work@top)
       |vpiSize:32
       |INT:8
     |vpiLhs:
-    \_parameter: (work@top.NumRegions), line:5, parent:work@top
+    \_parameter: (NumRegions), line:5
       |vpiName:NumRegions
-      |vpiFullName:work@top.NumRegions
       |vpiImported:flash_ctrl_reg_pkg
       |vpiTypespec:
-      \_int_typespec: (NumRegions), line:5, parent:work@top.NumRegions
+      \_int_typespec: (NumRegions), line:5, parent:NumRegions
         |vpiName:NumRegions
   |vpiParameter:
   \_parameter: (work@top.NBanks), line:4, parent:work@top
+    |vpiName:NBanks
+    |vpiFullName:work@top.NBanks
+    |vpiImported:flash_ctrl_reg_pkg
+    |vpiTypespec:
+    \_int_typespec: (NBanks), line:4, parent:work@top.NBanks
+      |vpiName:NBanks
   |vpiParameter:
   \_parameter: (work@top.NumRegions), line:5, parent:work@top
+    |vpiName:NumRegions
+    |vpiFullName:work@top.NumRegions
+    |vpiImported:flash_ctrl_reg_pkg
+    |vpiTypespec:
+    \_int_typespec: (NumRegions), line:5, parent:work@top.NumRegions
+      |vpiName:NumRegions
 |uhdmtopModules:
 \_module: work@top (work@top) dut.sv:33: 
   |vpiDefName:work@top
@@ -1001,6 +1011,7 @@ design: (work@top)
       |vpiName:NBanks
       |vpiFullName:work@top.NBanks
       |vpiImported:flash_ctrl_reg_pkg
+      |INT:2
       |vpiTypespec:
       \_int_typespec: (NBanks), line:4, parent:work@top.NBanks
         |vpiName:NBanks
@@ -1017,19 +1028,14 @@ design: (work@top)
       |vpiName:NumRegions
       |vpiFullName:work@top.NumRegions
       |vpiImported:flash_ctrl_reg_pkg
+      |INT:8
       |vpiTypespec:
       \_int_typespec: (NumRegions), line:5, parent:work@top.NumRegions
         |vpiName:NumRegions
   |vpiParameter:
   \_parameter: (work@top.NBanks), line:4, parent:work@top
-    |vpiName:NBanks
-    |vpiFullName:work@top.NBanks
-    |INT:2
   |vpiParameter:
   \_parameter: (work@top.NumRegions), line:5, parent:work@top
-    |vpiName:NumRegions
-    |vpiFullName:work@top.NumRegions
-    |INT:8
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/TaskDecls/TaskDecls.log
+++ b/tests/TaskDecls/TaskDecls.log
@@ -802,11 +802,9 @@ design: (work@gen_errors)
     \_parameter: (work@gen_errors.width_a), line:19, parent:work@gen_errors
       |vpiName:width_a
       |vpiFullName:work@gen_errors.width_a
+      |INT:8
   |vpiParameter:
   \_parameter: (work@gen_errors.width_a), line:19, parent:work@gen_errors
-    |vpiName:width_a
-    |vpiFullName:work@gen_errors.width_a
-    |INT:8
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/Ternary/Ternary.log
+++ b/tests/Ternary/Ternary.log
@@ -1242,6 +1242,7 @@ design: (work@test)
                 \_parameter: (work@test.USER_DELAY_INIT), line:24, parent:work@test
                   |vpiName:USER_DELAY_INIT
                   |vpiFullName:work@test.USER_DELAY_INIT
+                  |vpiLocalParam:1
                   |INT:1
             |vpiStmt:
             \_assignment: , line:40, parent:work@test
@@ -1513,6 +1514,7 @@ design: (work@test)
                           \_parameter: (work@test.USER_CHECK_STATE), line:30, parent:work@test
                             |vpiName:USER_CHECK_STATE
                             |vpiFullName:work@test.USER_CHECK_STATE
+                            |vpiLocalParam:1
                             |INT:64
               |vpiCaseItem:
               \_case_item: , line:57
@@ -1642,6 +1644,7 @@ design: (work@test)
                               \_parameter: (work@test.USER_CHECK_SPACE), line:31, parent:work@test
                                 |vpiName:USER_CHECK_SPACE
                                 |vpiFullName:work@test.USER_CHECK_SPACE
+                                |vpiLocalParam:1
                                 |INT:128
                         |vpiElseStmt:
                         \_begin: (work@test), line:65
@@ -1681,6 +1684,7 @@ design: (work@test)
                                 \_parameter: (work@test.USER_READ_LENGTH), line:33, parent:work@test
                                   |vpiName:USER_READ_LENGTH
                                   |vpiFullName:work@test.USER_READ_LENGTH
+                                  |vpiLocalParam:1
                                   |INT:512
                               |vpiOperand:
                               \_ref_obj: (work@test.USER_READ_DATA), line:67
@@ -1690,6 +1694,7 @@ design: (work@test)
                                 \_parameter: (work@test.USER_READ_DATA), line:34, parent:work@test
                                   |vpiName:USER_READ_DATA
                                   |vpiFullName:work@test.USER_READ_DATA
+                                  |vpiLocalParam:1
                                   |INT:1024
               |vpiCaseItem:
               \_case_item: , line:72
@@ -1730,6 +1735,7 @@ design: (work@test)
                         \_parameter: (work@test.ESTABLISHED), line:10, parent:work@test
                           |vpiName:ESTABLISHED
                           |vpiFullName:work@test.ESTABLISHED
+                          |vpiLocalParam:1
                           |INT:3
                     |vpiStmt:
                     \_begin: (work@test), line:73
@@ -1751,6 +1757,7 @@ design: (work@test)
                           \_parameter: (work@test.USER_IDLE), line:29, parent:work@test
                             |vpiName:USER_IDLE
                             |vpiFullName:work@test.USER_IDLE
+                            |vpiLocalParam:1
                             |INT:32
                     |vpiElseStmt:
                     \_begin: (work@test), line:75
@@ -1772,6 +1779,7 @@ design: (work@test)
                           \_parameter: (work@test.USER_WRITE_DATA), line:32, parent:work@test
                             |vpiName:USER_WRITE_DATA
                             |vpiFullName:work@test.USER_WRITE_DATA
+                            |vpiLocalParam:1
                             |INT:256
   |vpiPort:
   \_port: (CLK), line:6, parent:work@test
@@ -2122,6 +2130,7 @@ design: (work@test)
                 \_parameter: (work@test.USER_DELAY_INIT), line:24, parent:work@test
                   |vpiName:USER_DELAY_INIT
                   |vpiFullName:work@test.USER_DELAY_INIT
+                  |vpiLocalParam:1
                   |INT:1
             |vpiStmt:
             \_assignment: , line:40, parent:work@test
@@ -2399,6 +2408,7 @@ design: (work@test)
                           \_parameter: (work@test.USER_CHECK_STATE), line:30, parent:work@test
                             |vpiName:USER_CHECK_STATE
                             |vpiFullName:work@test.USER_CHECK_STATE
+                            |vpiLocalParam:1
                             |INT:64
               |vpiCaseItem:
               \_case_item: , line:57
@@ -2537,6 +2547,7 @@ design: (work@test)
                               \_parameter: (work@test.USER_CHECK_SPACE), line:31, parent:work@test
                                 |vpiName:USER_CHECK_SPACE
                                 |vpiFullName:work@test.USER_CHECK_SPACE
+                                |vpiLocalParam:1
                                 |INT:128
                         |vpiElseStmt:
                         \_begin: (work@test), line:65
@@ -2576,6 +2587,7 @@ design: (work@test)
                                 \_parameter: (work@test.USER_READ_LENGTH), line:33, parent:work@test
                                   |vpiName:USER_READ_LENGTH
                                   |vpiFullName:work@test.USER_READ_LENGTH
+                                  |vpiLocalParam:1
                                   |INT:512
                               |vpiOperand:
                               \_ref_obj: (work@test.USER_READ_DATA), line:67
@@ -2585,6 +2597,7 @@ design: (work@test)
                                 \_parameter: (work@test.USER_READ_DATA), line:34, parent:work@test
                                   |vpiName:USER_READ_DATA
                                   |vpiFullName:work@test.USER_READ_DATA
+                                  |vpiLocalParam:1
                                   |INT:1024
               |vpiCaseItem:
               \_case_item: , line:72
@@ -2627,6 +2640,7 @@ design: (work@test)
                         \_parameter: (work@test.ESTABLISHED), line:10, parent:work@test
                           |vpiName:ESTABLISHED
                           |vpiFullName:work@test.ESTABLISHED
+                          |vpiLocalParam:1
                           |INT:3
                     |vpiStmt:
                     \_begin: (work@test), line:73
@@ -2648,6 +2662,7 @@ design: (work@test)
                           \_parameter: (work@test.USER_IDLE), line:29, parent:work@test
                             |vpiName:USER_IDLE
                             |vpiFullName:work@test.USER_IDLE
+                            |vpiLocalParam:1
                             |INT:32
                     |vpiElseStmt:
                     \_begin: (work@test), line:75
@@ -2669,6 +2684,7 @@ design: (work@test)
                           \_parameter: (work@test.USER_WRITE_DATA), line:32, parent:work@test
                             |vpiName:USER_WRITE_DATA
                             |vpiFullName:work@test.USER_WRITE_DATA
+                            |vpiLocalParam:1
                             |INT:256
   |vpiPort:
   \_port: (CLK), line:6, parent:work@test
@@ -2730,6 +2746,7 @@ design: (work@test)
       |vpiName:FRAME_LENGTH
       |vpiFullName:work@test.FRAME_LENGTH
       |vpiLocalParam:1
+      |INT:15
   |vpiParamAssign:
   \_param_assign: , line:10, parent:work@test
     |vpiRhs:
@@ -2740,9 +2757,6 @@ design: (work@test)
       |INT:3
     |vpiLhs:
     \_parameter: (work@test.ESTABLISHED), line:10, parent:work@test
-      |vpiName:ESTABLISHED
-      |vpiFullName:work@test.ESTABLISHED
-      |vpiLocalParam:1
   |vpiParamAssign:
   \_param_assign: , line:24, parent:work@test
     |vpiRhs:
@@ -2753,9 +2767,6 @@ design: (work@test)
       |INT:1
     |vpiLhs:
     \_parameter: (work@test.USER_DELAY_INIT), line:24, parent:work@test
-      |vpiName:USER_DELAY_INIT
-      |vpiFullName:work@test.USER_DELAY_INIT
-      |vpiLocalParam:1
   |vpiParamAssign:
   \_param_assign: , line:25, parent:work@test
     |vpiRhs:
@@ -2769,6 +2780,7 @@ design: (work@test)
       |vpiName:USER_CLEAN
       |vpiFullName:work@test.USER_CLEAN
       |vpiLocalParam:1
+      |INT:2
   |vpiParamAssign:
   \_param_assign: , line:26, parent:work@test
     |vpiRhs:
@@ -2782,6 +2794,7 @@ design: (work@test)
       |vpiName:USER_CLEAN_CHECK
       |vpiFullName:work@test.USER_CLEAN_CHECK
       |vpiLocalParam:1
+      |INT:4
   |vpiParamAssign:
   \_param_assign: , line:27, parent:work@test
     |vpiRhs:
@@ -2795,6 +2808,7 @@ design: (work@test)
       |vpiName:USER_CLEAR_INTS
       |vpiFullName:work@test.USER_CLEAR_INTS
       |vpiLocalParam:1
+      |INT:8
   |vpiParamAssign:
   \_param_assign: , line:28, parent:work@test
     |vpiRhs:
@@ -2808,6 +2822,7 @@ design: (work@test)
       |vpiName:USER_INIT
       |vpiFullName:work@test.USER_INIT
       |vpiLocalParam:1
+      |INT:16
   |vpiParamAssign:
   \_param_assign: , line:29, parent:work@test
     |vpiRhs:
@@ -2818,9 +2833,6 @@ design: (work@test)
       |INT:32
     |vpiLhs:
     \_parameter: (work@test.USER_IDLE), line:29, parent:work@test
-      |vpiName:USER_IDLE
-      |vpiFullName:work@test.USER_IDLE
-      |vpiLocalParam:1
   |vpiParamAssign:
   \_param_assign: , line:30, parent:work@test
     |vpiRhs:
@@ -2831,9 +2843,6 @@ design: (work@test)
       |INT:64
     |vpiLhs:
     \_parameter: (work@test.USER_CHECK_STATE), line:30, parent:work@test
-      |vpiName:USER_CHECK_STATE
-      |vpiFullName:work@test.USER_CHECK_STATE
-      |vpiLocalParam:1
   |vpiParamAssign:
   \_param_assign: , line:31, parent:work@test
     |vpiRhs:
@@ -2844,9 +2853,6 @@ design: (work@test)
       |INT:128
     |vpiLhs:
     \_parameter: (work@test.USER_CHECK_SPACE), line:31, parent:work@test
-      |vpiName:USER_CHECK_SPACE
-      |vpiFullName:work@test.USER_CHECK_SPACE
-      |vpiLocalParam:1
   |vpiParamAssign:
   \_param_assign: , line:32, parent:work@test
     |vpiRhs:
@@ -2857,9 +2863,6 @@ design: (work@test)
       |INT:256
     |vpiLhs:
     \_parameter: (work@test.USER_WRITE_DATA), line:32, parent:work@test
-      |vpiName:USER_WRITE_DATA
-      |vpiFullName:work@test.USER_WRITE_DATA
-      |vpiLocalParam:1
   |vpiParamAssign:
   \_param_assign: , line:33, parent:work@test
     |vpiRhs:
@@ -2870,9 +2873,6 @@ design: (work@test)
       |INT:512
     |vpiLhs:
     \_parameter: (work@test.USER_READ_LENGTH), line:33, parent:work@test
-      |vpiName:USER_READ_LENGTH
-      |vpiFullName:work@test.USER_READ_LENGTH
-      |vpiLocalParam:1
   |vpiParamAssign:
   \_param_assign: , line:34, parent:work@test
     |vpiRhs:
@@ -2883,50 +2883,32 @@ design: (work@test)
       |INT:1024
     |vpiLhs:
     \_parameter: (work@test.USER_READ_DATA), line:34, parent:work@test
-      |vpiName:USER_READ_DATA
-      |vpiFullName:work@test.USER_READ_DATA
-      |vpiLocalParam:1
+  |vpiParameter:
+  \_parameter: (work@test.FRAME_LENGTH), line:9, parent:work@test
   |vpiParameter:
   \_parameter: (work@test.ESTABLISHED), line:10, parent:work@test
   |vpiParameter:
-  \_parameter: (work@test.FRAME_LENGTH), line:9, parent:work@test
-    |vpiName:FRAME_LENGTH
-    |vpiFullName:work@test.FRAME_LENGTH
-    |INT:15
-  |vpiParameter:
-  \_parameter: (work@test.USER_CHECK_SPACE), line:31, parent:work@test
-  |vpiParameter:
-  \_parameter: (work@test.USER_CHECK_STATE), line:30, parent:work@test
+  \_parameter: (work@test.USER_DELAY_INIT), line:24, parent:work@test
   |vpiParameter:
   \_parameter: (work@test.USER_CLEAN), line:25, parent:work@test
-    |vpiName:USER_CLEAN
-    |vpiFullName:work@test.USER_CLEAN
-    |INT:2
   |vpiParameter:
   \_parameter: (work@test.USER_CLEAN_CHECK), line:26, parent:work@test
-    |vpiName:USER_CLEAN_CHECK
-    |vpiFullName:work@test.USER_CLEAN_CHECK
-    |INT:4
   |vpiParameter:
   \_parameter: (work@test.USER_CLEAR_INTS), line:27, parent:work@test
-    |vpiName:USER_CLEAR_INTS
-    |vpiFullName:work@test.USER_CLEAR_INTS
-    |INT:8
   |vpiParameter:
-  \_parameter: (work@test.USER_DELAY_INIT), line:24, parent:work@test
+  \_parameter: (work@test.USER_INIT), line:28, parent:work@test
   |vpiParameter:
   \_parameter: (work@test.USER_IDLE), line:29, parent:work@test
   |vpiParameter:
-  \_parameter: (work@test.USER_INIT), line:28, parent:work@test
-    |vpiName:USER_INIT
-    |vpiFullName:work@test.USER_INIT
-    |INT:16
+  \_parameter: (work@test.USER_CHECK_STATE), line:30, parent:work@test
   |vpiParameter:
-  \_parameter: (work@test.USER_READ_DATA), line:34, parent:work@test
+  \_parameter: (work@test.USER_CHECK_SPACE), line:31, parent:work@test
+  |vpiParameter:
+  \_parameter: (work@test.USER_WRITE_DATA), line:32, parent:work@test
   |vpiParameter:
   \_parameter: (work@test.USER_READ_LENGTH), line:33, parent:work@test
   |vpiParameter:
-  \_parameter: (work@test.USER_WRITE_DATA), line:32, parent:work@test
+  \_parameter: (work@test.USER_READ_DATA), line:34, parent:work@test
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/TypeParam/TypeParam.log
+++ b/tests/TypeParam/TypeParam.log
@@ -159,20 +159,18 @@ design: (work@top)
           |vpiSize:64
           |INT:10
         |vpiLhs:
-        \_parameter: (work@bottom.SIZE), line:17, parent:work@bottom
+        \_parameter: (work@top.u0.u1.SIZE), line:17, parent:work@top.u0.u1
           |vpiName:SIZE
-          |vpiFullName:work@bottom.SIZE
-      |vpiParameter:
-      \_parameter: (work@top.u0.u1.SIZE), line:17, parent:work@top.u0.u1
-        |vpiName:SIZE
-        |vpiFullName:work@top.u0.u1.SIZE
-        |INT:10
+          |vpiFullName:work@top.u0.u1.SIZE
+          |INT:10
       |vpiParameter:
       \_type_parameter: (work@top.u0.u1.TP1), parent:work@top.u0.u1
         |vpiFullName:work@top.u0.u1.TP1
         |vpiName:TP1
         |vpiTypespec:
         \_int_typespec: , line:2, parent:work@top.u0.u1.TP1
+      |vpiParameter:
+      \_parameter: (work@top.u0.u1.SIZE), line:17, parent:work@top.u0.u1
       |vpiParameter:
       \_type_parameter: (work@bottom.TP2), line:17, parent:work@bottom
         |vpiFullName:work@bottom.TP2
@@ -226,18 +224,18 @@ design: (work@top)
           |vpiSize:64
           |INT:20
         |vpiLhs:
-        \_parameter: (work@bottom.SIZE), line:17, parent:work@bottom
-      |vpiParameter:
-      \_parameter: (work@top.u0.u2.SIZE), line:13, parent:work@top.u0.u2
-        |vpiName:SIZE
-        |vpiFullName:work@top.u0.u2.SIZE
-        |INT:20
+        \_parameter: (work@top.u0.u2.SIZE), line:17, parent:work@top.u0.u2
+          |vpiName:SIZE
+          |vpiFullName:work@top.u0.u2.SIZE
+          |INT:20
       |vpiParameter:
       \_type_parameter: (work@top.u0.u2.TP1), parent:work@top.u0.u2
         |vpiFullName:work@top.u0.u2.TP1
         |vpiName:TP1
         |vpiTypespec:
         \_int_typespec: , line:13, parent:work@top.u0.u2.TP1
+      |vpiParameter:
+      \_parameter: (work@top.u0.u2.SIZE), line:17, parent:work@top.u0.u2
       |vpiParameter:
       \_type_parameter: (work@bottom.TP2), line:17, parent:work@bottom
     |vpiInstance:

--- a/tests/UnitDefParam/UnitDefParam.log
+++ b/tests/UnitDefParam/UnitDefParam.log
@@ -1277,14 +1277,12 @@ design: (work@top_def)
         |vpiSize:64
         |INT:3
       |vpiLhs:
-      \_parameter: (work@def.SIZE1), line:3, parent:work@def
+      \_parameter: (work@top_def.u1.SIZE1), line:3, parent:work@top_def.u1
         |vpiName:SIZE1
-        |vpiFullName:work@def.SIZE1
+        |vpiFullName:work@top_def.u1.SIZE1
+        |INT:3
     |vpiParameter:
     \_parameter: (work@top_def.u1.SIZE1), line:3, parent:work@top_def.u1
-      |vpiName:SIZE1
-      |vpiFullName:work@top_def.u1.SIZE1
-      |INT:3
 |uhdmtopModules:
 \_module: work@small_top (work@small_top) top.v:7: 
   |vpiDefName:work@small_top
@@ -2084,9 +2082,10 @@ design: (work@top_def)
         |vpiSize:64
         |INT:3
       |vpiLhs:
-      \_parameter: (work@small_test.SIZE), line:14, parent:work@small_test
+      \_parameter: (work@small_top.u1.SIZE), line:14, parent:work@small_top.u1
         |vpiName:SIZE
-        |vpiFullName:work@small_test.SIZE
+        |vpiFullName:work@small_top.u1.SIZE
+        |INT:3
     |vpiParamAssign:
     \_param_assign: , line:15, parent:work@small_top.u1
       |vpiRhs:
@@ -2096,9 +2095,10 @@ design: (work@top_def)
         |vpiSize:64
         |INT:4
       |vpiLhs:
-      \_parameter: (work@small_test.dummy), line:15, parent:work@small_test
+      \_parameter: (work@small_top.u1.dummy), line:15, parent:work@small_top.u1
         |vpiName:dummy
-        |vpiFullName:work@small_test.dummy
+        |vpiFullName:work@small_top.u1.dummy
+        |INT:4
     |vpiParamAssign:
     \_param_assign: , line:16, parent:work@small_top.u1
       |vpiRhs:
@@ -2108,24 +2108,16 @@ design: (work@top_def)
         |vpiSize:13
         |INT:4
       |vpiLhs:
-      \_parameter: (work@small_test.p1), line:16, parent:work@small_test
+      \_parameter: (work@small_top.u1.p1), line:16, parent:work@small_top.u1
         |vpiName:p1
-        |vpiFullName:work@small_test.p1
+        |vpiFullName:work@small_top.u1.p1
+        |INT:4
     |vpiParameter:
-    \_parameter: (work@small_top.u1.SIZE), parent:work@small_top.u1
-      |vpiName:SIZE
-      |vpiFullName:work@small_top.u1.SIZE
-      |INT:3
+    \_parameter: (work@small_top.u1.SIZE), line:14, parent:work@small_top.u1
     |vpiParameter:
-    \_parameter: (work@small_top.u1.dummy), parent:work@small_top.u1
-      |vpiName:dummy
-      |vpiFullName:work@small_top.u1.dummy
-      |INT:4
+    \_parameter: (work@small_top.u1.dummy), line:15, parent:work@small_top.u1
     |vpiParameter:
     \_parameter: (work@small_top.u1.p1), line:16, parent:work@small_top.u1
-      |vpiName:p1
-      |vpiFullName:work@small_top.u1.p1
-      |INT:4
 |uhdmtopModules:
 \_module: work@defparam_example (work@defparam_example) small.v:14: 
   |vpiDefName:work@defparam_example
@@ -2146,14 +2138,12 @@ design: (work@top_def)
         |vpiSize:64
         |INT:0
       |vpiLhs:
-      \_parameter: (work@secret_number.SIZE), line:3, parent:work@secret_number
+      \_parameter: (work@defparam_example.U0.SIZE), line:3, parent:work@defparam_example.U0
         |vpiName:SIZE
-        |vpiFullName:work@secret_number.SIZE
+        |vpiFullName:work@defparam_example.U0.SIZE
+        |INT:0
     |vpiParameter:
     \_parameter: (work@defparam_example.U0.SIZE), line:3, parent:work@defparam_example.U0
-      |vpiName:SIZE
-      |vpiFullName:work@defparam_example.U0.SIZE
-      |INT:0
   |vpiModule:
   \_module: work@secret_number (work@defparam_example.U1) small.v:20: , parent:work@defparam_example
     |vpiDefName:work@secret_number
@@ -2187,12 +2177,12 @@ design: (work@top_def)
         |vpiSize:64
         |INT:1
       |vpiLhs:
-      \_parameter: (work@secret_number.SIZE), line:3, parent:work@secret_number
+      \_parameter: (work@defparam_example.U1.SIZE), line:3, parent:work@defparam_example.U1
+        |vpiName:SIZE
+        |vpiFullName:work@defparam_example.U1.SIZE
+        |INT:1
     |vpiParameter:
-    \_parameter: (work@defparam_example.U1.SIZE), parent:work@defparam_example.U1
-      |vpiName:SIZE
-      |vpiFullName:work@defparam_example.U1.SIZE
-      |INT:1
+    \_parameter: (work@defparam_example.U1.SIZE), line:3, parent:work@defparam_example.U1
   |vpiModule:
   \_module: work@secret_number (work@defparam_example.U2) small.v:21: , parent:work@defparam_example
     |vpiDefName:work@secret_number
@@ -2243,12 +2233,12 @@ design: (work@top_def)
         |vpiSize:64
         |INT:2
       |vpiLhs:
-      \_parameter: (work@secret_number.SIZE), line:3, parent:work@secret_number
+      \_parameter: (work@defparam_example.U2.SIZE), line:3, parent:work@defparam_example.U2
+        |vpiName:SIZE
+        |vpiFullName:work@defparam_example.U2.SIZE
+        |INT:2
     |vpiParameter:
-    \_parameter: (work@defparam_example.U2.SIZE), parent:work@defparam_example.U2
-      |vpiName:SIZE
-      |vpiFullName:work@defparam_example.U2.SIZE
-      |INT:2
+    \_parameter: (work@defparam_example.U2.SIZE), line:3, parent:work@defparam_example.U2
   |vpiModule:
   \_module: work@secret_number (work@defparam_example.U3) small.v:22: , parent:work@defparam_example
     |vpiDefName:work@secret_number
@@ -2316,12 +2306,12 @@ design: (work@top_def)
         |vpiSize:64
         |INT:3
       |vpiLhs:
-      \_parameter: (work@secret_number.SIZE), line:3, parent:work@secret_number
+      \_parameter: (work@defparam_example.U3.SIZE), line:3, parent:work@defparam_example.U3
+        |vpiName:SIZE
+        |vpiFullName:work@defparam_example.U3.SIZE
+        |INT:3
     |vpiParameter:
-    \_parameter: (work@defparam_example.U3.SIZE), parent:work@defparam_example.U3
-      |vpiName:SIZE
-      |vpiFullName:work@defparam_example.U3.SIZE
-      |INT:3
+    \_parameter: (work@defparam_example.U3.SIZE), line:3, parent:work@defparam_example.U3
   |vpiModule:
   \_module: work@defparam_example::NO_DEF (work@defparam_example.U5) small.v:23: , parent:work@defparam_example
     |vpiDefName:work@defparam_example::NO_DEF

--- a/tests/UnitElab/UnitElab.log
+++ b/tests/UnitElab/UnitElab.log
@@ -15690,6 +15690,7 @@ design: (work@bottom1)
     \_parameter: (work@test.POWER1), line:37, parent:work@test
       |vpiName:POWER1
       |vpiFullName:work@test.POWER1
+      |INT:1
   |vpiParamAssign:
   \_param_assign: , line:38, parent:work@test
     |vpiRhs:
@@ -15702,16 +15703,11 @@ design: (work@bottom1)
     \_parameter: (work@test.POWER2), line:38, parent:work@test
       |vpiName:POWER2
       |vpiFullName:work@test.POWER2
+      |INT:1
   |vpiParameter:
   \_parameter: (work@test.POWER1), line:37, parent:work@test
-    |vpiName:POWER1
-    |vpiFullName:work@test.POWER1
-    |INT:1
   |vpiParameter:
   \_parameter: (work@test.POWER2), line:38, parent:work@test
-    |vpiName:POWER2
-    |vpiFullName:work@test.POWER2
-    |INT:1
 |uhdmtopModules:
 \_module: work@small_top (work@small_top) small.v:1: 
   |vpiDefName:work@small_top
@@ -36193,11 +36189,12 @@ design: (work@bottom1)
         |vpiConstType:7
         |vpiDecompile:10
         |vpiSize:64
-        |REAL:t.ttts
+        |INT:10
       |vpiLhs:
-      \_parameter: (work@small_test.SIZE), line:8, parent:work@small_test
+      \_parameter: (work@small_top.u1.SIZE), line:8, parent:work@small_top.u1
         |vpiName:SIZE
-        |vpiFullName:work@small_test.SIZE
+        |vpiFullName:work@small_top.u1.SIZE
+        |INT:10
     |vpiParamAssign:
     \_param_assign: , line:9, parent:work@small_top.u1
       |vpiRhs:
@@ -36207,9 +36204,10 @@ design: (work@bottom1)
         |vpiSize:64
         |INT:2
       |vpiLhs:
-      \_parameter: (work@small_test.dummy), line:9, parent:work@small_test
+      \_parameter: (work@small_top.u1.dummy), line:9, parent:work@small_top.u1
         |vpiName:dummy
-        |vpiFullName:work@small_test.dummy
+        |vpiFullName:work@small_top.u1.dummy
+        |INT:2
     |vpiParamAssign:
     \_param_assign: , line:10, parent:work@small_top.u1
       |vpiRhs:
@@ -36219,24 +36217,16 @@ design: (work@bottom1)
         |vpiSize:13
         |INT:4
       |vpiLhs:
-      \_parameter: (work@small_test.p1), line:10, parent:work@small_test
+      \_parameter: (work@small_top.u1.p1), line:10, parent:work@small_top.u1
         |vpiName:p1
-        |vpiFullName:work@small_test.p1
+        |vpiFullName:work@small_top.u1.p1
+        |INT:4
     |vpiParameter:
-    \_parameter: (work@small_top.u1.SIZE), line:2, parent:work@small_top.u1
-      |vpiName:SIZE
-      |vpiFullName:work@small_top.u1.SIZE
-      |REAL:t.ttts
+    \_parameter: (work@small_top.u1.SIZE), line:8, parent:work@small_top.u1
     |vpiParameter:
-    \_parameter: (work@small_top.u1.dummy), line:2, parent:work@small_top.u1
-      |vpiName:dummy
-      |vpiFullName:work@small_top.u1.dummy
-      |INT:2
+    \_parameter: (work@small_top.u1.dummy), line:9, parent:work@small_top.u1
     |vpiParameter:
     \_parameter: (work@small_top.u1.p1), line:10, parent:work@small_top.u1
-      |vpiName:p1
-      |vpiFullName:work@small_top.u1.p1
-      |INT:4
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/UnitPackage/UnitPackage.log
+++ b/tests/UnitPackage/UnitPackage.log
@@ -1551,27 +1551,14 @@ design: (work@simple_package)
       |vpiSize:32
       |INT:2
     |vpiLhs:
-    \_parameter: (work@simple_package.SIZE), line:8, parent:work@simple_package
+    \_parameter: (SIZE), line:8
       |vpiName:SIZE
-      |vpiFullName:work@simple_package.SIZE
-      |vpiImported:definesPkg
-  |vpiParamAssign:
-  \_param_assign: , line:8, parent:work@simple_package
-    |vpiRhs:
-    \_constant: , line:8
-      |vpiConstType:7
-      |vpiDecompile:2
-      |vpiSize:32
-      |INT:2
-    |vpiLhs:
-    \_parameter: (work@simple_package.SIZE), line:8, parent:work@simple_package
-      |vpiName:SIZE
-      |vpiFullName:work@simple_package.SIZE
       |vpiImported:definesPkg
   |vpiParameter:
   \_parameter: (work@simple_package.SIZE), line:8, parent:work@simple_package
-  |vpiParameter:
-  \_parameter: (work@simple_package.SIZE), line:8, parent:work@simple_package
+    |vpiName:SIZE
+    |vpiFullName:work@simple_package.SIZE
+    |vpiImported:definesPkg
 |uhdmtopModules:
 \_module: work@simple_package (work@simple_package) simple_pkg.sv:11: 
   |vpiDefName:work@simple_package
@@ -1770,38 +1757,21 @@ design: (work@simple_package)
           |vpiTypespec:
           \_bit_typespec: , line:14
       |vpiParamAssign:
-      \_param_assign: , line:8
+      \_param_assign: , line:8, parent:work@simple_package.inst
         |vpiRhs:
         \_constant: , line:8
           |vpiConstType:7
           |vpiDecompile:2
-          |vpiSize:32
+          |vpiSize:64
           |INT:2
         |vpiLhs:
-        \_parameter: (SIZE), line:8
+        \_parameter: (work@simple_package.inst.SIZE), line:8, parent:work@simple_package.inst
           |vpiName:SIZE
+          |vpiFullName:work@simple_package.inst.SIZE
           |vpiImported:definesPkg
-      |vpiParamAssign:
-      \_param_assign: , line:8
-        |vpiRhs:
-        \_constant: , line:8
-          |vpiConstType:7
-          |vpiDecompile:2
-          |vpiSize:32
           |INT:2
-        |vpiLhs:
-        \_parameter: (SIZE), line:8
-          |vpiName:SIZE
-          |vpiImported:definesPkg
       |vpiParameter:
       \_parameter: (work@simple_package.inst.SIZE), line:8, parent:work@simple_package.inst
-        |vpiName:SIZE
-        |vpiFullName:work@simple_package.inst.SIZE
-        |INT:2
-      |vpiParameter:
-      \_parameter: (SIZE), line:8
-      |vpiParameter:
-      \_parameter: (SIZE), line:8
   |vpiVariables:
   \_enum_var: (work@simple_package.value), line:13, parent:work@simple_package
   |vpiTypedef:
@@ -1874,24 +1844,9 @@ design: (work@simple_package)
       |vpiName:SIZE
       |vpiFullName:work@simple_package.SIZE
       |vpiImported:definesPkg
-  |vpiParamAssign:
-  \_param_assign: , line:8, parent:work@simple_package
-    |vpiRhs:
-    \_constant: , line:8
-      |vpiConstType:7
-      |vpiDecompile:2
-      |vpiSize:64
       |INT:2
-    |vpiLhs:
-    \_parameter: (work@simple_package.SIZE), line:8, parent:work@simple_package
-      |vpiName:SIZE
-      |vpiFullName:work@simple_package.SIZE
-      |vpiImported:definesPkg
   |vpiParameter:
   \_parameter: (work@simple_package.SIZE), line:8, parent:work@simple_package
-    |vpiName:SIZE
-    |vpiFullName:work@simple_package.SIZE
-    |INT:2
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/UnitPartSelect/UnitPartSelect.log
+++ b/tests/UnitPartSelect/UnitPartSelect.log
@@ -1321,8 +1321,6 @@ design: (work@toto)
       |INT:0
     |vpiLhs:
     \_parameter: (work@toto.IDLE), line:3, parent:work@toto
-      |vpiName:IDLE
-      |vpiFullName:work@toto.IDLE
   |vpiParameter:
   \_parameter: (work@toto.IDLE), line:3, parent:work@toto
 |uhdmtopModules:

--- a/third_party/tests/SimpleParserTest/SimpleParserTest.log
+++ b/third_party/tests/SimpleParserTest/SimpleParserTest.log
@@ -8749,6 +8749,7 @@ design: (work@dff_async_reset)
     \_parameter: (work@syn_fifo.DATA_WIDTH), line:22, parent:work@syn_fifo
       |vpiName:DATA_WIDTH
       |vpiFullName:work@syn_fifo.DATA_WIDTH
+      |INT:8
   |vpiParamAssign:
   \_param_assign: , line:23, parent:work@syn_fifo
     |vpiRhs:
@@ -8761,6 +8762,7 @@ design: (work@dff_async_reset)
     \_parameter: (work@syn_fifo.ADDR_WIDTH), line:23, parent:work@syn_fifo
       |vpiName:ADDR_WIDTH
       |vpiFullName:work@syn_fifo.ADDR_WIDTH
+      |INT:8
   |vpiParamAssign:
   \_param_assign: , line:24, parent:work@syn_fifo
     |vpiRhs:
@@ -8773,21 +8775,13 @@ design: (work@dff_async_reset)
     \_parameter: (work@syn_fifo.RAM_DEPTH), line:24, parent:work@syn_fifo
       |vpiName:RAM_DEPTH
       |vpiFullName:work@syn_fifo.RAM_DEPTH
-  |vpiParameter:
-  \_parameter: (work@syn_fifo.ADDR_WIDTH), line:23, parent:work@syn_fifo
-    |vpiName:ADDR_WIDTH
-    |vpiFullName:work@syn_fifo.ADDR_WIDTH
-    |INT:8
+      |INT:256
   |vpiParameter:
   \_parameter: (work@syn_fifo.DATA_WIDTH), line:22, parent:work@syn_fifo
-    |vpiName:DATA_WIDTH
-    |vpiFullName:work@syn_fifo.DATA_WIDTH
-    |INT:8
+  |vpiParameter:
+  \_parameter: (work@syn_fifo.ADDR_WIDTH), line:23, parent:work@syn_fifo
   |vpiParameter:
   \_parameter: (work@syn_fifo.RAM_DEPTH), line:24, parent:work@syn_fifo
-    |vpiName:RAM_DEPTH
-    |vpiFullName:work@syn_fifo.RAM_DEPTH
-    |INT:256
 |uhdmtopModules:
 \_module: work@uart (work@uart) uart.v:8: 
   |vpiDefName:work@uart
@@ -9630,9 +9624,10 @@ design: (work@dff_async_reset)
         |vpiSize:64
         |INT:8
       |vpiLhs:
-      \_parameter: (work@arbiter.NUMUNITS), line:7, parent:work@arbiter
+      \_parameter: (work@top.U.NUMUNITS), line:7, parent:work@top.U
         |vpiName:NUMUNITS
-        |vpiFullName:work@arbiter.NUMUNITS
+        |vpiFullName:work@top.U.NUMUNITS
+        |INT:8
     |vpiParamAssign:
     \_param_assign: , line:8, parent:work@top.U
       |vpiRhs:
@@ -9642,19 +9637,14 @@ design: (work@dff_async_reset)
         |vpiSize:64
         |INT:3
       |vpiLhs:
-      \_parameter: (work@arbiter.ADDRESSWIDTH), line:8, parent:work@arbiter
+      \_parameter: (work@top.U.ADDRESSWIDTH), line:8, parent:work@top.U
         |vpiName:ADDRESSWIDTH
-        |vpiFullName:work@arbiter.ADDRESSWIDTH
-    |vpiParameter:
-    \_parameter: (work@top.U.ADDRESSWIDTH), line:8, parent:work@top.U
-      |vpiName:ADDRESSWIDTH
-      |vpiFullName:work@top.U.ADDRESSWIDTH
-      |INT:3
+        |vpiFullName:work@top.U.ADDRESSWIDTH
+        |INT:3
     |vpiParameter:
     \_parameter: (work@top.U.NUMUNITS), line:7, parent:work@top.U
-      |vpiName:NUMUNITS
-      |vpiFullName:work@top.U.NUMUNITS
-      |INT:8
+    |vpiParameter:
+    \_parameter: (work@top.U.ADDRESSWIDTH), line:8, parent:work@top.U
   |vpiNet:
   \_logic_net: (work@top.clk), line:5, parent:work@top
   |vpiNet:
@@ -10017,11 +10007,12 @@ design: (work@dff_async_reset)
     \_parameter: (work@LFSR_TASK.Chain1), line:7, parent:work@LFSR_TASK
       |vpiName:Chain1
       |vpiFullName:work@LFSR_TASK.Chain1
+      |INT:142
       |vpiTypespec:
       \_bit_typespec: (Chain1), line:7, parent:work@LFSR_TASK.Chain1
         |vpiName:Chain1
         |vpiRange:
-        \_range: , line:7
+        \_range: , line:7, parent:Chain1
           |vpiLeftRange:
           \_constant: , line:7
             |vpiConstType:7
@@ -10046,11 +10037,12 @@ design: (work@dff_async_reset)
     \_parameter: (work@LFSR_TASK.Chain2), line:8, parent:work@LFSR_TASK
       |vpiName:Chain2
       |vpiFullName:work@LFSR_TASK.Chain2
+      |INT:174
       |vpiTypespec:
       \_bit_typespec: (Chain2), line:8, parent:work@LFSR_TASK.Chain2
         |vpiName:Chain2
         |vpiRange:
-        \_range: , line:8
+        \_range: , line:8, parent:Chain2
           |vpiLeftRange:
           \_constant: , line:8
             |vpiConstType:7
@@ -10065,14 +10057,8 @@ design: (work@dff_async_reset)
             |INT:0
   |vpiParameter:
   \_parameter: (work@LFSR_TASK.Chain1), line:7, parent:work@LFSR_TASK
-    |vpiName:Chain1
-    |vpiFullName:work@LFSR_TASK.Chain1
-    |INT:142
   |vpiParameter:
   \_parameter: (work@LFSR_TASK.Chain2), line:8, parent:work@LFSR_TASK
-    |vpiName:Chain2
-    |vpiFullName:work@LFSR_TASK.Chain2
-    |INT:174
 |uhdmtopModules:
 \_module: work@mux21_switch (work@mux21_switch) mux21.v:7: 
   |vpiDefName:work@mux21_switch

--- a/third_party/tests/ariane/Ariane.log
+++ b/third_party/tests/ariane/Ariane.log
@@ -1,5 +1,5 @@
+make[4]: Entering directory '${SURELOG_DIR}/third_party/tests/ariane'
 [Verilator] Building Model
-${SURELOG_DIR}/build/bin/surelog -sverilog -parse -d coveruhdm -verbose -timescale=1ps/1ps ${SURELOG_DIR}/third_party/tests/ariane/include/riscv_pkg.sv ${SURELOG_DIR}/third_party/tests/ariane/src/riscv-dbg/src/dm_pkg.sv ${SURELOG_DIR}/third_party/tests/ariane/include/ariane_pkg.sv ${SURELOG_DIR}/third_party/tests/ariane/include/std_cache_pkg.sv ${SURELOG_DIR}/third_party/tests/ariane/include/wt_cache_pkg.sv ${SURELOG_DIR}/third_party/tests/ariane/src/axi/src/axi_pkg.sv ${SURELOG_DIR}/third_party/tests/ariane/src/register_interface/src/reg_intf.sv ${SURELOG_DIR}/third_party/tests/ariane/src/register_interface/src/reg_intf_pkg.sv ${SURELOG_DIR}/third_party/tests/ariane/include/axi_intf.sv ${SURELOG_DIR}/third_party/tests/ariane/tb/ariane_soc_pkg.sv ${SURELOG_DIR}/third_party/tests/ariane/include/ariane_axi_pkg.sv ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_pkg.sv ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpu_div_sqrt_mvp/hdl/defs_div_sqrt_mvp.sv ${SURELOG_DIR}/third_party/tests/ariane/src/serdiv.sv ${SURELOG_DIR}/third_party/tests/ariane/src/ariane_regfile_ff.sv ${SURELOG_DIR}/third_party/tests/ariane/src/amo_buffer.sv ${SURELOG_DIR}/third_party/tests/ariane/src/id_stage.sv ${SURELOG_DIR}/third_party/tests/ariane/src/branch_unit.sv ${SURELOG_DIR}/third_party/tests/ariane/src/controller.sv ${SURELOG_DIR}/third_party/tests/ariane/src/issue_stage.sv ${SURELOG_DIR}/third_party/tests/ariane/src/re_name.sv ${SURELOG_DIR}/third_party/tests/ariane/src/ariane.sv ${SURELOG_DIR}/third_party/tests/ariane/src/csr_buffer.sv ${SURELOG_DIR}/third_party/tests/ariane/src/tlb.sv ${SURELOG_DIR}/third_party/tests/ariane/src/decoder.sv ${SURELOG_DIR}/third_party/tests/ariane/src/ex_stage.sv ${SURELOG_DIR}/third_party/tests/ariane/src/scoreboard.sv ${SURELOG_DIR}/third_party/tests/ariane/src/mmu.sv ${SURELOG_DIR}/third_party/tests/ariane/src/store_unit.sv ${SURELOG_DIR}/third_party/tests/ariane/src/mult.sv ${SURELOG_DIR}/third_party/tests/ariane/src/axi_adapter.sv ${SURELOG_DIR}/third_party/tests/ariane/src/fpu_wrap.sv ${SURELOG_DIR}/third_party/tests/ariane/src/commit_stage.sv ${SURELOG_DIR}/third_party/tests/ariane/src/load_store_unit.sv ${SURELOG_DIR}/third_party/tests/ariane/src/alu.sv ${SURELOG_DIR}/third_party/tests/ariane/src/multiplier.sv ${SURELOG_DIR}/third_party/tests/ariane/src/store_buffer.sv ${SURELOG_DIR}/third_party/tests/ariane/src/compressed_decoder.sv ${SURELOG_DIR}/third_party/tests/ariane/src/axi_shim.sv ${SURELOG_DIR}/third_party/tests/ariane/src/instr_realign.sv ${SURELOG_DIR}/third_party/tests/ariane/src/perf_counters.sv ${SURELOG_DIR}/third_party/tests/ariane/src/ptw.sv ${SURELOG_DIR}/third_party/tests/ariane/src/csr_regfile.sv ${SURELOG_DIR}/third_party/tests/ariane/src/load_unit.sv ${SURELOG_DIR}/third_party/tests/ariane/src/issue_read_operands.sv ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_opgroup_fmt_slice.sv ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_top.sv ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_divsqrt_multi.sv ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_opgroup_multifmt_slice.sv ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_classifier.sv ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_cast_multi.sv ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_opgroup_block.sv ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_rounding.sv ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpu_div_sqrt_mvp/hdl/iteration_div_sqrt_mvp.sv ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpu_div_sqrt_mvp/hdl/nrbd_nrsc_mvp.sv ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpu_div_sqrt_mvp/hdl/div_sqrt_top_mvp.sv ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpu_div_sqrt_mvp/hdl/preprocess_mvp.sv ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpu_div_sqrt_mvp/hdl/control_mvp.sv ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpu_div_sqrt_mvp/hdl/norm_div_sqrt_mvp.sv ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpu_div_sqrt_mvp/hdl/div_sqrt_mvp_wrapper.sv ${SURELOG_DIR}/third_party/tests/ariane/src/frontend/frontend.sv ${SURELOG_DIR}/third_party/tests/ariane/src/frontend/instr_scan.sv ${SURELOG_DIR}/third_party/tests/ariane/src/frontend/instr_queue.sv ${SURELOG_DIR}/third_party/tests/ariane/src/frontend/bht.sv ${SURELOG_DIR}/third_party/tests/ariane/src/frontend/btb.sv ${SURELOG_DIR}/third_party/tests/ariane/src/frontend/ras.sv ${SURELOG_DIR}/third_party/tests/ariane/src/cache_subsystem/tag_cmp.sv ${SURELOG_DIR}/third_party/tests/ariane/src/cache_subsystem/wt_dcache_ctrl.sv ${SURELOG_DIR}/third_party/tests/ariane/src/cache_subsystem/amo_alu.sv ${SURELOG_DIR}/third_party/tests/ariane/src/cache_subsystem/wt_axi_adapter.sv ${SURELOG_DIR}/third_party/tests/ariane/src/cache_subsystem/std_nbdcache.sv ${SURELOG_DIR}/third_party/tests/ariane/src/cache_subsystem/cache_ctrl.sv ${SURELOG_DIR}/third_party/tests/ariane/src/cache_subsystem/miss_handler.sv ${SURELOG_DIR}/third_party/tests/ariane/src/cache_subsystem/wt_cache_subsystem.sv ${SURELOG_DIR}/third_party/tests/ariane/src/cache_subsystem/wt_dcache_missunit.sv ${SURELOG_DIR}/third_party/tests/ariane/src/cache_subsystem/wt_icache.sv ${SURELOG_DIR}/third_party/tests/ariane/src/cache_subsystem/std_icache.sv ${SURELOG_DIR}/third_party/tests/ariane/src/cache_subsystem/wt_dcache_wbuffer.sv ${SURELOG_DIR}/third_party/tests/ariane/src/cache_subsystem/wt_l15_adapter.sv ${SURELOG_DIR}/third_party/tests/ariane/src/cache_subsystem/wt_dcache_mem.sv ${SURELOG_DIR}/third_party/tests/ariane/src/cache_subsystem/std_cache_subsystem.sv ${SURELOG_DIR}/third_party/tests/ariane/src/cache_subsystem/wt_dcache.sv ${SURELOG_DIR}/third_party/tests/ariane/bootrom/bootrom.sv ${SURELOG_DIR}/third_party/tests/ariane/src/clint/axi_lite_interface.sv ${SURELOG_DIR}/third_party/tests/ariane/src/clint/clint.sv ${SURELOG_DIR}/third_party/tests/ariane/fpga/src/axi2apb/src/axi2apb_wrap.sv ${SURELOG_DIR}/third_party/tests/ariane/fpga/src/axi2apb/src/axi2apb.sv ${SURELOG_DIR}/third_party/tests/ariane/fpga/src/axi2apb/src/axi2apb_64_32.sv ${SURELOG_DIR}/third_party/tests/ariane/fpga/src/axi_slice/src/axi_w_buffer.sv ${SURELOG_DIR}/third_party/tests/ariane/fpga/src/axi_slice/src/axi_b_buffer.sv ${SURELOG_DIR}/third_party/tests/ariane/fpga/src/axi_slice/src/axi_slice_wrap.sv ${SURELOG_DIR}/third_party/tests/ariane/fpga/src/axi_slice/src/axi_slice.sv ${SURELOG_DIR}/third_party/tests/ariane/fpga/src/axi_slice/src/axi_single_slice.sv ${SURELOG_DIR}/third_party/tests/ariane/fpga/src/axi_slice/src/axi_ar_buffer.sv ${SURELOG_DIR}/third_party/tests/ariane/fpga/src/axi_slice/src/axi_r_buffer.sv ${SURELOG_DIR}/third_party/tests/ariane/fpga/src/axi_slice/src/axi_aw_buffer.sv ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_regs_top.sv ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_BR_allocator.sv ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_BW_allocator.sv ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_address_decoder_BR.sv ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_DW_allocator.sv ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_address_decoder_BW.sv ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_address_decoder_DW.sv ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_node_arbiter.sv ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_response_block.sv ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_request_block.sv ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_AR_allocator.sv ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_AW_allocator.sv ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_address_decoder_AR.sv ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_address_decoder_AW.sv ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/apb_regs_top.sv ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_node_intf_wrap.sv ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_node.sv ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_node_wrap_with_slices.sv ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_multiplexer.sv ${SURELOG_DIR}/third_party/tests/ariane/src/axi_riscv_atomics/src/axi_riscv_amos.sv ${SURELOG_DIR}/third_party/tests/ariane/src/axi_riscv_atomics/src/axi_riscv_atomics.sv ${SURELOG_DIR}/third_party/tests/ariane/src/axi_riscv_atomics/src/axi_res_tbl.sv ${SURELOG_DIR}/third_party/tests/ariane/src/axi_riscv_atomics/src/axi_riscv_lrsc_wrap.sv ${SURELOG_DIR}/third_party/tests/ariane/src/axi_riscv_atomics/src/axi_riscv_amos_alu.sv ${SURELOG_DIR}/third_party/tests/ariane/src/axi_riscv_atomics/src/axi_riscv_lrsc.sv ${SURELOG_DIR}/third_party/tests/ariane/src/axi_riscv_atomics/src/axi_riscv_atomics_wrap.sv ${SURELOG_DIR}/third_party/tests/ariane/src/axi_mem_if/src/axi2mem.sv ${SURELOG_DIR}/third_party/tests/ariane/src/rv_plic/rtl/rv_plic_target.sv ${SURELOG_DIR}/third_party/tests/ariane/src/rv_plic/rtl/rv_plic_gateway.sv ${SURELOG_DIR}/third_party/tests/ariane/src/rv_plic/rtl/plic_regmap.sv ${SURELOG_DIR}/third_party/tests/ariane/src/rv_plic/rtl/plic_top.sv ${SURELOG_DIR}/third_party/tests/ariane/src/riscv-dbg/src/dmi_cdc.sv ${SURELOG_DIR}/third_party/tests/ariane/src/riscv-dbg/src/dmi_jtag.sv ${SURELOG_DIR}/third_party/tests/ariane/src/riscv-dbg/src/dmi_jtag_tap.sv ${SURELOG_DIR}/third_party/tests/ariane/src/riscv-dbg/src/dm_csrs.sv ${SURELOG_DIR}/third_party/tests/ariane/src/riscv-dbg/src/dm_mem.sv ${SURELOG_DIR}/third_party/tests/ariane/src/riscv-dbg/src/dm_sba.sv ${SURELOG_DIR}/third_party/tests/ariane/src/riscv-dbg/src/dm_top.sv ${SURELOG_DIR}/third_party/tests/ariane/src/riscv-dbg/debug_rom/debug_rom.sv ${SURELOG_DIR}/third_party/tests/ariane/src/register_interface/src/apb_to_reg.sv ${SURELOG_DIR}/third_party/tests/ariane/src/axi/src/axi_multicut.sv ${SURELOG_DIR}/third_party/tests/ariane/src/common_cells/src/deprecated/generic_fifo.sv ${SURELOG_DIR}/third_party/tests/ariane/src/common_cells/src/deprecated/pulp_sync.sv ${SURELOG_DIR}/third_party/tests/ariane/src/common_cells/src/deprecated/find_first_one.sv ${SURELOG_DIR}/third_party/tests/ariane/src/common_cells/src/rstgen_bypass.sv ${SURELOG_DIR}/third_party/tests/ariane/src/common_cells/src/rstgen.sv ${SURELOG_DIR}/third_party/tests/ariane/src/common_cells/src/stream_mux.sv ${SURELOG_DIR}/third_party/tests/ariane/src/common_cells/src/stream_demux.sv ${SURELOG_DIR}/third_party/tests/ariane/src/common_cells/src/exp_backoff.sv ${SURELOG_DIR}/third_party/tests/ariane/src/util/axi_master_connect.sv ${SURELOG_DIR}/third_party/tests/ariane/src/util/axi_slave_connect.sv ${SURELOG_DIR}/third_party/tests/ariane/src/util/axi_master_connect_rev.sv ${SURELOG_DIR}/third_party/tests/ariane/src/util/axi_slave_connect_rev.sv ${SURELOG_DIR}/third_party/tests/ariane/src/axi/src/axi_cut.sv ${SURELOG_DIR}/third_party/tests/ariane/src/axi/src/axi_join.sv ${SURELOG_DIR}/third_party/tests/ariane/src/axi/src/axi_delayer.sv ${SURELOG_DIR}/third_party/tests/ariane/src/axi/src/axi_to_axi_lite.sv ${SURELOG_DIR}/third_party/tests/ariane/src/fpga-support/rtl/SyncSpRamBeNx64.sv ${SURELOG_DIR}/third_party/tests/ariane/src/common_cells/src/unread.sv ${SURELOG_DIR}/third_party/tests/ariane/src/common_cells/src/sync.sv ${SURELOG_DIR}/third_party/tests/ariane/src/common_cells/src/cdc_2phase.sv ${SURELOG_DIR}/third_party/tests/ariane/src/common_cells/src/spill_register.sv ${SURELOG_DIR}/third_party/tests/ariane/src/common_cells/src/sync_wedge.sv ${SURELOG_DIR}/third_party/tests/ariane/src/common_cells/src/edge_detect.sv ${SURELOG_DIR}/third_party/tests/ariane/src/common_cells/src/stream_arbiter.sv ${SURELOG_DIR}/third_party/tests/ariane/src/common_cells/src/stream_arbiter_flushable.sv ${SURELOG_DIR}/third_party/tests/ariane/src/common_cells/src/deprecated/fifo_v1.sv ${SURELOG_DIR}/third_party/tests/ariane/src/common_cells/src/deprecated/fifo_v2.sv ${SURELOG_DIR}/third_party/tests/ariane/src/common_cells/src/fifo_v3.sv ${SURELOG_DIR}/third_party/tests/ariane/src/common_cells/src/lzc.sv ${SURELOG_DIR}/third_party/tests/ariane/src/common_cells/src/popcount.sv ${SURELOG_DIR}/third_party/tests/ariane/src/common_cells/src/rr_arb_tree.sv ${SURELOG_DIR}/third_party/tests/ariane/src/common_cells/src/deprecated/rrarbiter.sv ${SURELOG_DIR}/third_party/tests/ariane/src/common_cells/src/stream_delay.sv ${SURELOG_DIR}/third_party/tests/ariane/src/common_cells/src/lfsr_8bit.sv ${SURELOG_DIR}/third_party/tests/ariane/src/common_cells/src/lfsr_16bit.sv ${SURELOG_DIR}/third_party/tests/ariane/src/common_cells/src/counter.sv ${SURELOG_DIR}/third_party/tests/ariane/src/common_cells/src/shift_reg.sv ${SURELOG_DIR}/third_party/tests/ariane/src/tech_cells_generic/src/pulp_clock_gating.sv ${SURELOG_DIR}/third_party/tests/ariane/src/tech_cells_generic/src/cluster_clock_inverter.sv ${SURELOG_DIR}/third_party/tests/ariane/src/tech_cells_generic/src/pulp_clock_mux2.sv ${SURELOG_DIR}/third_party/tests/ariane/tb/ariane_testharness.sv ${SURELOG_DIR}/third_party/tests/ariane/tb/ariane_peripherals.sv ${SURELOG_DIR}/third_party/tests/ariane/tb/common/uart.sv ${SURELOG_DIR}/third_party/tests/ariane/tb/common/SimDTM.sv ${SURELOG_DIR}/third_party/tests/ariane/tb/common/SimJTAG.sv +define+WT_DCACHE src/util/sram.sv +incdir+src/axi_node  --unroll-count 256 -Werror-PINMISSING -Werror-IMPLICIT -Wno-fatal -Wno-PINCONNECTEMPTY -Wno-ASSIGNDLY -Wno-DECLFILENAME -Wno-UNUSED -Wno-UNOPTFLAT -Wno-BLKANDNBLK -Wno-style   -LDFLAGS "-Lblah/lib -Wl,-rpath,blah/lib -lfesvr -lpthread" -CFLAGS "" -Wall --cc  --vpi  +incdir+src/common_cells/include/ --top-module ariane_testharness --Mdir work-ver -O3 --exe tb/ariane_tb.cpp tb/dpi/SimDTM.cc tb/dpi/SimJTAG.cc tb/dpi/remote_bitbang.cc tb/dpi/msim_helper.cc
 [INF:CM0023] Creating log file work-ver/slpp_all/surelog.log.
 
 [WRN:CM0010] Command line argument "--unroll-count" ignored.
@@ -74,23 +74,21 @@ ${SURELOG_DIR}/build/bin/surelog -sverilog -parse -d coveruhdm -verbose -timesca
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpu_div_sqrt_mvp/hdl/defs_div_sqrt_mvp.sv".
 
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/ariane.sv".
+
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/serdiv.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/ariane_regfile_ff.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/amo_buffer.sv".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/id_stage.sv".
-
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/branch_unit.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/mmu.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/controller.sv".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/issue_stage.sv".
-
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/re_name.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/ariane.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/csr_buffer.sv".
 
@@ -98,25 +96,21 @@ ${SURELOG_DIR}/build/bin/surelog -sverilog -parse -d coveruhdm -verbose -timesca
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/decoder.sv".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/ex_stage.sv".
-
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/scoreboard.sv".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/mmu.sv".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/perf_counters.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/store_unit.sv".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/mult.sv".
-
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/axi_adapter.sv".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/fpu_wrap.sv".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/issue_stage.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/commit_stage.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/load_store_unit.sv".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/alu.sv".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/id_stage.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/multiplier.sv".
 
@@ -126,11 +120,17 @@ ${SURELOG_DIR}/build/bin/surelog -sverilog -parse -d coveruhdm -verbose -timesca
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/axi_shim.sv".
 
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/alu.sv".
+
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/instr_realign.sv".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/perf_counters.sv".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/ex_stage.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/ptw.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/mult.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/fpu_wrap.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/csr_regfile.sv".
 
@@ -144,8 +144,6 @@ ${SURELOG_DIR}/build/bin/surelog -sverilog -parse -d coveruhdm -verbose -timesca
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_opgroup_fmt_slice.sv".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_top.sv".
-
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_divsqrt_multi.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv".
@@ -153,6 +151,8 @@ ${SURELOG_DIR}/build/bin/surelog -sverilog -parse -d coveruhdm -verbose -timesca
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_opgroup_multifmt_slice.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_classifier.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_top.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv".
 
@@ -202,13 +202,13 @@ ${SURELOG_DIR}/build/bin/surelog -sverilog -parse -d coveruhdm -verbose -timesca
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/cache_subsystem/miss_handler.sv".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/cache_subsystem/wt_cache_subsystem.sv".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/cache_subsystem/std_cache_subsystem.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/cache_subsystem/wt_dcache_missunit.sv".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/cache_subsystem/wt_icache.sv".
-
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/cache_subsystem/std_icache.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/cache_subsystem/wt_icache.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/cache_subsystem/wt_dcache_wbuffer.sv".
 
@@ -216,7 +216,7 @@ ${SURELOG_DIR}/build/bin/surelog -sverilog -parse -d coveruhdm -verbose -timesca
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/cache_subsystem/wt_dcache_mem.sv".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/cache_subsystem/std_cache_subsystem.sv".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/cache_subsystem/wt_cache_subsystem.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/cache_subsystem/wt_dcache.sv".
 
@@ -246,7 +246,7 @@ ${SURELOG_DIR}/build/bin/surelog -sverilog -parse -d coveruhdm -verbose -timesca
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/fpga/src/axi_slice/src/axi_w_buffer.sv".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/fpga/src/axi_slice/src/axi_b_buffer.sv".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/fpga/src/axi_slice/src/axi_r_buffer.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/fpga/src/axi_slice/src/axi_slice_wrap.sv".
 
@@ -256,7 +256,7 @@ ${SURELOG_DIR}/build/bin/surelog -sverilog -parse -d coveruhdm -verbose -timesca
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/fpga/src/axi_slice/src/axi_ar_buffer.sv".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/fpga/src/axi_slice/src/axi_r_buffer.sv".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/fpga/src/axi_slice/src/axi_b_buffer.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/fpga/src/axi_slice/src/axi_aw_buffer.sv".
 
@@ -462,23 +462,21 @@ ${SURELOG_DIR}/build/bin/surelog -sverilog -parse -d coveruhdm -verbose -timesca
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpu_div_sqrt_mvp/hdl/defs_div_sqrt_mvp.sv".
 
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/ariane.sv".
+
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/serdiv.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/ariane_regfile_ff.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/amo_buffer.sv".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/id_stage.sv".
-
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/branch_unit.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/mmu.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/controller.sv".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/issue_stage.sv".
-
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/re_name.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/ariane.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/csr_buffer.sv".
 
@@ -486,25 +484,21 @@ ${SURELOG_DIR}/build/bin/surelog -sverilog -parse -d coveruhdm -verbose -timesca
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/decoder.sv".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/ex_stage.sv".
-
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/scoreboard.sv".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/mmu.sv".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/perf_counters.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/store_unit.sv".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/mult.sv".
-
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/axi_adapter.sv".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/fpu_wrap.sv".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/issue_stage.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/commit_stage.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/load_store_unit.sv".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/alu.sv".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/id_stage.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/multiplier.sv".
 
@@ -514,11 +508,17 @@ ${SURELOG_DIR}/build/bin/surelog -sverilog -parse -d coveruhdm -verbose -timesca
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/axi_shim.sv".
 
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/alu.sv".
+
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/instr_realign.sv".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/perf_counters.sv".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/ex_stage.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/ptw.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/mult.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/fpu_wrap.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/csr_regfile.sv".
 
@@ -530,8 +530,6 @@ ${SURELOG_DIR}/build/bin/surelog -sverilog -parse -d coveruhdm -verbose -timesca
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_opgroup_fmt_slice.sv".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_top.sv".
-
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_divsqrt_multi.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv".
@@ -539,6 +537,8 @@ ${SURELOG_DIR}/build/bin/surelog -sverilog -parse -d coveruhdm -verbose -timesca
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_opgroup_multifmt_slice.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_classifier.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_top.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv".
 
@@ -588,13 +588,13 @@ ${SURELOG_DIR}/build/bin/surelog -sverilog -parse -d coveruhdm -verbose -timesca
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/cache_subsystem/miss_handler.sv".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/cache_subsystem/wt_cache_subsystem.sv".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/cache_subsystem/std_cache_subsystem.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/cache_subsystem/wt_dcache_missunit.sv".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/cache_subsystem/wt_icache.sv".
-
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/cache_subsystem/std_icache.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/cache_subsystem/wt_icache.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/cache_subsystem/wt_dcache_wbuffer.sv".
 
@@ -602,7 +602,7 @@ ${SURELOG_DIR}/build/bin/surelog -sverilog -parse -d coveruhdm -verbose -timesca
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/cache_subsystem/wt_dcache_mem.sv".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/cache_subsystem/std_cache_subsystem.sv".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/cache_subsystem/wt_cache_subsystem.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/cache_subsystem/wt_dcache.sv".
 
@@ -620,7 +620,7 @@ ${SURELOG_DIR}/build/bin/surelog -sverilog -parse -d coveruhdm -verbose -timesca
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/fpga/src/axi_slice/src/axi_w_buffer.sv".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/fpga/src/axi_slice/src/axi_b_buffer.sv".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/fpga/src/axi_slice/src/axi_r_buffer.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/fpga/src/axi_slice/src/axi_slice_wrap.sv".
 
@@ -630,7 +630,7 @@ ${SURELOG_DIR}/build/bin/surelog -sverilog -parse -d coveruhdm -verbose -timesca
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/fpga/src/axi_slice/src/axi_ar_buffer.sv".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/fpga/src/axi_slice/src/axi_r_buffer.sv".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/fpga/src/axi_slice/src/axi_b_buffer.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/fpga/src/axi_slice/src/axi_aw_buffer.sv".
 
@@ -3831,29 +3831,29 @@ there are 1 more instances of this message.
 UHDM HTML COVERAGE REPORT: work-ver/slpp_all//surelog.uhdm.chk.html
 [ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/ariane.sv:743: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:207: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:206: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_opgroup_multifmt_slice.sv:127: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:209: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:127: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:210: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_cast_multi.sv:206: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_opgroup_multifmt_slice.sv:127: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_divsqrt_multi.sv:126: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:206: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:207: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:209: UHDM coverage pointing to empty source line.
+[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_cast_multi.sv:206: UHDM coverage pointing to empty source line.
 
 [  FATAL] : 0
 [ SYNTAX] : 0
 [  ERROR] : 11
 [WARNING] : 21
 [   NOTE] : 18
-cd work-ver && make -j -f Variane_testharness.mk
-make[1]: Entering directory '${SURELOG_DIR}/third_party/tests/ariane/work-ver'
-make[1]: Leaving directory '${SURELOG_DIR}/third_party/tests/ariane/work-ver'
+make[5]: Entering directory '${SURELOG_DIR}/third_party/tests/ariane/work-ver'
+make[5]: Leaving directory '${SURELOG_DIR}/third_party/tests/ariane/work-ver'
 Makefile:398: recipe for target 'verilate' failed
+make[4]: Leaving directory '${SURELOG_DIR}/third_party/tests/ariane'
 


### PR DESCRIPTION
This change brings some regularization on parameter in the elaborated model.

Parameters are now uniquified (One UHDM object per parameter in the hierarchy).

Parameters that do not have default values get assigned values  during instantiation and the parameter->VpiValue() returns their value.

Parameters that do have default values are also modeled with a param_assign object.
The param_assign object lhs points to the uniquified parameter, the rhs holds the value of the parameter. In the case of simple scalar value, the paramter->VpiValue() holds the scalar value too. In the case of multidimensional or complex struct init values, only the param_assign->Rhs() expression holds the value.

