### PR TITLE
Add -noparametersubstitution parameter and remove -yosys/-verilator

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,6 @@ For more build/test options and system requirements for building see
    -nocomp               Turns off Compilation & Elaboration
    -noelab               Turns off Elaboration
    -elabuhdm             Forces UHDM/VPI Full Elaboration, default is the Folded Model
-   -verilator            Creates Verilator-friendly UHDM db (Fixes for Verilator limitations)
-   -yosys                Creates Yosys-friendly UHDM db (Fixes for Yosys limitations)
    -batch <batch.txt>    Runs all the tests specified in the file in batch mode. Tests are expressed as one full command line per line.
    -pythonlistener       Enables the Parser Python Listener
    -pythonlistenerfile <script.py> Specifies the AST python listener file
@@ -102,6 +100,21 @@ For more build/test options and system requirements for building see
    -timescale=<timescale> Specifies the overall timescale
    -nobuiltin            Do not parse SV builtin classes (array...)
 ```
+ * YOSYS AND VERILATOR FEATURES:
+   To enable feature:
+   ```
+   --enable-feature=<feature1>,<feature2>
+
+   ```
+   To disable feature:
+   ```
+   --disable-feature=<feature1>,<feature2>
+   ```
+   Possible features:
+   ```
+   parametersubstitution	Disables substitution of assignment patterns in parameters
+
+   ```
  * TRACES OPTIONS:
  ```
    -d <int>              Debug <level> 1-4, lib, ast, inst, incl, uhdm, coveruhdm

