### PR TITLE
Fix for Paramater Verilator limitation

### DIFF
--- a/tests/ParamComplexVerilator/ParamComplexVerilator.log
+++ b/tests/ParamComplexVerilator/ParamComplexVerilator.log
@@ -1,0 +1,789 @@
+[INF:CM0023] Creating log file ../../build/tests/ParamComplexVerilator/slpp_all/surelog.log.
+
+LIB:  work
+FILE: dut.sv
+n<> u<0> t<Null_rule> p<175> s<174> l<1>
+n<pkg> u<1> t<StringConst> p<36> s<34> l<1>
+n<> u<2> t<Struct_keyword> p<3> l<2>
+n<> u<3> t<Struct_union> p<29> c<2> s<4> l<2>
+n<> u<4> t<Packed_keyword> p<29> s<11> l<2>
+n<> u<5> t<IntVec_TypeLogic> p<6> l<3>
+n<> u<6> t<Data_type> p<7> c<5> l<3>
+n<> u<7> t<Data_type_or_void> p<11> c<6> s<10> l<3>
+n<a> u<8> t<StringConst> p<9> l<3>
+n<> u<9> t<Variable_decl_assignment> p<10> c<8> l<3>
+n<> u<10> t<List_of_variable_decl_assignments> p<11> c<9> l<3>
+n<> u<11> t<Struct_union_member> p<29> c<7> s<28> l<3>
+n<> u<12> t<IntVec_TypeLogic> p<23> s<22> l<4>
+n<2> u<13> t<IntConst> p<14> l<4>
+n<> u<14> t<Primary_literal> p<15> c<13> l<4>
+n<> u<15> t<Constant_primary> p<16> c<14> l<4>
+n<> u<16> t<Constant_expression> p<21> c<15> s<20> l<4>
+n<0> u<17> t<IntConst> p<18> l<4>
+n<> u<18> t<Primary_literal> p<19> c<17> l<4>
+n<> u<19> t<Constant_primary> p<20> c<18> l<4>
+n<> u<20> t<Constant_expression> p<21> c<19> l<4>
+n<> u<21> t<Constant_range> p<22> c<16> l<4>
+n<> u<22> t<Packed_dimension> p<23> c<21> l<4>
+n<> u<23> t<Data_type> p<24> c<12> l<4>
+n<> u<24> t<Data_type_or_void> p<28> c<23> s<27> l<4>
+n<b> u<25> t<StringConst> p<26> l<4>
+n<> u<26> t<Variable_decl_assignment> p<27> c<25> l<4>
+n<> u<27> t<List_of_variable_decl_assignments> p<28> c<26> l<4>
+n<> u<28> t<Struct_union_member> p<29> c<24> l<4>
+n<> u<29> t<Data_type> p<31> c<3> s<30> l<2>
+n<complex_t> u<30> t<StringConst> p<31> l<5>
+n<> u<31> t<Type_declaration> p<32> c<29> l<2>
+n<> u<32> t<Data_declaration> p<33> c<31> l<2>
+n<> u<33> t<Package_or_generate_item_declaration> p<34> c<32> l<2>
+n<> u<34> t<Package_item> p<36> c<33> s<35> l<2>
+n<> u<35> t<Endpackage> p<36> l<6>
+n<> u<36> t<Package_declaration> p<37> c<1> l<1>
+n<> u<37> t<Description> p<174> c<36> s<121> l<1>
+n<> u<38> t<Module_keyword> p<42> s<39> l<9>
+n<top> u<39> t<StringConst> p<42> s<41> l<9>
+n<> u<40> t<Port> p<41> l<9>
+n<> u<41> t<List_of_ports> p<42> c<40> l<9>
+n<> u<42> t<Module_nonansi_header> p<120> c<38> s<77> l<9>
+n<pkg> u<43> t<StringConst> p<44> l<10>
+n<> u<44> t<Class_type> p<45> c<43> l<10>
+n<> u<45> t<Class_scope> p<47> c<44> s<46> l<10>
+n<complex_t> u<46> t<StringConst> p<47> l<10>
+n<> u<47> t<Data_type> p<48> c<45> l<10>
+n<> u<48> t<Data_type_or_implicit> p<71> c<47> s<70> l<10>
+n<init_val> u<49> t<StringConst> p<69> s<68> l<10>
+n<a> u<50> t<StringConst> p<51> l<10>
+n<> u<51> t<Structure_pattern_key> p<62> c<50> s<55> l<10>
+n<> u<52> t<Number_1Tickb0> p<53> l<10>
+n<> u<53> t<Primary_literal> p<54> c<52> l<10>
+n<> u<54> t<Primary> p<55> c<53> l<10>
+n<> u<55> t<Expression> p<62> c<54> s<57> l<10>
+n<b> u<56> t<StringConst> p<57> l<10>
+n<> u<57> t<Structure_pattern_key> p<62> c<56> s<61> l<10>
+n<> u<58> t<Number_Tick1> p<59> l<10>
+n<> u<59> t<Primary_literal> p<60> c<58> l<10>
+n<> u<60> t<Primary> p<61> c<59> l<10>
+n<> u<61> t<Expression> p<62> c<60> l<10>
+n<> u<62> t<Assignment_pattern> p<63> c<51> l<10>
+n<> u<63> t<Assignment_pattern_expression> p<64> c<62> l<10>
+n<> u<64> t<Constant_assignment_pattern_expression> p<65> c<63> l<10>
+n<> u<65> t<Constant_primary> p<66> c<64> l<10>
+n<> u<66> t<Constant_expression> p<67> c<65> l<10>
+n<> u<67> t<Constant_mintypmax_expression> p<68> c<66> l<10>
+n<> u<68> t<Constant_param_expression> p<69> c<67> l<10>
+n<> u<69> t<Param_assignment> p<70> c<49> l<10>
+n<> u<70> t<List_of_param_assignments> p<71> c<69> l<10>
+n<> u<71> t<Local_parameter_declaration> p<72> c<48> l<10>
+n<> u<72> t<Package_or_generate_item_declaration> p<73> c<71> l<10>
+n<> u<73> t<Module_or_generate_item_declaration> p<74> c<72> l<10>
+n<> u<74> t<Module_common_item> p<75> c<73> l<10>
+n<> u<75> t<Module_or_generate_item> p<76> c<74> l<10>
+n<> u<76> t<Non_port_module_item> p<77> c<75> l<10>
+n<> u<77> t<Module_item> p<120> c<76> s<119> l<10>
+n<dut> u<78> t<StringConst> p<116> s<110> l<11>
+n<size> u<79> t<StringConst> p<97> s<96> l<12>
+n<> u<80> t<Dollar_keyword> p<92> s<81> l<12>
+n<bits> u<81> t<StringConst> p<92> s<91> l<12>
+n<pkg> u<82> t<StringConst> p<83> l<12>
+n<> u<83> t<Class_type> p<84> c<82> l<12>
+n<> u<84> t<Class_scope> p<88> c<83> s<85> l<12>
+n<complex_t> u<85> t<StringConst> p<88> s<87> l<12>
+n<> u<86> t<Bit_select> p<87> l<12>
+n<> u<87> t<Select> p<88> c<86> l<12>
+n<> u<88> t<Complex_func_call> p<89> c<84> l<12>
+n<> u<89> t<Primary> p<90> c<88> l<12>
+n<> u<90> t<Expression> p<91> c<89> l<12>
+n<> u<91> t<List_of_arguments> p<92> c<90> l<12>
+n<> u<92> t<Complex_func_call> p<93> c<80> l<12>
+n<> u<93> t<Primary> p<94> c<92> l<12>
+n<> u<94> t<Expression> p<95> c<93> l<12>
+n<> u<95> t<Mintypmax_expression> p<96> c<94> l<12>
+n<> u<96> t<Param_expression> p<97> c<95> l<12>
+n<> u<97> t<Named_parameter_assignment> p<109> c<79> s<108> l<12>
+n<init> u<98> t<StringConst> p<108> s<107> l<13>
+n<init_val> u<99> t<StringConst> p<100> l<13>
+n<> u<100> t<Primary_literal> p<101> c<99> l<13>
+n<> u<101> t<Primary> p<102> c<100> l<13>
+n<> u<102> t<Expression> p<103> c<101> l<13>
+n<> u<103> t<Concatenation> p<104> c<102> l<13>
+n<> u<104> t<Primary> p<105> c<103> l<13>
+n<> u<105> t<Expression> p<106> c<104> l<13>
+n<> u<106> t<Mintypmax_expression> p<107> c<105> l<13>
+n<> u<107> t<Param_expression> p<108> c<106> l<13>
+n<> u<108> t<Named_parameter_assignment> p<109> c<98> l<13>
+n<> u<109> t<List_of_parameter_assignments> p<110> c<97> l<12>
+n<> u<110> t<Parameter_value_assignment> p<116> c<109> s<115> l<11>
+n<asgn0> u<111> t<StringConst> p<112> l<14>
+n<> u<112> t<Name_of_instance> p<115> c<111> s<114> l<14>
+n<> u<113> t<Ordered_port_connection> p<114> l<14>
+n<> u<114> t<List_of_port_connections> p<115> c<113> l<14>
+n<> u<115> t<Hierarchical_instance> p<116> c<112> l<14>
+n<> u<116> t<Module_instantiation> p<117> c<78> l<11>
+n<> u<117> t<Module_or_generate_item> p<118> c<116> l<11>
+n<> u<118> t<Non_port_module_item> p<119> c<117> l<11>
+n<> u<119> t<Module_item> p<120> c<118> l<11>
+n<> u<120> t<Module_declaration> p<121> c<42> l<9>
+n<> u<121> t<Description> p<174> c<120> s<173> l<9>
+n<> u<122> t<Module_keyword> p<171> s<123> l<17>
+n<dut> u<123> t<StringConst> p<171> s<168> l<17>
+n<> u<124> t<IntegerAtomType_Int> p<125> l<18>
+n<> u<125> t<Data_type> p<126> c<124> l<18>
+n<> u<126> t<Data_type_or_implicit> p<136> c<125> s<135> l<18>
+n<size> u<127> t<StringConst> p<134> s<133> l<18>
+n<0> u<128> t<IntConst> p<129> l<18>
+n<> u<129> t<Primary_literal> p<130> c<128> l<18>
+n<> u<130> t<Constant_primary> p<131> c<129> l<18>
+n<> u<131> t<Constant_expression> p<132> c<130> l<18>
+n<> u<132> t<Constant_mintypmax_expression> p<133> c<131> l<18>
+n<> u<133> t<Constant_param_expression> p<134> c<132> l<18>
+n<> u<134> t<Param_assignment> p<135> c<127> l<18>
+n<> u<135> t<List_of_param_assignments> p<136> c<134> l<18>
+n<> u<136> t<Parameter_declaration> p<137> c<126> l<18>
+n<> u<137> t<Parameter_port_declaration> p<168> c<136> s<167> l<18>
+n<> u<138> t<IntVec_TypeBit> p<155> s<154> l<19>
+n<size> u<139> t<StringConst> p<140> l<19>
+n<> u<140> t<Primary_literal> p<141> c<139> l<19>
+n<> u<141> t<Constant_primary> p<142> c<140> l<19>
+n<> u<142> t<Constant_expression> p<148> c<141> s<147> l<19>
+n<1> u<143> t<IntConst> p<144> l<19>
+n<> u<144> t<Primary_literal> p<145> c<143> l<19>
+n<> u<145> t<Constant_primary> p<146> c<144> l<19>
+n<> u<146> t<Constant_expression> p<148> c<145> l<19>
+n<> u<147> t<BinOp_Minus> p<148> s<146> l<19>
+n<> u<148> t<Constant_expression> p<153> c<142> s<152> l<19>
+n<0> u<149> t<IntConst> p<150> l<19>
+n<> u<150> t<Primary_literal> p<151> c<149> l<19>
+n<> u<151> t<Constant_primary> p<152> c<150> l<19>
+n<> u<152> t<Constant_expression> p<153> c<151> l<19>
+n<> u<153> t<Constant_range> p<154> c<148> l<19>
+n<> u<154> t<Packed_dimension> p<155> c<153> l<19>
+n<> u<155> t<Data_type> p<156> c<138> l<19>
+n<> u<156> t<Data_type_or_implicit> p<166> c<155> s<165> l<19>
+n<init> u<157> t<StringConst> p<164> s<163> l<19>
+n<> u<158> t<Number_Tick0> p<159> l<19>
+n<> u<159> t<Primary_literal> p<160> c<158> l<19>
+n<> u<160> t<Constant_primary> p<161> c<159> l<19>
+n<> u<161> t<Constant_expression> p<162> c<160> l<19>
+n<> u<162> t<Constant_mintypmax_expression> p<163> c<161> l<19>
+n<> u<163> t<Constant_param_expression> p<164> c<162> l<19>
+n<> u<164> t<Param_assignment> p<165> c<157> l<19>
+n<> u<165> t<List_of_param_assignments> p<166> c<164> l<19>
+n<> u<166> t<Parameter_declaration> p<167> c<156> l<19>
+n<> u<167> t<Parameter_port_declaration> p<168> c<166> l<19>
+n<> u<168> t<Parameter_port_list> p<171> c<137> s<170> l<17>
+n<> u<169> t<Port> p<170> l<20>
+n<> u<170> t<List_of_ports> p<171> c<169> l<20>
+n<> u<171> t<Module_nonansi_header> p<172> c<122> l<17>
+n<> u<172> t<Module_declaration> p<173> c<171> l<17>
+n<> u<173> t<Description> p<174> c<172> l<17>
+n<> u<174> t<Source_text> p<175> c<37> l<1>
+n<> u<175> t<Top_level_rule> l<1>
+[WRN:PA0205] dut.sv:1: No timescale set for "pkg".
+
+[WRN:PA0205] dut.sv:9: No timescale set for "top".
+
+[WRN:PA0205] dut.sv:17: No timescale set for "dut".
+
+[INF:CP0300] Compilation...
+
+[INF:CP0301] dut.sv:1: Compile package "pkg".
+
+[INF:CP0303] dut.sv:17: Compile module "work@dut".
+
+[INF:CP0303] dut.sv:9: Compile module "work@top".
+
+[INF:CP0302] builtin.sv:4: Compile class "work@mailbox".
+
+[INF:CP0302] builtin.sv:33: Compile class "work@process".
+
+[INF:CP0302] builtin.sv:58: Compile class "work@semaphore".
+
+[INF:EL0526] Design Elaboration...
+
+[NTE:EL0503] dut.sv:9: Top level module "work@top".
+
+[NTE:EL0508] Nb Top level modules: 1.
+
+[NTE:EL0509] Max instance depth: 2.
+
+[NTE:EL0510] Nb instances: 2.
+
+[NTE:EL0511] Nb leaf instances: 1.
+
+UHDM HTML COVERAGE REPORT: ../../build/tests/ParamComplexVerilator/slpp_all//surelog.uhdm.chk.html
+====== UHDM =======
+design: (work@top)
+|vpiName:work@top
+|uhdmallPackages:
+\_package: builtin (builtin), parent:work@top
+  |vpiDefName:builtin
+  |vpiFullName:builtin
+  |vpiClassDefn:
+  \_class_defn: (builtin::array), parent:builtin
+    |vpiName:array
+    |vpiFullName:builtin::array
+  |vpiClassDefn:
+  \_class_defn: (builtin::queue), parent:builtin
+    |vpiName:queue
+    |vpiFullName:builtin::queue
+  |vpiClassDefn:
+  \_class_defn: (builtin::string), parent:builtin
+    |vpiName:string
+    |vpiFullName:builtin::string
+  |vpiClassDefn:
+  \_class_defn: (builtin::system), parent:builtin
+    |vpiName:system
+    |vpiFullName:builtin::system
+|uhdmallPackages:
+\_package: pkg (pkg) dut.sv:1: , parent:work@top
+  |vpiDefName:pkg
+  |vpiFullName:pkg
+  |vpiTypedef:
+  \_struct_typespec: (complex_t), line:2, parent:work@top.init_val
+    |vpiPacked:1
+    |vpiName:complex_t
+    |vpiTypespecMember:
+    \_typespec_member: (a), line:3
+      |vpiName:a
+      |vpiTypespec:
+      \_logic_typespec: , line:3
+    |vpiTypespecMember:
+    \_typespec_member: (b), line:4
+      |vpiName:b
+      |vpiTypespec:
+      \_logic_typespec: , line:4
+        |vpiRange:
+        \_range: , line:4, parent:complex_t
+          |vpiLeftRange:
+          \_constant: , line:4
+            |vpiConstType:7
+            |vpiDecompile:2
+            |vpiSize:32
+            |INT:2
+          |vpiRightRange:
+          \_constant: , line:4
+            |vpiConstType:7
+            |vpiDecompile:0
+            |vpiSize:32
+            |INT:0
+|uhdmallClasses:
+\_class_defn: (work@mailbox) ${SURELOG_DIR}/build/bin/sv/builtin.sv:4: , parent:work@top
+  |vpiName:work@mailbox
+  |vpiMethod:
+  \_function: (work@mailbox::new), line:6, parent:work@mailbox
+    |vpiMethod:1
+    |vpiName:new
+    |vpiFullName:work@mailbox::new
+    |vpiReturn:
+    \_class_var: 
+      |vpiTypespec:
+      \_class_typespec: 
+        |vpiClassDefn:
+        \_class_defn: (work@mailbox) ${SURELOG_DIR}/build/bin/sv/builtin.sv:4: , parent:work@top
+    |vpiIODecl:
+    \_io_decl: (bound), parent:work@mailbox::new
+      |vpiName:bound
+      |vpiDirection:5
+      |vpiExpr:
+      \_int_var: (work@mailbox::new::bound), line:6, parent:bound
+        |vpiFullName:work@mailbox::new::bound
+  |vpiMethod:
+  \_function: (work@mailbox::num), line:9, parent:work@mailbox
+    |vpiMethod:1
+    |vpiVisibility:1
+    |vpiName:num
+    |vpiFullName:work@mailbox::num
+    |vpiReturn:
+    \_int_var: , line:9
+  |vpiMethod:
+  \_task: (work@mailbox::put), line:12, parent:work@mailbox
+    |vpiMethod:1
+    |vpiVisibility:1
+    |vpiName:put
+    |vpiFullName:work@mailbox::put
+    |vpiIODecl:
+    \_io_decl: (message), parent:work@mailbox::put
+      |vpiName:message
+      |vpiDirection:5
+  |vpiMethod:
+  \_function: (work@mailbox::try_put), line:15, parent:work@mailbox
+    |vpiMethod:1
+    |vpiVisibility:1
+    |vpiName:try_put
+    |vpiFullName:work@mailbox::try_put
+    |vpiIODecl:
+    \_io_decl: (message), parent:work@mailbox::try_put
+      |vpiName:message
+      |vpiDirection:5
+  |vpiMethod:
+  \_task: (work@mailbox::get), line:18, parent:work@mailbox
+    |vpiMethod:1
+    |vpiVisibility:1
+    |vpiName:get
+    |vpiFullName:work@mailbox::get
+    |vpiIODecl:
+    \_io_decl: (message), parent:work@mailbox::get
+      |vpiName:message
+      |vpiDirection:6
+  |vpiMethod:
+  \_function: (work@mailbox::try_get), line:21, parent:work@mailbox
+    |vpiMethod:1
+    |vpiVisibility:1
+    |vpiName:try_get
+    |vpiFullName:work@mailbox::try_get
+    |vpiReturn:
+    \_int_var: , line:21
+    |vpiIODecl:
+    \_io_decl: (message), parent:work@mailbox::try_get
+      |vpiName:message
+      |vpiDirection:6
+  |vpiMethod:
+  \_task: (work@mailbox::peek), line:24, parent:work@mailbox
+    |vpiMethod:1
+    |vpiVisibility:1
+    |vpiName:peek
+    |vpiFullName:work@mailbox::peek
+    |vpiIODecl:
+    \_io_decl: (message), parent:work@mailbox::peek
+      |vpiName:message
+      |vpiDirection:6
+  |vpiMethod:
+  \_function: (work@mailbox::try_peek), line:27, parent:work@mailbox
+    |vpiMethod:1
+    |vpiVisibility:1
+    |vpiName:try_peek
+    |vpiFullName:work@mailbox::try_peek
+    |vpiReturn:
+    \_int_var: , line:27
+    |vpiIODecl:
+    \_io_decl: (message), parent:work@mailbox::try_peek
+      |vpiName:message
+      |vpiDirection:6
+|uhdmallClasses:
+\_class_defn: (work@process) ${SURELOG_DIR}/build/bin/sv/builtin.sv:33: , parent:work@top
+  |vpiName:work@process
+  |vpiMethod:
+  \_function: (work@process::self), line:37, parent:work@process
+    |vpiMethod:1
+    |vpiVisibility:1
+    |vpiName:self
+    |vpiFullName:work@process::self
+    |vpiReturn:
+    \_chandle_var: , line:37
+  |vpiMethod:
+  \_function: (work@process::status), line:40, parent:work@process
+    |vpiMethod:1
+    |vpiVisibility:1
+    |vpiName:status
+    |vpiFullName:work@process::status
+    |vpiReturn:
+    \_chandle_var: , line:40
+  |vpiMethod:
+  \_task: (work@process::kill), line:43, parent:work@process
+    |vpiMethod:1
+    |vpiVisibility:1
+    |vpiName:kill
+    |vpiFullName:work@process::kill
+    |vpiStmt:
+    \_begin: (work@process::kill), parent:work@process::kill
+      |vpiFullName:work@process::kill
+  |vpiMethod:
+  \_task: (work@process::await), line:46, parent:work@process
+    |vpiMethod:1
+    |vpiVisibility:1
+    |vpiName:await
+    |vpiFullName:work@process::await
+    |vpiStmt:
+    \_begin: (work@process::await), parent:work@process::await
+      |vpiFullName:work@process::await
+  |vpiMethod:
+  \_task: (work@process::suspend), line:49, parent:work@process
+    |vpiMethod:1
+    |vpiVisibility:1
+    |vpiName:suspend
+    |vpiFullName:work@process::suspend
+    |vpiStmt:
+    \_begin: (work@process::suspend), parent:work@process::suspend
+      |vpiFullName:work@process::suspend
+  |vpiMethod:
+  \_task: (work@process::resume), line:52, parent:work@process
+    |vpiMethod:1
+    |vpiVisibility:1
+    |vpiName:resume
+    |vpiFullName:work@process::resume
+    |vpiStmt:
+    \_begin: (work@process::resume), parent:work@process::resume
+      |vpiFullName:work@process::resume
+  |vpiTypedef:
+  \_enum_typespec: (state), line:35, parent:work@process
+    |vpiName:state
+    |vpiEnumConst:
+    \_enum_const: (FINISHED), line:35, parent:state
+      |vpiName:FINISHED
+      |INT:0
+    |vpiEnumConst:
+    \_enum_const: (KILLED), line:35, parent:state
+      |vpiName:KILLED
+      |INT:4
+    |vpiEnumConst:
+    \_enum_const: (RUNNING), line:35, parent:state
+      |vpiName:RUNNING
+      |INT:1
+    |vpiEnumConst:
+    \_enum_const: (SUSPENDED), line:35, parent:state
+      |vpiName:SUSPENDED
+      |INT:3
+    |vpiEnumConst:
+    \_enum_const: (WAITING), line:35, parent:state
+      |vpiName:WAITING
+      |INT:2
+|uhdmallClasses:
+\_class_defn: (work@semaphore) ${SURELOG_DIR}/build/bin/sv/builtin.sv:58: , parent:work@top
+  |vpiName:work@semaphore
+  |vpiMethod:
+  \_function: (work@semaphore::new), line:60, parent:work@semaphore
+    |vpiMethod:1
+    |vpiName:new
+    |vpiFullName:work@semaphore::new
+    |vpiReturn:
+    \_class_var: 
+      |vpiTypespec:
+      \_class_typespec: 
+        |vpiClassDefn:
+        \_class_defn: (work@semaphore) ${SURELOG_DIR}/build/bin/sv/builtin.sv:58: , parent:work@top
+    |vpiIODecl:
+    \_io_decl: (keyCount), parent:work@semaphore::new
+      |vpiName:keyCount
+      |vpiDirection:5
+      |vpiExpr:
+      \_int_var: (work@semaphore::new::keyCount), line:60, parent:keyCount
+        |vpiFullName:work@semaphore::new::keyCount
+  |vpiMethod:
+  \_task: (work@semaphore::put), line:63, parent:work@semaphore
+    |vpiMethod:1
+    |vpiVisibility:1
+    |vpiName:put
+    |vpiFullName:work@semaphore::put
+    |vpiIODecl:
+    \_io_decl: (keyCount), parent:work@semaphore::put
+      |vpiName:keyCount
+      |vpiDirection:5
+      |vpiExpr:
+      \_int_var: (work@semaphore::put::keyCount), line:63, parent:keyCount
+        |vpiFullName:work@semaphore::put::keyCount
+  |vpiMethod:
+  \_task: (work@semaphore::get), line:66, parent:work@semaphore
+    |vpiMethod:1
+    |vpiVisibility:1
+    |vpiName:get
+    |vpiFullName:work@semaphore::get
+    |vpiIODecl:
+    \_io_decl: (keyCount), parent:work@semaphore::get
+      |vpiName:keyCount
+      |vpiDirection:5
+      |vpiExpr:
+      \_int_var: (work@semaphore::get::keyCount), line:66, parent:keyCount
+        |vpiFullName:work@semaphore::get::keyCount
+  |vpiMethod:
+  \_function: (work@semaphore::try_get), line:69, parent:work@semaphore
+    |vpiMethod:1
+    |vpiVisibility:1
+    |vpiName:try_get
+    |vpiFullName:work@semaphore::try_get
+    |vpiReturn:
+    \_int_var: , line:69
+    |vpiIODecl:
+    \_io_decl: (keyCount), parent:work@semaphore::try_get
+      |vpiName:keyCount
+      |vpiDirection:5
+      |vpiExpr:
+      \_int_var: (work@semaphore::try_get::keyCount), line:69, parent:keyCount
+        |vpiFullName:work@semaphore::try_get::keyCount
+|uhdmallModules:
+\_module: work@dut (work@dut) dut.sv:17: , parent:work@top
+  |vpiDefName:work@dut
+  |vpiFullName:work@dut
+  |vpiParamAssign:
+  \_param_assign: , line:18, parent:work@dut
+    |vpiRhs:
+    \_constant: , line:18
+      |vpiConstType:7
+      |vpiDecompile:0
+      |vpiSize:32
+      |INT:0
+    |vpiLhs:
+    \_parameter: (work@dut.size), line:18, parent:work@dut
+      |vpiName:size
+      |vpiFullName:work@dut.size
+      |vpiTypespec:
+      \_int_typespec: (size), line:18, parent:work@dut.size
+        |vpiName:size
+  |vpiParamAssign:
+  \_param_assign: , line:19, parent:work@dut
+    |vpiRhs:
+    \_constant: , line:19
+      |vpiConstType:3
+      |vpiDecompile:'b0
+      |BIN:0
+    |vpiLhs:
+    \_parameter: (work@dut.init), line:19, parent:work@dut
+      |vpiName:init
+      |vpiFullName:work@dut.init
+      |vpiTypespec:
+      \_bit_typespec: (init), line:19, parent:work@dut.init
+        |vpiName:init
+        |vpiRange:
+        \_range: , line:19
+          |vpiLeftRange:
+          \_operation: , line:19
+            |vpiOpType:11
+            |vpiOperand:
+            \_ref_obj: (size), line:19
+              |vpiName:size
+            |vpiOperand:
+            \_constant: , line:19
+              |vpiConstType:7
+              |vpiDecompile:1
+              |vpiSize:32
+              |INT:1
+          |vpiRightRange:
+          \_constant: , line:19
+            |vpiConstType:7
+            |vpiDecompile:0
+            |vpiSize:32
+            |INT:0
+  |vpiParameter:
+  \_parameter: (work@dut.size), line:18, parent:work@dut
+  |vpiParameter:
+  \_parameter: (work@dut.init), line:19, parent:work@dut
+|uhdmallModules:
+\_module: work@top (work@top) dut.sv:9: , parent:work@top
+  |vpiDefName:work@top
+  |vpiFullName:work@top
+  |vpiParamAssign:
+  \_param_assign: , line:10, parent:work@top
+    |vpiRhs:
+    \_operation: , line:10
+      |vpiOpType:75
+      |vpiOperand:
+      \_tagged_pattern: 
+        |vpiTypespec:
+        \_string_typespec: (a), line:10
+          |vpiName:a
+        |vpiPattern:
+        \_constant: , line:10
+          |vpiConstType:3
+          |vpiDecompile:1'b0
+          |vpiSize:1
+          |BIN:0
+      |vpiOperand:
+      \_tagged_pattern: 
+        |vpiTypespec:
+        \_string_typespec: (b), line:10
+          |vpiName:b
+        |vpiPattern:
+        \_constant: , line:10
+          |vpiConstType:3
+          |vpiDecompile:'b1
+          |BIN:1
+    |vpiLhs:
+    \_parameter: (work@top.init_val), line:10, parent:work@top
+      |vpiName:init_val
+      |vpiFullName:work@top.init_val
+      |vpiLocalParam:1
+      |vpiTypespec:
+      \_struct_typespec: (complex_t), line:2, parent:work@top.init_val
+        |vpiPacked:1
+        |vpiName:complex_t
+        |vpiTypespecMember:
+        \_typespec_member: (a), line:3, parent:complex_t
+          |vpiName:a
+          |vpiTypespec:
+          \_logic_typespec: , line:3, parent:a
+        |vpiTypespecMember:
+        \_typespec_member: (b), line:4, parent:complex_t
+          |vpiName:b
+          |vpiTypespec:
+          \_logic_typespec: , line:4, parent:b
+            |vpiRange:
+            \_range: , line:4
+              |vpiLeftRange:
+              \_constant: , line:4
+                |vpiConstType:7
+                |vpiDecompile:2
+                |vpiSize:32
+                |INT:2
+              |vpiRightRange:
+              \_constant: , line:4
+                |vpiConstType:7
+                |vpiDecompile:0
+                |vpiSize:32
+                |INT:0
+  |vpiParameter:
+  \_parameter: (work@top.init_val), line:10, parent:work@top
+    |vpiName:init_val
+    |vpiFullName:work@top.init_val
+    |vpiLocalParam:1
+    |vpiTypespec:
+    \_struct_typespec: (complex_t), line:2, parent:work@top.init_val
+      |vpiPacked:1
+      |vpiName:complex_t
+      |vpiTypespecMember:
+      \_typespec_member: (a), line:3
+        |vpiName:a
+        |vpiTypespec:
+        \_logic_typespec: , line:3
+      |vpiTypespecMember:
+      \_typespec_member: (b), line:4
+        |vpiName:b
+        |vpiTypespec:
+        \_logic_typespec: , line:4
+          |vpiRange:
+          \_range: , line:4, parent:complex_t
+            |vpiLeftRange:
+            \_constant: , line:4
+              |vpiConstType:7
+              |vpiDecompile:2
+              |vpiSize:32
+              |INT:2
+            |vpiRightRange:
+            \_constant: , line:4
+              |vpiConstType:7
+              |vpiDecompile:0
+              |vpiSize:32
+              |INT:0
+|uhdmtopModules:
+\_module: work@top (work@top) dut.sv:9: 
+  |vpiDefName:work@top
+  |vpiName:work@top
+  |vpiModule:
+  \_module: work@dut (work@top.asgn0) dut.sv:11: , parent:work@top
+    |vpiDefName:work@dut
+    |vpiName:asgn0
+    |vpiFullName:work@top.asgn0
+    |vpiInstance:
+    \_module: work@top (work@top) dut.sv:9: 
+    |vpiParamAssign:
+    \_param_assign: , line:18, parent:work@top.asgn0
+      |vpiRhs:
+      \_constant: , line:12
+        |vpiDecompile:4
+        |INT:4
+      |vpiLhs:
+      \_parameter: (work@top.asgn0.size), line:18, parent:work@top.asgn0
+        |vpiName:size
+        |vpiFullName:work@top.asgn0.size
+        |INT:4
+        |vpiTypespec:
+        \_int_typespec: (size), line:18, parent:work@top.asgn0.size
+          |vpiName:size
+    |vpiParamAssign:
+    \_param_assign: , line:19, parent:work@top.asgn0
+      |vpiRhs:
+      \_operation: , line:13
+        |vpiOpType:33
+        |vpiOperand:
+        \_ref_obj: (init_val), line:13
+          |vpiName:init_val
+          |vpiActual:
+          \_parameter: (work@top.init_val), line:10, parent:work@top
+            |vpiName:init_val
+            |vpiFullName:work@top.init_val
+            |vpiLocalParam:1
+            |vpiTypespec:
+            \_struct_typespec: (complex_t), line:2, parent:work@top.init_val
+              |vpiPacked:1
+              |vpiName:complex_t
+              |vpiTypespecMember:
+              \_typespec_member: (a), line:3, parent:complex_t
+                |vpiName:a
+                |vpiTypespec:
+                \_logic_typespec: , line:3, parent:a
+              |vpiTypespecMember:
+              \_typespec_member: (b), line:4, parent:complex_t
+                |vpiName:b
+                |vpiTypespec:
+                \_logic_typespec: , line:4, parent:b
+                  |vpiRange:
+                  \_range: , line:4
+                    |vpiLeftRange:
+                    \_constant: , line:4
+                      |vpiConstType:7
+                      |vpiDecompile:2
+                      |vpiSize:32
+                      |INT:2
+                    |vpiRightRange:
+                    \_constant: , line:4
+                      |vpiConstType:7
+                      |vpiDecompile:0
+                      |vpiSize:32
+                      |INT:0
+      |vpiLhs:
+      \_parameter: (work@top.asgn0.init), line:19, parent:work@top.asgn0
+        |vpiName:init
+        |vpiFullName:work@top.asgn0.init
+        |vpiTypespec:
+        \_bit_typespec: (init), line:19, parent:work@top.asgn0.init
+          |vpiName:init
+          |vpiRange:
+          \_range: , line:19, parent:init
+            |vpiLeftRange:
+            \_operation: , line:19
+              |vpiOpType:11
+              |vpiOperand:
+              \_ref_obj: (work@top.asgn0.init.init.size), line:19
+                |vpiName:size
+                |vpiFullName:work@top.asgn0.init.init.size
+              |vpiOperand:
+              \_constant: , line:19
+                |vpiConstType:7
+                |vpiDecompile:1
+                |vpiSize:32
+                |INT:1
+            |vpiRightRange:
+            \_constant: , line:19
+              |vpiConstType:7
+              |vpiDecompile:0
+              |vpiSize:32
+              |INT:0
+    |vpiParameter:
+    \_parameter: (work@top.asgn0.size), line:18, parent:work@top.asgn0
+    |vpiParameter:
+    \_parameter: (work@top.asgn0.init), line:19, parent:work@top.asgn0
+  |vpiParamAssign:
+  \_param_assign: , line:10, parent:work@top
+    |vpiRhs:
+    \_operation: , line:10
+      |vpiOpType:75
+      |vpiOperand:
+      \_tagged_pattern: 
+        |vpiTypespec:
+        \_string_typespec: (a), line:10
+          |vpiName:a
+        |vpiPattern:
+        \_constant: , line:10
+          |vpiConstType:3
+          |vpiDecompile:1'b0
+          |vpiSize:1
+          |BIN:0
+      |vpiOperand:
+      \_tagged_pattern: 
+        |vpiTypespec:
+        \_string_typespec: (b), line:10
+          |vpiName:b
+        |vpiPattern:
+        \_constant: , line:10
+          |vpiConstType:3
+          |vpiDecompile:'b1
+          |BIN:1
+    |vpiLhs:
+    \_parameter: (work@top.init_val), line:10, parent:work@top
+  |vpiParameter:
+  \_parameter: (work@top.init_val), line:10, parent:work@top
+===================
+[  FATAL] : 0
+[ SYNTAX] : 0
+[  ERROR] : 0
+[WARNING] : 3
+[   NOTE] : 5
+

--- a/tests/ParamComplexVerilator/ParamComplexVerilator.sl
+++ b/tests/ParamComplexVerilator/ParamComplexVerilator.sl
@@ -1,0 +1,1 @@
+-parse -d uhdm -d coveruhdm -elabuhdm -d ast -verilator dut.sv

--- a/tests/ParamComplexVerilator/dut.sv
+++ b/tests/ParamComplexVerilator/dut.sv
@@ -1,0 +1,22 @@
+package pkg;
+  typedef struct packed {
+    logic a;
+    logic [2:0] b;
+  } complex_t;
+endpackage
+
+
+module top ();
+   localparam pkg::complex_t init_val = '{a: 1'b0, b: '1};
+   dut #(
+       .size ($bits(pkg::complex_t)),
+       .init ({init_val})
+     ) asgn0();
+endmodule
+
+module dut #(
+    parameter int size = 0,
+    parameter bit [size-1:0] init = '0
+  ) ();
+
+endmodule // dut


### PR DESCRIPTION
Fixes #1013

@rkapuscik, please add -verilator to the Surelog command line or use the SURELOG::CommandLineParser API to set the VerilatorMode on.

This is a limitation for Verilator that I don't want to make default.
