### PR TITLE
Disable vpiAssignmentPatternOp assigned to parameters in yosys mode

### DIFF
--- a/src/DesignCompile/CompileExpression.cpp
+++ b/src/DesignCompile/CompileExpression.cpp
@@ -135,8 +135,11 @@ bool substituteAssignedValue(param_assign* param, CompileDesign* compileDesign) 
       bool verilatorMode = compileDesign->getCompiler()
                                ->getCommandLineParser()
                                ->getVerilatorMode();
-      if (verilatorMode) {
-        // Verilator does not support vpiAssignmentPatternOp assigned to
+      bool yosysMode = compileDesign->getCompiler()
+                               ->getCommandLineParser()
+                               ->getYosysMode();
+      if (verilatorMode || yosysMode) {
+        // Verilator and Yosys do not support vpiAssignmentPatternOp assigned to
         // parameters
         substitute = false;
       }


### PR DESCRIPTION
Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>