--- a/src/CommandLine/CommandLineParser.cpp
+++ b/src/CommandLine/CommandLineParser.cpp
@@ -117,8 +117,7 @@ const std::vector<std::string> helpText = {
     "  -top/--top-module <module> Top level module for elaboration (multiple cmds ok)",
     "  -batch <batch.txt>    Runs all the tests specified in the file in batch mode",
     "                        Tests are expressed as one full command line per line.",
-    "  -verilator            Creates Verilator-friendly UHDM db (Fixes for Verilator limitations)",
-    "  -yosys                Creates Yosys-friendly UHDM db (Fixes for Yosys limitations)",
+    "  -parametersubstitution Enables substitution of assignment patterns in parameters",
     "  -pythonlistener       Enables the Parser Python Listener",
     "  -pythonlistenerfile <script.py> Specifies the AST python listener file",
     "  -pythonevalscriptperfile <script.py>  Eval the Python script on each "
@@ -267,8 +266,7 @@ CommandLineParser::CommandLineParser(ErrorContainer* errors,
       m_parseOnly(false),
       m_compile(false),
       m_elaborate(false),
-      m_verilator(false),
-      m_yosys(false),
+      m_parametersubstitution(true),
       m_diff_comp_mode(diff_comp_mode),
       m_help(false),
       m_cacheAllowed(true),
@@ -588,6 +586,28 @@ bool CommandLineParser::parseCommandLine(int argc, const char** argv) {
           m_debugLevel = debugLevel;
         }
       }
+    } else if (strstr(all_arguments[i].c_str(), "--enable-feature=")) {
+      std::string features, tmp;
+      features = all_arguments[i].substr(17, std::string::npos);
+      std::istringstream f(features);
+      while (getline(f, tmp, ',')) {
+        if (tmp == "parametersubstitution") {
+          m_parametersubstitution = true;
+        } else {
+          std::cout << "Feature: " << tmp << " ignored." << std::endl;
+        }
+      }
+    } else if (strstr(all_arguments[i].c_str(), "--disable-feature=")) {
+      std::string features, tmp;
+      features = all_arguments[i].substr(18, std::string::npos);
+      std::istringstream f(features);
+      while (getline(f, tmp, ',')) {
+        if (tmp == "parametersubstitution") {
+          m_parametersubstitution = false;
+        } else {
+          std::cout << "Feature: " << tmp << " ignored." << std::endl;
+        }
+      }
     } else if (strstr(all_arguments[i].c_str(), "-timescale=")) {
       std::string timescale;
       timescale = all_arguments[i].substr(11, std::string::npos);
@@ -840,10 +860,6 @@ bool CommandLineParser::parseCommandLine(int argc, const char** argv) {
       m_compile = false;
       m_elaborate = false;
       m_parseOnly = true;
-    } else if (all_arguments[i] == "-verilator") {
-      m_verilator = true;
-    } else if (all_arguments[i] == "-yosys") {
-      m_yosys = true;
     } else if (all_arguments[i] == "-nocomp") {
       m_compile = false;
       m_elaborate = false;

--- a/src/CommandLine/CommandLineParser.h
+++ b/src/CommandLine/CommandLineParser.h
@@ -102,8 +102,7 @@ class CommandLineParser final {
   bool getDebugUhdm() { return m_dumpUhdm; }
   bool getElabUhdm() { return m_elabUhdm; }
   bool getCoverUhdm() { return m_coverUhdm; }
-  bool getVerilatorMode() { return m_verilator; }
-  bool getYosysMode() { return m_yosys; }
+  bool getParametersSubstitution() { return m_parametersubstitution; }
   bool showVpiIds() { return m_showVpiIDs; }
   bool getDebugInstanceTree() { return m_debugInstanceTree; }
   bool getDebugLibraryDef() { return m_debugLibraryDef; }
@@ -121,8 +120,7 @@ class CommandLineParser final {
   void setParseOnly(bool val) { m_parseOnly = val; }
   void setCompile(bool val) { m_compile = val; }
   void setElaborate(bool val) { m_elaborate = val; }
-  void setVerilatorMode(bool val) { m_verilator = val; }
-  void setYosysMode(bool val) { m_yosys = val; }
+  void setParametersSubstitution(bool val) { m_parametersubstitution = val; }
   bool pythonListener() { return m_pythonListener && m_pythonAllowed; }
   bool pythonAllowed() { return m_pythonAllowed; }
   void noPython() { m_pythonAllowed = false; }
@@ -205,8 +203,7 @@ class CommandLineParser final {
   bool m_parseOnly;
   bool m_compile;
   bool m_elaborate;
-  bool m_verilator;
-  bool m_yosys;
+  bool m_parametersubstitution;
   bool m_diff_comp_mode;
   bool m_help;
   bool m_cacheAllowed;

--- a/src/DesignCompile/CompileExpression.cpp
+++ b/src/DesignCompile/CompileExpression.cpp
@@ -974,14 +974,9 @@ bool substituteAssignedValue(param_assign* param, CompileDesign* compileDesign) 
     operation* op = (operation*)param->Rhs();
     int opType = op->VpiOpType();
     if (opType == vpiAssignmentPatternOp) {
-      bool verilatorMode = compileDesign->getCompiler()
-                               ->getCommandLineParser()
-                               ->getVerilatorMode();
-      if (verilatorMode) {
-        // Verilator does not support vpiAssignmentPatternOp assigned to
-        // parameters
-        substitute = false;
-      }
+      substitute = compileDesign->getCompiler()
+                                ->getCommandLineParser()
+                                ->getParametersSubstitution();
     }
   }
   return substitute;

--- a/tests/ParamComplexVerilator/ParamComplexVerilator.sl
+++ b/tests/ParamComplexVerilator/ParamComplexVerilator.sl
@@ -1,1 +1,1 @@
--parse -d uhdm -d coveruhdm -elabuhdm -d ast -verilator dut.sv
+-parse -d uhdm -d coveruhdm -elabuhdm -d ast --disable-feature=parametersubstitution dut.sv


### PR DESCRIPTION
This PR removes ``-yosys`` and ``-verilator`` parameters and instead introduces ``-noparametersubstitution``

CC: @tgorochowik