### PR TITLE
Make assignment operators blocking

### DIFF
--- a/src/DesignCompile/CompileHelper.cpp
+++ b/src/DesignCompile/CompileHelper.cpp
@@ -2328,13 +2328,16 @@ UHDM::assignment* CompileHelper::compileBlockingAssignment(DesignComponent* comp
   assignment* assign = s.MakeAssignment();
   UHDM::delay_control* delay_control = nullptr;
   if (Delay_or_event_control) {
-    delay_control = s.MakeDelay_control();
-    assign->Delay_control(delay_control);
-    delay_control->VpiParent(assign);
     NodeId Delay_control = fC->Child(Delay_or_event_control);
     NodeId IntConst = fC->Child(Delay_control);
     std::string value = fC->SymName(IntConst);
-    delay_control->VpiDelay(value);
+    if (value != "" && value != "@@BAD_SYMBOL@@") {
+      std::cout << "!*** Creating a delay with " << value << std::endl;
+      delay_control = s.MakeDelay_control();
+      delay_control->VpiParent(assign);
+      delay_control->VpiDelay(value);
+      assign->Delay_control(delay_control);
+    }
   }
   if (AssignOp_Assign)
     assign->VpiOpType(UhdmWriter::getVpiOpType(fC->Type(AssignOp_Assign)));

--- a/src/DesignCompile/CompileStmt.cpp
+++ b/src/DesignCompile/CompileStmt.cpp
@@ -91,14 +91,14 @@ VectorOfany* CompileHelper::compileStmt(
     stmt = dc;
     break;
   }
-  case VObjectType::slNonblocking_assignment:
-  case VObjectType::slOperator_assignment: {
+  case VObjectType::slNonblocking_assignment: {
     NodeId Operator_assignment  = the_stmt;
     UHDM::assignment* assign = compileBlockingAssignment(component, fC,
                 Operator_assignment, false, compileDesign, pstmt);
     stmt = assign;
     break;
   }
+  case VObjectType::slOperator_assignment:
   case VObjectType::slBlocking_assignment: {
     NodeId Operator_assignment = fC->Child(the_stmt);
     UHDM::assignment* assign = compileBlockingAssignment(component, fC,

--- a/tests/EvalFunc/EvalFunc.log
+++ b/tests/EvalFunc/EvalFunc.log
@@ -848,15 +848,16 @@ design: (work@top)
         |vpiForIncStmt:
         \_assignment: , line:6, parent:prim_util_pkg::_clog2
           |vpiOpType:82
+          |vpiBlocking:1
           |vpiLhs:
-          \_ref_obj: (prim_util_pkg::_clog2::result), line:6, parent:prim_util_pkg::_clog2
+          \_ref_obj: (prim_util_pkg::_clog2::result), line:6
             |vpiName:result
             |vpiFullName:prim_util_pkg::_clog2::result
           |vpiRhs:
-          \_operation: , line:6, parent:prim_util_pkg::_clog2
+          \_operation: , line:6
             |vpiOpType:24
             |vpiOperand:
-            \_ref_obj: (prim_util_pkg::_clog2::result), line:6, parent:prim_util_pkg::_clog2
+            \_ref_obj: (prim_util_pkg::_clog2::result), line:6
               |vpiName:result
               |vpiFullName:prim_util_pkg::_clog2::result
             |vpiOperand:
@@ -1366,15 +1367,16 @@ design: (work@top)
             |vpiForIncStmt:
             \_assignment: , line:43, parent:work@top.log2
               |vpiOpType:82
+              |vpiBlocking:1
               |vpiLhs:
-              \_ref_obj: (work@top.log2.res), line:43, parent:work@top.log2
+              \_ref_obj: (work@top.log2.res), line:43
                 |vpiName:res
                 |vpiFullName:work@top.log2.res
               |vpiRhs:
-              \_operation: , line:43, parent:work@top.log2
+              \_operation: , line:43
                 |vpiOpType:24
                 |vpiOperand:
-                \_ref_obj: (work@top.log2.res), line:43, parent:work@top.log2
+                \_ref_obj: (work@top.log2.res), line:43
                   |vpiName:res
                   |vpiFullName:work@top.log2.res
                 |vpiOperand:
@@ -1536,15 +1538,16 @@ design: (work@top)
             |vpiForIncStmt:
             \_assignment: , line:57, parent:work@top.log2_2
               |vpiOpType:82
+              |vpiBlocking:1
               |vpiLhs:
-              \_ref_obj: (work@top.log2_2.log2_2), line:57, parent:work@top.log2_2
+              \_ref_obj: (work@top.log2_2.log2_2), line:57
                 |vpiName:log2_2
                 |vpiFullName:work@top.log2_2.log2_2
               |vpiRhs:
-              \_operation: , line:57, parent:work@top.log2_2
+              \_operation: , line:57
                 |vpiOpType:24
                 |vpiOperand:
-                \_ref_obj: (work@top.log2_2.log2_2), line:57, parent:work@top.log2_2
+                \_ref_obj: (work@top.log2_2.log2_2), line:57
                   |vpiName:log2_2
                   |vpiFullName:work@top.log2_2.log2_2
                 |vpiOperand:
@@ -1872,6 +1875,7 @@ design: (work@top)
             |vpiForIncStmt:
             \_assignment: , line:43, parent:work@top.log2
               |vpiOpType:82
+              |vpiBlocking:1
               |vpiLhs:
               \_ref_obj: (work@top.log2.res), line:43
                 |vpiName:res
@@ -2057,6 +2061,7 @@ design: (work@top)
             |vpiForIncStmt:
             \_assignment: , line:57, parent:work@top.log2_2
               |vpiOpType:82
+              |vpiBlocking:1
               |vpiLhs:
               \_ref_obj: (work@top.log2_2.log2_2), line:57
                 |vpiName:log2_2

--- a/tests/EvalFuncPack/EvalFuncPack.log
+++ b/tests/EvalFuncPack/EvalFuncPack.log
@@ -794,15 +794,16 @@ design: (work@flash_ctrl_info_cfg)
         |vpiForIncStmt:
         \_assignment: , line:9, parent:prim_util_pkg::_clog2
           |vpiOpType:82
+          |vpiBlocking:1
           |vpiLhs:
-          \_ref_obj: (prim_util_pkg::_clog2::result), line:9, parent:prim_util_pkg::_clog2
+          \_ref_obj: (prim_util_pkg::_clog2::result), line:9
             |vpiName:result
             |vpiFullName:prim_util_pkg::_clog2::result
           |vpiRhs:
-          \_operation: , line:9, parent:prim_util_pkg::_clog2
+          \_operation: , line:9
             |vpiOpType:24
             |vpiOperand:
-            \_ref_obj: (prim_util_pkg::_clog2::result), line:9, parent:prim_util_pkg::_clog2
+            \_ref_obj: (prim_util_pkg::_clog2::result), line:9
               |vpiName:result
               |vpiFullName:prim_util_pkg::_clog2::result
             |vpiOperand:

--- a/tests/ForLoop/ForLoop.log
+++ b/tests/ForLoop/ForLoop.log
@@ -1115,25 +1115,18 @@ design: (work@t)
         |vpiForIncStmt:
         \_assignment: , line:7, parent:work@t
           |vpiOpType:82
+          |vpiBlocking:1
           |vpiLhs:
-          \_ref_obj: (work@t.a), line:7, parent:work@t
+          \_ref_obj: (work@t.a), line:7
             |vpiName:a
             |vpiFullName:work@t.a
-            |vpiActual:
-            \_int_var: (work@t.a), line:3, parent:work@t
-              |vpiName:a
-              |vpiFullName:work@t.a
-              |vpiAutomatic:1
-              |vpiVisibility:1
           |vpiRhs:
-          \_operation: , line:7, parent:work@t
+          \_operation: , line:7
             |vpiOpType:24
             |vpiOperand:
-            \_ref_obj: (work@t.a), line:7, parent:work@t
+            \_ref_obj: (work@t.a), line:7
               |vpiName:a
               |vpiFullName:work@t.a
-              |vpiActual:
-              \_int_var: (work@t.a), line:3, parent:work@t
             |vpiOperand:
             \_constant: , line:7
               |vpiConstType:7
@@ -1146,21 +1139,18 @@ design: (work@t)
         |vpiForIncStmt:
         \_assignment: , line:8, parent:work@t
           |vpiOpType:82
+          |vpiBlocking:1
           |vpiLhs:
-          \_ref_obj: (work@t.a), line:8, parent:work@t
+          \_ref_obj: (work@t.a), line:8
             |vpiName:a
             |vpiFullName:work@t.a
-            |vpiActual:
-            \_int_var: (work@t.a), line:3, parent:work@t
           |vpiRhs:
-          \_operation: , line:8, parent:work@t
+          \_operation: , line:8
             |vpiOpType:24
             |vpiOperand:
-            \_ref_obj: (work@t.a), line:8, parent:work@t
+            \_ref_obj: (work@t.a), line:8
               |vpiName:a
               |vpiFullName:work@t.a
-              |vpiActual:
-              \_int_var: (work@t.a), line:3, parent:work@t
             |vpiOperand:
             \_constant: , line:8
               |vpiConstType:7
@@ -1170,25 +1160,18 @@ design: (work@t)
         |vpiForIncStmt:
         \_assignment: , line:8, parent:work@t
           |vpiOpType:82
+          |vpiBlocking:1
           |vpiLhs:
-          \_ref_obj: (work@t.b), line:8, parent:work@t
+          \_ref_obj: (work@t.b), line:8
             |vpiName:b
             |vpiFullName:work@t.b
-            |vpiActual:
-            \_int_var: (work@t.b), line:3, parent:work@t
-              |vpiName:b
-              |vpiFullName:work@t.b
-              |vpiAutomatic:1
-              |vpiVisibility:1
           |vpiRhs:
-          \_operation: , line:8, parent:work@t
+          \_operation: , line:8
             |vpiOpType:24
             |vpiOperand:
-            \_ref_obj: (work@t.b), line:8, parent:work@t
+            \_ref_obj: (work@t.b), line:8
               |vpiName:b
               |vpiFullName:work@t.b
-              |vpiActual:
-              \_int_var: (work@t.b), line:3, parent:work@t
             |vpiOperand:
             \_constant: , line:8
               |vpiConstType:7
@@ -1230,21 +1213,18 @@ design: (work@t)
         |vpiForIncStmt:
         \_assignment: , line:10, parent:work@t
           |vpiOpType:82
+          |vpiBlocking:1
           |vpiLhs:
-          \_ref_obj: (work@t.a), line:10, parent:work@t
+          \_ref_obj: (work@t.a), line:10
             |vpiName:a
             |vpiFullName:work@t.a
-            |vpiActual:
-            \_int_var: (work@t.a), line:3, parent:work@t
           |vpiRhs:
-          \_operation: , line:10, parent:work@t
+          \_operation: , line:10
             |vpiOpType:24
             |vpiOperand:
-            \_ref_obj: (work@t.a), line:10, parent:work@t
+            \_ref_obj: (work@t.a), line:10
               |vpiName:a
               |vpiFullName:work@t.a
-              |vpiActual:
-              \_int_var: (work@t.a), line:3, parent:work@t
             |vpiOperand:
             \_constant: , line:10
               |vpiConstType:7
@@ -1270,21 +1250,18 @@ design: (work@t)
         |vpiForIncStmt:
         \_assignment: , line:11, parent:work@t
           |vpiOpType:82
+          |vpiBlocking:1
           |vpiLhs:
-          \_ref_obj: (work@t.a), line:11, parent:work@t
+          \_ref_obj: (work@t.a), line:11
             |vpiName:a
             |vpiFullName:work@t.a
-            |vpiActual:
-            \_int_var: (work@t.a), line:3, parent:work@t
           |vpiRhs:
-          \_operation: , line:11, parent:work@t
+          \_operation: , line:11
             |vpiOpType:24
             |vpiOperand:
-            \_ref_obj: (work@t.a), line:11, parent:work@t
+            \_ref_obj: (work@t.a), line:11
               |vpiName:a
               |vpiFullName:work@t.a
-              |vpiActual:
-              \_int_var: (work@t.a), line:3, parent:work@t
             |vpiOperand:
             \_constant: , line:11
               |vpiConstType:7
@@ -1294,21 +1271,18 @@ design: (work@t)
         |vpiForIncStmt:
         \_assignment: , line:11, parent:work@t
           |vpiOpType:82
+          |vpiBlocking:1
           |vpiLhs:
-          \_ref_obj: (work@t.b), line:11, parent:work@t
+          \_ref_obj: (work@t.b), line:11
             |vpiName:b
             |vpiFullName:work@t.b
-            |vpiActual:
-            \_int_var: (work@t.b), line:3, parent:work@t
           |vpiRhs:
-          \_operation: , line:11, parent:work@t
+          \_operation: , line:11
             |vpiOpType:24
             |vpiOperand:
-            \_ref_obj: (work@t.b), line:11, parent:work@t
+            \_ref_obj: (work@t.b), line:11
               |vpiName:b
               |vpiFullName:work@t.b
-              |vpiActual:
-              \_int_var: (work@t.b), line:3, parent:work@t
             |vpiOperand:
             \_constant: , line:11
               |vpiConstType:7
@@ -1374,21 +1348,18 @@ design: (work@t)
         |vpiForIncStmt:
         \_assignment: , line:13, parent:work@t
           |vpiOpType:82
+          |vpiBlocking:1
           |vpiLhs:
-          \_ref_obj: (work@t.a), line:13, parent:work@t
+          \_ref_obj: (work@t.a), line:13
             |vpiName:a
             |vpiFullName:work@t.a
-            |vpiActual:
-            \_int_var: (work@t.a), line:3, parent:work@t
           |vpiRhs:
-          \_operation: , line:13, parent:work@t
+          \_operation: , line:13
             |vpiOpType:24
             |vpiOperand:
-            \_ref_obj: (work@t.a), line:13, parent:work@t
+            \_ref_obj: (work@t.a), line:13
               |vpiName:a
               |vpiFullName:work@t.a
-              |vpiActual:
-              \_int_var: (work@t.a), line:3, parent:work@t
             |vpiOperand:
             \_constant: , line:13
               |vpiConstType:7
@@ -1426,21 +1397,18 @@ design: (work@t)
         |vpiForIncStmt:
         \_assignment: , line:14, parent:work@t
           |vpiOpType:82
+          |vpiBlocking:1
           |vpiLhs:
-          \_ref_obj: (work@t.a), line:14, parent:work@t
+          \_ref_obj: (work@t.a), line:14
             |vpiName:a
             |vpiFullName:work@t.a
-            |vpiActual:
-            \_int_var: (work@t.a), line:3, parent:work@t
           |vpiRhs:
-          \_operation: , line:14, parent:work@t
+          \_operation: , line:14
             |vpiOpType:24
             |vpiOperand:
-            \_ref_obj: (work@t.a), line:14, parent:work@t
+            \_ref_obj: (work@t.a), line:14
               |vpiName:a
               |vpiFullName:work@t.a
-              |vpiActual:
-              \_int_var: (work@t.a), line:3, parent:work@t
             |vpiOperand:
             \_constant: , line:14
               |vpiConstType:7
@@ -1450,21 +1418,18 @@ design: (work@t)
         |vpiForIncStmt:
         \_assignment: , line:14, parent:work@t
           |vpiOpType:82
+          |vpiBlocking:1
           |vpiLhs:
-          \_ref_obj: (work@t.b), line:14, parent:work@t
+          \_ref_obj: (work@t.b), line:14
             |vpiName:b
             |vpiFullName:work@t.b
-            |vpiActual:
-            \_int_var: (work@t.b), line:3, parent:work@t
           |vpiRhs:
-          \_operation: , line:14, parent:work@t
+          \_operation: , line:14
             |vpiOpType:24
             |vpiOperand:
-            \_ref_obj: (work@t.b), line:14, parent:work@t
+            \_ref_obj: (work@t.b), line:14
               |vpiName:b
               |vpiFullName:work@t.b
-              |vpiActual:
-              \_int_var: (work@t.b), line:3, parent:work@t
             |vpiOperand:
             \_constant: , line:14
               |vpiConstType:7
@@ -1530,21 +1495,18 @@ design: (work@t)
         |vpiForIncStmt:
         \_assignment: , line:16, parent:work@t
           |vpiOpType:82
+          |vpiBlocking:1
           |vpiLhs:
-          \_ref_obj: (work@t.a), line:16, parent:work@t
+          \_ref_obj: (work@t.a), line:16
             |vpiName:a
             |vpiFullName:work@t.a
-            |vpiActual:
-            \_int_var: (work@t.a), line:3, parent:work@t
           |vpiRhs:
-          \_operation: , line:16, parent:work@t
+          \_operation: , line:16
             |vpiOpType:24
             |vpiOperand:
-            \_ref_obj: (work@t.a), line:16, parent:work@t
+            \_ref_obj: (work@t.a), line:16
               |vpiName:a
               |vpiFullName:work@t.a
-              |vpiActual:
-              \_int_var: (work@t.a), line:3, parent:work@t
             |vpiOperand:
             \_constant: , line:16
               |vpiConstType:7
@@ -1582,21 +1544,18 @@ design: (work@t)
         |vpiForIncStmt:
         \_assignment: , line:17, parent:work@t
           |vpiOpType:82
+          |vpiBlocking:1
           |vpiLhs:
-          \_ref_obj: (work@t.a), line:17, parent:work@t
+          \_ref_obj: (work@t.a), line:17
             |vpiName:a
             |vpiFullName:work@t.a
-            |vpiActual:
-            \_int_var: (work@t.a), line:3, parent:work@t
           |vpiRhs:
-          \_operation: , line:17, parent:work@t
+          \_operation: , line:17
             |vpiOpType:24
             |vpiOperand:
-            \_ref_obj: (work@t.a), line:17, parent:work@t
+            \_ref_obj: (work@t.a), line:17
               |vpiName:a
               |vpiFullName:work@t.a
-              |vpiActual:
-              \_int_var: (work@t.a), line:3, parent:work@t
             |vpiOperand:
             \_constant: , line:17
               |vpiConstType:7
@@ -1606,21 +1565,18 @@ design: (work@t)
         |vpiForIncStmt:
         \_assignment: , line:17, parent:work@t
           |vpiOpType:82
+          |vpiBlocking:1
           |vpiLhs:
-          \_ref_obj: (work@t.b), line:17, parent:work@t
+          \_ref_obj: (work@t.b), line:17
             |vpiName:b
             |vpiFullName:work@t.b
-            |vpiActual:
-            \_int_var: (work@t.b), line:3, parent:work@t
           |vpiRhs:
-          \_operation: , line:17, parent:work@t
+          \_operation: , line:17
             |vpiOpType:24
             |vpiOperand:
-            \_ref_obj: (work@t.b), line:17, parent:work@t
+            \_ref_obj: (work@t.b), line:17
               |vpiName:b
               |vpiFullName:work@t.b
-              |vpiActual:
-              \_int_var: (work@t.b), line:3, parent:work@t
             |vpiOperand:
             \_constant: , line:17
               |vpiConstType:7
@@ -1686,21 +1642,18 @@ design: (work@t)
         |vpiForIncStmt:
         \_assignment: , line:19, parent:work@t
           |vpiOpType:82
+          |vpiBlocking:1
           |vpiLhs:
-          \_ref_obj: (work@t.a), line:19, parent:work@t
+          \_ref_obj: (work@t.a), line:19
             |vpiName:a
             |vpiFullName:work@t.a
-            |vpiActual:
-            \_int_var: (work@t.a), line:3, parent:work@t
           |vpiRhs:
-          \_operation: , line:19, parent:work@t
+          \_operation: , line:19
             |vpiOpType:24
             |vpiOperand:
-            \_ref_obj: (work@t.a), line:19, parent:work@t
+            \_ref_obj: (work@t.a), line:19
               |vpiName:a
               |vpiFullName:work@t.a
-              |vpiActual:
-              \_int_var: (work@t.a), line:3, parent:work@t
             |vpiOperand:
             \_constant: , line:19
               |vpiConstType:7
@@ -1738,21 +1691,18 @@ design: (work@t)
         |vpiForIncStmt:
         \_assignment: , line:20, parent:work@t
           |vpiOpType:82
+          |vpiBlocking:1
           |vpiLhs:
-          \_ref_obj: (work@t.a), line:20, parent:work@t
+          \_ref_obj: (work@t.a), line:20
             |vpiName:a
             |vpiFullName:work@t.a
-            |vpiActual:
-            \_int_var: (work@t.a), line:3, parent:work@t
           |vpiRhs:
-          \_operation: , line:20, parent:work@t
+          \_operation: , line:20
             |vpiOpType:24
             |vpiOperand:
-            \_ref_obj: (work@t.a), line:20, parent:work@t
+            \_ref_obj: (work@t.a), line:20
               |vpiName:a
               |vpiFullName:work@t.a
-              |vpiActual:
-              \_int_var: (work@t.a), line:3, parent:work@t
             |vpiOperand:
             \_constant: , line:20
               |vpiConstType:7
@@ -1762,21 +1712,18 @@ design: (work@t)
         |vpiForIncStmt:
         \_assignment: , line:20, parent:work@t
           |vpiOpType:82
+          |vpiBlocking:1
           |vpiLhs:
-          \_ref_obj: (work@t.b), line:20, parent:work@t
+          \_ref_obj: (work@t.b), line:20
             |vpiName:b
             |vpiFullName:work@t.b
-            |vpiActual:
-            \_int_var: (work@t.b), line:3, parent:work@t
           |vpiRhs:
-          \_operation: , line:20, parent:work@t
+          \_operation: , line:20
             |vpiOpType:24
             |vpiOperand:
-            \_ref_obj: (work@t.b), line:20, parent:work@t
+            \_ref_obj: (work@t.b), line:20
               |vpiName:b
               |vpiFullName:work@t.b
-              |vpiActual:
-              \_int_var: (work@t.b), line:3, parent:work@t
             |vpiOperand:
             \_constant: , line:20
               |vpiConstType:7
@@ -1866,21 +1813,18 @@ design: (work@t)
         |vpiForIncStmt:
         \_assignment: , line:22, parent:work@t
           |vpiOpType:82
+          |vpiBlocking:1
           |vpiLhs:
-          \_ref_obj: (work@t.a), line:22, parent:work@t
+          \_ref_obj: (work@t.a), line:22
             |vpiName:a
             |vpiFullName:work@t.a
-            |vpiActual:
-            \_int_var: (work@t.a), line:3, parent:work@t
           |vpiRhs:
-          \_operation: , line:22, parent:work@t
+          \_operation: , line:22
             |vpiOpType:24
             |vpiOperand:
-            \_ref_obj: (work@t.a), line:22, parent:work@t
+            \_ref_obj: (work@t.a), line:22
               |vpiName:a
               |vpiFullName:work@t.a
-              |vpiActual:
-              \_int_var: (work@t.a), line:3, parent:work@t
             |vpiOperand:
             \_constant: , line:22
               |vpiConstType:7
@@ -1930,21 +1874,18 @@ design: (work@t)
         |vpiForIncStmt:
         \_assignment: , line:23, parent:work@t
           |vpiOpType:82
+          |vpiBlocking:1
           |vpiLhs:
-          \_ref_obj: (work@t.a), line:23, parent:work@t
+          \_ref_obj: (work@t.a), line:23
             |vpiName:a
             |vpiFullName:work@t.a
-            |vpiActual:
-            \_int_var: (work@t.a), line:3, parent:work@t
           |vpiRhs:
-          \_operation: , line:23, parent:work@t
+          \_operation: , line:23
             |vpiOpType:24
             |vpiOperand:
-            \_ref_obj: (work@t.a), line:23, parent:work@t
+            \_ref_obj: (work@t.a), line:23
               |vpiName:a
               |vpiFullName:work@t.a
-              |vpiActual:
-              \_int_var: (work@t.a), line:3, parent:work@t
             |vpiOperand:
             \_constant: , line:23
               |vpiConstType:7
@@ -1954,21 +1895,18 @@ design: (work@t)
         |vpiForIncStmt:
         \_assignment: , line:23, parent:work@t
           |vpiOpType:82
+          |vpiBlocking:1
           |vpiLhs:
-          \_ref_obj: (work@t.b), line:23, parent:work@t
+          \_ref_obj: (work@t.b), line:23
             |vpiName:b
             |vpiFullName:work@t.b
-            |vpiActual:
-            \_int_var: (work@t.b), line:3, parent:work@t
           |vpiRhs:
-          \_operation: , line:23, parent:work@t
+          \_operation: , line:23
             |vpiOpType:24
             |vpiOperand:
-            \_ref_obj: (work@t.b), line:23, parent:work@t
+            \_ref_obj: (work@t.b), line:23
               |vpiName:b
               |vpiFullName:work@t.b
-              |vpiActual:
-              \_int_var: (work@t.b), line:3, parent:work@t
             |vpiOperand:
             \_constant: , line:23
               |vpiConstType:7
@@ -2013,6 +1951,7 @@ design: (work@t)
         |vpiForIncStmt:
         \_assignment: , line:7, parent:work@t
           |vpiOpType:82
+          |vpiBlocking:1
           |vpiLhs:
           \_ref_obj: (work@t.a), line:7
             |vpiName:a
@@ -2044,6 +1983,7 @@ design: (work@t)
         |vpiForIncStmt:
         \_assignment: , line:8, parent:work@t
           |vpiOpType:82
+          |vpiBlocking:1
           |vpiLhs:
           \_ref_obj: (work@t.a), line:8
             |vpiName:a
@@ -2068,6 +2008,7 @@ design: (work@t)
         |vpiForIncStmt:
         \_assignment: , line:8, parent:work@t
           |vpiOpType:82
+          |vpiBlocking:1
           |vpiLhs:
           \_ref_obj: (work@t.b), line:8
             |vpiName:b
@@ -2132,6 +2073,7 @@ design: (work@t)
         |vpiForIncStmt:
         \_assignment: , line:10, parent:work@t
           |vpiOpType:82
+          |vpiBlocking:1
           |vpiLhs:
           \_ref_obj: (work@t.a), line:10
             |vpiName:a
@@ -2174,6 +2116,7 @@ design: (work@t)
         |vpiForIncStmt:
         \_assignment: , line:11, parent:work@t
           |vpiOpType:82
+          |vpiBlocking:1
           |vpiLhs:
           \_ref_obj: (work@t.a), line:11
             |vpiName:a
@@ -2198,6 +2141,7 @@ design: (work@t)
         |vpiForIncStmt:
         \_assignment: , line:11, parent:work@t
           |vpiOpType:82
+          |vpiBlocking:1
           |vpiLhs:
           \_ref_obj: (work@t.b), line:11
             |vpiName:b
@@ -2282,6 +2226,7 @@ design: (work@t)
         |vpiForIncStmt:
         \_assignment: , line:13, parent:work@t
           |vpiOpType:82
+          |vpiBlocking:1
           |vpiLhs:
           \_ref_obj: (work@t.a), line:13
             |vpiName:a
@@ -2336,6 +2281,7 @@ design: (work@t)
         |vpiForIncStmt:
         \_assignment: , line:14, parent:work@t
           |vpiOpType:82
+          |vpiBlocking:1
           |vpiLhs:
           \_ref_obj: (work@t.a), line:14
             |vpiName:a
@@ -2360,6 +2306,7 @@ design: (work@t)
         |vpiForIncStmt:
         \_assignment: , line:14, parent:work@t
           |vpiOpType:82
+          |vpiBlocking:1
           |vpiLhs:
           \_ref_obj: (work@t.b), line:14
             |vpiName:b
@@ -2444,6 +2391,7 @@ design: (work@t)
         |vpiForIncStmt:
         \_assignment: , line:16, parent:work@t
           |vpiOpType:82
+          |vpiBlocking:1
           |vpiLhs:
           \_ref_obj: (work@t.a), line:16
             |vpiName:a
@@ -2498,6 +2446,7 @@ design: (work@t)
         |vpiForIncStmt:
         \_assignment: , line:17, parent:work@t
           |vpiOpType:82
+          |vpiBlocking:1
           |vpiLhs:
           \_ref_obj: (work@t.a), line:17
             |vpiName:a
@@ -2522,6 +2471,7 @@ design: (work@t)
         |vpiForIncStmt:
         \_assignment: , line:17, parent:work@t
           |vpiOpType:82
+          |vpiBlocking:1
           |vpiLhs:
           \_ref_obj: (work@t.b), line:17
             |vpiName:b
@@ -2606,6 +2556,7 @@ design: (work@t)
         |vpiForIncStmt:
         \_assignment: , line:19, parent:work@t
           |vpiOpType:82
+          |vpiBlocking:1
           |vpiLhs:
           \_ref_obj: (work@t.a), line:19
             |vpiName:a
@@ -2660,6 +2611,7 @@ design: (work@t)
         |vpiForIncStmt:
         \_assignment: , line:20, parent:work@t
           |vpiOpType:82
+          |vpiBlocking:1
           |vpiLhs:
           \_ref_obj: (work@t.a), line:20
             |vpiName:a
@@ -2684,6 +2636,7 @@ design: (work@t)
         |vpiForIncStmt:
         \_assignment: , line:20, parent:work@t
           |vpiOpType:82
+          |vpiBlocking:1
           |vpiLhs:
           \_ref_obj: (work@t.b), line:20
             |vpiName:b
@@ -2792,6 +2745,7 @@ design: (work@t)
         |vpiForIncStmt:
         \_assignment: , line:22, parent:work@t
           |vpiOpType:82
+          |vpiBlocking:1
           |vpiLhs:
           \_ref_obj: (work@t.a), line:22
             |vpiName:a
@@ -2858,6 +2812,7 @@ design: (work@t)
         |vpiForIncStmt:
         \_assignment: , line:23, parent:work@t
           |vpiOpType:82
+          |vpiBlocking:1
           |vpiLhs:
           \_ref_obj: (work@t.a), line:23
             |vpiName:a
@@ -2882,6 +2837,7 @@ design: (work@t)
         |vpiForIncStmt:
         \_assignment: , line:23, parent:work@t
           |vpiOpType:82
+          |vpiBlocking:1
           |vpiLhs:
           \_ref_obj: (work@t.b), line:23
             |vpiName:b

--- a/tests/FuncNoArgs/FuncNoArgs.log
+++ b/tests/FuncNoArgs/FuncNoArgs.log
@@ -618,15 +618,16 @@ design: (work@my_opt_reduce_or)
         |vpiForIncStmt:
         \_assignment: , line:11, parent:work@my_opt_reduce_or.count_nonconst_bits
           |vpiOpType:82
+          |vpiBlocking:1
           |vpiLhs:
-          \_ref_obj: (work@my_opt_reduce_or.count_nonconst_bits.i), line:11, parent:work@my_opt_reduce_or.count_nonconst_bits
+          \_ref_obj: (work@my_opt_reduce_or.count_nonconst_bits.i), line:11
             |vpiName:i
             |vpiFullName:work@my_opt_reduce_or.count_nonconst_bits.i
           |vpiRhs:
-          \_operation: , line:11, parent:work@my_opt_reduce_or.count_nonconst_bits
+          \_operation: , line:11
             |vpiOpType:24
             |vpiOperand:
-            \_ref_obj: (work@my_opt_reduce_or.count_nonconst_bits.i), line:11, parent:work@my_opt_reduce_or.count_nonconst_bits
+            \_ref_obj: (work@my_opt_reduce_or.count_nonconst_bits.i), line:11
               |vpiName:i
               |vpiFullName:work@my_opt_reduce_or.count_nonconst_bits.i
             |vpiOperand:
@@ -860,6 +861,7 @@ design: (work@my_opt_reduce_or)
         |vpiForIncStmt:
         \_assignment: , line:11, parent:work@my_opt_reduce_or.count_nonconst_bits
           |vpiOpType:82
+          |vpiBlocking:1
           |vpiLhs:
           \_ref_obj: (work@my_opt_reduce_or.count_nonconst_bits.i), line:11
             |vpiName:i

--- a/tests/PreprocFunc/PreprocFunc.log
+++ b/tests/PreprocFunc/PreprocFunc.log
@@ -775,15 +775,16 @@ design: (work@asym_ram)
             |vpiForIncStmt:
             \_assignment: , line:23, parent:work@asym_ram.log2
               |vpiOpType:82
+              |vpiBlocking:1
               |vpiLhs:
-              \_ref_obj: (work@asym_ram.log2.res), line:23, parent:work@asym_ram.log2
+              \_ref_obj: (work@asym_ram.log2.res), line:23
                 |vpiName:res
                 |vpiFullName:work@asym_ram.log2.res
               |vpiRhs:
-              \_operation: , line:23, parent:work@asym_ram.log2
+              \_operation: , line:23
                 |vpiOpType:24
                 |vpiOperand:
-                \_ref_obj: (work@asym_ram.log2.res), line:23, parent:work@asym_ram.log2
+                \_ref_obj: (work@asym_ram.log2.res), line:23
                   |vpiName:res
                   |vpiFullName:work@asym_ram.log2.res
                 |vpiOperand:
@@ -1151,6 +1152,7 @@ design: (work@asym_ram)
             |vpiForIncStmt:
             \_assignment: , line:23, parent:work@asym_ram.log2
               |vpiOpType:82
+              |vpiBlocking:1
               |vpiLhs:
               \_ref_obj: (work@asym_ram.log2.res), line:23
                 |vpiName:res

--- a/tests/ProcForLoop/ProcForLoop.log
+++ b/tests/ProcForLoop/ProcForLoop.log
@@ -486,15 +486,16 @@ design: (work@top)
         |vpiForIncStmt:
         \_assignment: , line:3, parent:work@top.foo
           |vpiOpType:82
+          |vpiBlocking:1
           |vpiLhs:
-          \_ref_obj: (work@top.foo.i), line:3, parent:work@top.foo
+          \_ref_obj: (work@top.foo.i), line:3
             |vpiName:i
             |vpiFullName:work@top.foo.i
           |vpiRhs:
-          \_operation: , line:3, parent:work@top.foo
+          \_operation: , line:3
             |vpiOpType:24
             |vpiOperand:
-            \_ref_obj: (work@top.foo.i), line:3, parent:work@top.foo
+            \_ref_obj: (work@top.foo.i), line:3
               |vpiName:i
               |vpiFullName:work@top.foo.i
             |vpiOperand:
@@ -612,6 +613,7 @@ design: (work@top)
         |vpiForIncStmt:
         \_assignment: , line:3, parent:work@top.foo
           |vpiOpType:82
+          |vpiBlocking:1
           |vpiLhs:
           \_ref_obj: (work@top.foo.i), line:3
             |vpiName:i

--- a/third_party/tests/SimpleParserTest/SimpleParserTest.log
+++ b/third_party/tests/SimpleParserTest/SimpleParserTest.log
@@ -954,15 +954,16 @@ design: (work@dff_async_reset)
         |vpiForIncStmt:
         \_assignment: , line:18, parent:work@LFSR_TASK.LFSR_TAPS8_TASK
           |vpiOpType:82
+          |vpiBlocking:1
           |vpiLhs:
-          \_ref_obj: (work@LFSR_TASK.LFSR_TAPS8_TASK.i), line:18, parent:work@LFSR_TASK.LFSR_TAPS8_TASK
+          \_ref_obj: (work@LFSR_TASK.LFSR_TAPS8_TASK.i), line:18
             |vpiName:i
             |vpiFullName:work@LFSR_TASK.LFSR_TAPS8_TASK.i
           |vpiRhs:
-          \_operation: , line:18, parent:work@LFSR_TASK.LFSR_TAPS8_TASK
+          \_operation: , line:18
             |vpiOpType:24
             |vpiOperand:
-            \_ref_obj: (work@LFSR_TASK.LFSR_TAPS8_TASK.I), line:18, parent:work@LFSR_TASK.LFSR_TAPS8_TASK
+            \_ref_obj: (work@LFSR_TASK.LFSR_TAPS8_TASK.I), line:18
               |vpiName:I
               |vpiFullName:work@LFSR_TASK.LFSR_TAPS8_TASK.I
             |vpiOperand:
@@ -1215,25 +1216,18 @@ design: (work@dff_async_reset)
           |vpiForIncStmt:
           \_assignment: , line:23, parent:work@arbiter
             |vpiOpType:82
+            |vpiBlocking:1
             |vpiLhs:
-            \_ref_obj: (work@arbiter.i), line:23, parent:work@arbiter
+            \_ref_obj: (work@arbiter.i), line:23
               |vpiName:i
               |vpiFullName:work@arbiter.i
-              |vpiActual:
-              \_int_var: (work@top.U.i), line:3, parent:work@top.U
-                |vpiName:i
-                |vpiFullName:work@top.U.i
-                |vpiAutomatic:1
-                |vpiVisibility:1
             |vpiRhs:
-            \_operation: , line:23, parent:work@arbiter
+            \_operation: , line:23
               |vpiOpType:24
               |vpiOperand:
-              \_ref_obj: (work@arbiter.i), line:23, parent:work@arbiter
+              \_ref_obj: (work@arbiter.i), line:23
                 |vpiName:i
                 |vpiFullName:work@arbiter.i
-                |vpiActual:
-                \_int_var: (work@top.U.i), line:3, parent:work@top.U
               |vpiOperand:
               \_constant: , line:23
                 |vpiConstType:7
@@ -1277,25 +1271,18 @@ design: (work@dff_async_reset)
               |vpiForIncStmt:
               \_assignment: , line:25, parent:work@arbiter
                 |vpiOpType:82
+                |vpiBlocking:1
                 |vpiLhs:
-                \_ref_obj: (work@arbiter.j), line:25, parent:work@arbiter
+                \_ref_obj: (work@arbiter.j), line:25
                   |vpiName:j
                   |vpiFullName:work@arbiter.j
-                  |vpiActual:
-                  \_int_var: (work@top.U.j), line:3, parent:work@top.U
-                    |vpiName:j
-                    |vpiFullName:work@top.U.j
-                    |vpiAutomatic:1
-                    |vpiVisibility:1
                 |vpiRhs:
-                \_operation: , line:25, parent:work@arbiter
+                \_operation: , line:25
                   |vpiOpType:24
                   |vpiOperand:
-                  \_ref_obj: (work@arbiter.j), line:25, parent:work@arbiter
+                  \_ref_obj: (work@arbiter.j), line:25
                     |vpiName:j
                     |vpiFullName:work@arbiter.j
-                    |vpiActual:
-                    \_int_var: (work@top.U.j), line:3, parent:work@top.U
                   |vpiOperand:
                   \_constant: , line:25
                     |vpiConstType:7
@@ -1316,6 +1303,10 @@ design: (work@dff_async_reset)
                     |vpiFullName:work@arbiter.tmp_prio.j
                     |vpiActual:
                     \_int_var: (work@top.U.j), line:3, parent:work@top.U
+                      |vpiName:j
+                      |vpiFullName:work@top.U.j
+                      |vpiAutomatic:1
+                      |vpiVisibility:1
                 |vpiRhs:
                 \_bit_select: (work@arbiter.tpriority), line:26
                   |vpiName:tpriority
@@ -1332,6 +1323,10 @@ design: (work@dff_async_reset)
                         |vpiFullName:work@arbiter.i
                         |vpiActual:
                         \_int_var: (work@top.U.i), line:3, parent:work@top.U
+                          |vpiName:i
+                          |vpiFullName:work@top.U.i
+                          |vpiAutomatic:1
+                          |vpiVisibility:1
                       |vpiOperand:
                       \_ref_obj: (work@arbiter.ADDRESSWIDTH), line:26
                         |vpiName:ADDRESSWIDTH
@@ -1707,25 +1702,18 @@ design: (work@dff_async_reset)
           |vpiForIncStmt:
           \_assignment: , line:64, parent:work@arbiter
             |vpiOpType:82
+            |vpiBlocking:1
             |vpiLhs:
-            \_ref_obj: (work@arbiter.k), line:64, parent:work@arbiter
+            \_ref_obj: (work@arbiter.k), line:64
               |vpiName:k
               |vpiFullName:work@arbiter.k
-              |vpiActual:
-              \_int_var: (work@top.U.k), line:3, parent:work@top.U
-                |vpiName:k
-                |vpiFullName:work@top.U.k
-                |vpiAutomatic:1
-                |vpiVisibility:1
             |vpiRhs:
-            \_operation: , line:64, parent:work@arbiter
+            \_operation: , line:64
               |vpiOpType:24
               |vpiOperand:
-              \_ref_obj: (work@arbiter.k), line:64, parent:work@arbiter
+              \_ref_obj: (work@arbiter.k), line:64
                 |vpiName:k
                 |vpiFullName:work@arbiter.k
-                |vpiActual:
-                \_int_var: (work@top.U.k), line:3, parent:work@top.U
               |vpiOperand:
               \_constant: , line:64
                 |vpiConstType:7
@@ -1746,6 +1734,10 @@ design: (work@dff_async_reset)
                 |vpiFullName:work@arbiter.selectPrio.k
                 |vpiActual:
                 \_int_var: (work@top.U.k), line:3, parent:work@top.U
+                  |vpiName:k
+                  |vpiFullName:work@top.U.k
+                  |vpiAutomatic:1
+                  |vpiVisibility:1
             |vpiRhs:
             \_operation: , line:65, parent:work@arbiter
               |vpiOpType:32
@@ -1838,25 +1830,18 @@ design: (work@dff_async_reset)
           |vpiForIncStmt:
           \_assignment: , line:70, parent:work@arbiter
             |vpiOpType:82
+            |vpiBlocking:1
             |vpiLhs:
-            \_ref_obj: (work@arbiter.r), line:70, parent:work@arbiter
+            \_ref_obj: (work@arbiter.r), line:70
               |vpiName:r
               |vpiFullName:work@arbiter.r
-              |vpiActual:
-              \_int_var: (work@top.U.r), line:3, parent:work@top.U
-                |vpiName:r
-                |vpiFullName:work@top.U.r
-                |vpiAutomatic:1
-                |vpiVisibility:1
             |vpiRhs:
-            \_operation: , line:70, parent:work@arbiter
+            \_operation: , line:70
               |vpiOpType:24
               |vpiOperand:
-              \_ref_obj: (work@arbiter.r), line:70, parent:work@arbiter
+              \_ref_obj: (work@arbiter.r), line:70
                 |vpiName:r
                 |vpiFullName:work@arbiter.r
-                |vpiActual:
-                \_int_var: (work@top.U.r), line:3, parent:work@top.U
               |vpiOperand:
               \_constant: , line:70
                 |vpiConstType:7
@@ -1877,6 +1862,10 @@ design: (work@dff_async_reset)
                 |vpiFullName:work@arbiter.finalRequest.r
                 |vpiActual:
                 \_int_var: (work@top.U.r), line:3, parent:work@top.U
+                  |vpiName:r
+                  |vpiFullName:work@top.U.r
+                  |vpiAutomatic:1
+                  |vpiVisibility:1
             |vpiRhs:
             \_operation: , line:71, parent:work@arbiter
               |vpiOpType:32
@@ -2077,25 +2066,18 @@ design: (work@dff_async_reset)
           |vpiForIncStmt:
           \_assignment: , line:81, parent:work@arbiter
             |vpiOpType:82
+            |vpiBlocking:1
             |vpiLhs:
-            \_ref_obj: (work@arbiter.p), line:81, parent:work@arbiter
+            \_ref_obj: (work@arbiter.p), line:81
               |vpiName:p
               |vpiFullName:work@arbiter.p
-              |vpiActual:
-              \_int_var: (work@top.U.p), line:3, parent:work@top.U
-                |vpiName:p
-                |vpiFullName:work@top.U.p
-                |vpiAutomatic:1
-                |vpiVisibility:1
             |vpiRhs:
-            \_operation: , line:81, parent:work@arbiter
+            \_operation: , line:81
               |vpiOpType:24
               |vpiOperand:
-              \_ref_obj: (work@arbiter.p), line:81, parent:work@arbiter
+              \_ref_obj: (work@arbiter.p), line:81
                 |vpiName:p
                 |vpiFullName:work@arbiter.p
-                |vpiActual:
-                \_int_var: (work@top.U.p), line:3, parent:work@top.U
               |vpiOperand:
               \_constant: , line:81
                 |vpiConstType:7
@@ -2141,6 +2123,10 @@ design: (work@dff_async_reset)
                   |vpiFullName:work@arbiter.selectPrio.p
                   |vpiActual:
                   \_int_var: (work@top.U.p), line:3, parent:work@top.U
+                    |vpiName:p
+                    |vpiFullName:work@top.U.p
+                    |vpiAutomatic:1
+                    |vpiVisibility:1
   |vpiProcess:
   \_always: , line:85, parent:work@arbiter
     |vpiAlwaysType:1
@@ -2285,25 +2271,18 @@ design: (work@dff_async_reset)
           |vpiForIncStmt:
           \_assignment: , line:88, parent:work@arbiter
             |vpiOpType:82
+            |vpiBlocking:1
             |vpiLhs:
-            \_ref_obj: (work@arbiter.q), line:88, parent:work@arbiter
+            \_ref_obj: (work@arbiter.q), line:88
               |vpiName:q
               |vpiFullName:work@arbiter.q
-              |vpiActual:
-              \_int_var: (work@top.U.q), line:3, parent:work@top.U
-                |vpiName:q
-                |vpiFullName:work@top.U.q
-                |vpiAutomatic:1
-                |vpiVisibility:1
             |vpiRhs:
-            \_operation: , line:88, parent:work@arbiter
+            \_operation: , line:88
               |vpiOpType:24
               |vpiOperand:
-              \_ref_obj: (work@arbiter.q), line:88, parent:work@arbiter
+              \_ref_obj: (work@arbiter.q), line:88
                 |vpiName:q
                 |vpiFullName:work@arbiter.q
-                |vpiActual:
-                \_int_var: (work@top.U.q), line:3, parent:work@top.U
               |vpiOperand:
               \_constant: , line:88
                 |vpiConstType:7
@@ -2324,6 +2303,10 @@ design: (work@dff_async_reset)
                 |vpiFullName:work@arbiter.minPrio.q
                 |vpiActual:
                 \_int_var: (work@top.U.q), line:3, parent:work@top.U
+                  |vpiName:q
+                  |vpiFullName:work@top.U.q
+                  |vpiAutomatic:1
+                  |vpiVisibility:1
             |vpiRhs:
             \_operation: , line:89, parent:work@arbiter
               |vpiOpType:32
@@ -2401,25 +2384,18 @@ design: (work@dff_async_reset)
           |vpiForIncStmt:
           \_assignment: , line:96, parent:work@arbiter
             |vpiOpType:82
+            |vpiBlocking:1
             |vpiLhs:
-            \_ref_obj: (work@arbiter.s), line:96, parent:work@arbiter
+            \_ref_obj: (work@arbiter.s), line:96
               |vpiName:s
               |vpiFullName:work@arbiter.s
-              |vpiActual:
-              \_int_var: (work@top.U.s), line:3, parent:work@top.U
-                |vpiName:s
-                |vpiFullName:work@top.U.s
-                |vpiAutomatic:1
-                |vpiVisibility:1
             |vpiRhs:
-            \_operation: , line:96, parent:work@arbiter
+            \_operation: , line:96
               |vpiOpType:24
               |vpiOperand:
-              \_ref_obj: (work@arbiter.s), line:96, parent:work@arbiter
+              \_ref_obj: (work@arbiter.s), line:96
                 |vpiName:s
                 |vpiFullName:work@arbiter.s
-                |vpiActual:
-                \_int_var: (work@top.U.s), line:3, parent:work@top.U
               |vpiOperand:
               \_constant: , line:96
                 |vpiConstType:7
@@ -2440,6 +2416,10 @@ design: (work@dff_async_reset)
                 |vpiFullName:work@arbiter.scan.s
                 |vpiActual:
                 \_int_var: (work@top.U.s), line:3, parent:work@top.U
+                  |vpiName:s
+                  |vpiFullName:work@top.U.s
+                  |vpiAutomatic:1
+                  |vpiVisibility:1
             |vpiRhs:
             \_operation: , line:97, parent:work@arbiter
               |vpiOpType:32
@@ -2681,25 +2661,18 @@ design: (work@dff_async_reset)
           |vpiForIncStmt:
           \_assignment: , line:104, parent:work@arbiter
             |vpiOpType:82
+            |vpiBlocking:1
             |vpiLhs:
-            \_ref_obj: (work@arbiter.t), line:104, parent:work@arbiter
+            \_ref_obj: (work@arbiter.t), line:104
               |vpiName:t
               |vpiFullName:work@arbiter.t
-              |vpiActual:
-              \_int_var: (work@top.U.t), line:3, parent:work@top.U
-                |vpiName:t
-                |vpiFullName:work@top.U.t
-                |vpiAutomatic:1
-                |vpiVisibility:1
             |vpiRhs:
-            \_operation: , line:104, parent:work@arbiter
+            \_operation: , line:104
               |vpiOpType:24
               |vpiOperand:
-              \_ref_obj: (work@arbiter.t), line:104, parent:work@arbiter
+              \_ref_obj: (work@arbiter.t), line:104
                 |vpiName:t
                 |vpiFullName:work@arbiter.t
-                |vpiActual:
-                \_int_var: (work@top.U.t), line:3, parent:work@top.U
               |vpiOperand:
               \_constant: , line:104
                 |vpiConstType:7
@@ -2720,6 +2693,10 @@ design: (work@dff_async_reset)
                 |vpiFullName:work@arbiter.found.t
                 |vpiActual:
                 \_int_var: (work@top.U.t), line:3, parent:work@top.U
+                  |vpiName:t
+                  |vpiFullName:work@top.U.t
+                  |vpiAutomatic:1
+                  |vpiVisibility:1
             |vpiRhs:
             \_operation: , line:105, parent:work@arbiter
               |vpiOpType:27
@@ -2932,25 +2909,18 @@ design: (work@dff_async_reset)
           |vpiForIncStmt:
           \_assignment: , line:112, parent:work@arbiter
             |vpiOpType:82
+            |vpiBlocking:1
             |vpiLhs:
-            \_ref_obj: (work@arbiter.u), line:112, parent:work@arbiter
+            \_ref_obj: (work@arbiter.u), line:112
               |vpiName:u
               |vpiFullName:work@arbiter.u
-              |vpiActual:
-              \_int_var: (work@top.U.u), line:3, parent:work@top.U
-                |vpiName:u
-                |vpiFullName:work@top.U.u
-                |vpiAutomatic:1
-                |vpiVisibility:1
             |vpiRhs:
-            \_operation: , line:112, parent:work@arbiter
+            \_operation: , line:112
               |vpiOpType:24
               |vpiOperand:
-              \_ref_obj: (work@arbiter.u), line:112, parent:work@arbiter
+              \_ref_obj: (work@arbiter.u), line:112
                 |vpiName:u
                 |vpiFullName:work@arbiter.u
-                |vpiActual:
-                \_int_var: (work@top.U.u), line:3, parent:work@top.U
               |vpiOperand:
               \_constant: , line:112
                 |vpiConstType:7
@@ -2975,6 +2945,10 @@ design: (work@dff_async_reset)
                   |vpiFullName:work@arbiter.grantD.scan.u
                   |vpiActual:
                   \_int_var: (work@top.U.u), line:3, parent:work@top.U
+                    |vpiName:u
+                    |vpiFullName:work@top.U.u
+                    |vpiAutomatic:1
+                    |vpiVisibility:1
             |vpiRhs:
             \_operation: , line:113, parent:work@arbiter
               |vpiOpType:26
@@ -3081,25 +3055,18 @@ design: (work@dff_async_reset)
           |vpiForIncStmt:
           \_assignment: , line:118, parent:work@arbiter
             |vpiOpType:82
+            |vpiBlocking:1
             |vpiLhs:
-            \_ref_obj: (work@arbiter.v), line:118, parent:work@arbiter
+            \_ref_obj: (work@arbiter.v), line:118
               |vpiName:v
               |vpiFullName:work@arbiter.v
-              |vpiActual:
-              \_int_var: (work@top.U.v), line:3, parent:work@top.U
-                |vpiName:v
-                |vpiFullName:work@top.U.v
-                |vpiAutomatic:1
-                |vpiVisibility:1
             |vpiRhs:
-            \_operation: , line:118, parent:work@arbiter
+            \_operation: , line:118
               |vpiOpType:24
               |vpiOperand:
-              \_ref_obj: (work@arbiter.v), line:118, parent:work@arbiter
+              \_ref_obj: (work@arbiter.v), line:118
                 |vpiName:v
                 |vpiFullName:work@arbiter.v
-                |vpiActual:
-                \_int_var: (work@top.U.v), line:3, parent:work@top.U
               |vpiOperand:
               \_constant: , line:118
                 |vpiConstType:7
@@ -3135,6 +3102,10 @@ design: (work@dff_async_reset)
                   |vpiFullName:work@arbiter.v
                   |vpiActual:
                   \_int_var: (work@top.U.v), line:3, parent:work@top.U
+                    |vpiName:v
+                    |vpiFullName:work@top.U.v
+                    |vpiAutomatic:1
+                    |vpiVisibility:1
                 |vpiOperand:
                 \_constant: , line:119
                   |vpiConstType:7


### PR DESCRIPTION
According to IEEE 11.4.1
```
An assignment  operator  is  semantically  equivalent  to  a  blocking  assignment, 
with  the  exception  that  any left-hand index expression is only evaluated once. 
```
This affects assignment operators in for loop step statements, which were reported as nonblocking in UHDM.