### PR TITLE
UHDM Coverage

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -469,7 +469,7 @@
             "type": "cppdbg",
             "request": "launch",
             "program": "${workspaceFolder}/dbuild/bin/surelog",
-            "args": ["-parse", "tests/ScratchPad.sv","-d", "inst" ,"-d", "ast", "-d", "uhdm","-nobuiltin", "-nocache", "-d", "vpi_ids", "-elabuhdm", "-d", "coveruhdm", "-replay"],
+            "args": ["-parse", "tests/ScratchPad.sv","-d", "inst" ,"-d", "ast", "-top", "bsg_cache_to_dram_ctrl_tx", "-d", "uhdm","-nobuiltin", "-nocache", "-d", "vpi_ids", "-elabuhdm", "-d", "coveruhdm", "-replay"],
             "stopAtEntry": false,
             "cwd": "${workspaceFolder}",
             "environment": [],

--- a/src/DesignCompile/CompileClass.cpp
+++ b/src/DesignCompile/CompileClass.cpp
@@ -172,6 +172,7 @@ bool CompileClass::compile() {
     switch (type) {
       case VObjectType::slPackage_import_item: {
         m_helper.importPackage(m_class, m_design, fC, id, m_compileDesign);
+        m_helper.compileImportDeclaration(m_class, fC, id, m_compileDesign);
         break;
       }
       case VObjectType::slClass_constructor_declaration: {

--- a/src/DesignCompile/CompileHelper.h
+++ b/src/DesignCompile/CompileHelper.h
@@ -265,6 +265,10 @@ public:
                                     const FileContent* fC, NodeId nodeId,
                                     CompileDesign* compileDesign);
 
+  void compileImportDeclaration(DesignComponent* component,
+        const FileContent* fC, NodeId id,
+        CompileDesign* compileDesign);
+
   UHDM::any* bindVariable(DesignComponent* component, const UHDM::any* scope, const std::string& name, CompileDesign* compileDesign);
   UHDM::any* bindVariable(DesignComponent* component, ValuedComponentI* instance, const std::string& name, CompileDesign* compileDesign);
 

--- a/src/DesignCompile/CompileModule.cpp
+++ b/src/DesignCompile/CompileModule.cpp
@@ -531,6 +531,7 @@ bool CompileModule::collectModuleObjects_(CollectType collectType) {
         case VObjectType::slPackage_import_item: {
           if (collectType != CollectType::FUNCTION) break;
           m_helper.importPackage(m_module, m_design, fC, id, m_compileDesign);
+          m_helper.compileImportDeclaration(m_module, fC, id, m_compileDesign);
           break;
         }
         case VObjectType::slAnsi_port_declaration: {
@@ -787,6 +788,7 @@ bool CompileModule::collectInterfaceObjects_(CollectType collectType) {
         case VObjectType::slPackage_import_item: {
           if (collectType != CollectType::FUNCTION) break;
           m_helper.importPackage(m_module, m_design, fC, id, m_compileDesign);
+          m_helper.compileImportDeclaration(m_module, fC, id, m_compileDesign);
           break;
         }
         case VObjectType::slParameter_port_list: {

--- a/src/DesignCompile/CompilePackage.cpp
+++ b/src/DesignCompile/CompilePackage.cpp
@@ -137,6 +137,7 @@ bool CompilePackage::collectObjects_(CollectType collectType) {
         case VObjectType::slPackage_import_item: {
           if (collectType != CollectType::FUNCTION) break; 
           m_helper.importPackage(m_package, m_design, fC, id, m_compileDesign);
+          m_helper.compileImportDeclaration(m_package, fC, id, m_compileDesign);
           break;
         }
         case VObjectType::slParameter_declaration: {

--- a/src/DesignCompile/CompileProgram.cpp
+++ b/src/DesignCompile/CompileProgram.cpp
@@ -140,6 +140,7 @@ bool CompileProgram::collectObjects_(CollectType collectType) {
       case VObjectType::slPackage_import_item: {
         if (collectType != CollectType::FUNCTION) break;
         m_helper.importPackage(m_program, m_design, fC, id, m_compileDesign);
+        m_helper.compileImportDeclaration(m_program, fC, id, m_compileDesign);
         break;
       }
       case VObjectType::slParameter_port_list: {

--- a/src/DesignCompile/NetlistElaboration.cpp
+++ b/src/DesignCompile/NetlistElaboration.cpp
@@ -518,11 +518,13 @@ bool NetlistElaboration::high_conn_(ModuleInstance* instance) {
 
       bool wildcard = false;
       NodeId MemNamed_port_connection = Named_port_connection;
+      int wildcardLineNumber = 0;
       while (Named_port_connection) {
         NodeId formalId = fC->Child(Named_port_connection);
         if (fC->Type(formalId) == VObjectType::slDotStar) {
           // .* connection
           wildcard = true;
+          wildcardLineNumber = fC->Line(formalId);
           break;
         }
         Named_port_connection = fC->Sibling(Named_port_connection);
@@ -763,7 +765,7 @@ bool NetlistElaboration::high_conn_(ModuleInstance* instance) {
             if (pp->High_conn() == nullptr) {
               ref_obj* ref = s.MakeRef_obj();
               ref->VpiFile(fC->getFileName());
-              ref->VpiLineNo(fC->Line(s1->getNodeId()));
+              ref->VpiLineNo(wildcardLineNumber);
               ref->VpiName(sigName);
               pp->High_conn(ref);
               UHDM::any* net = bind_net_(parent, sigName);

--- a/src/DesignCompile/UhdmChecker.h
+++ b/src/DesignCompile/UhdmChecker.h
@@ -37,7 +37,7 @@ public:
   bool check(const std::string& reportFile);
 
 private:
-    bool registerFile(const FileContent* fC);
+    bool registerFile(const FileContent* fC, std::set<std::string>& moduleNames);
     bool reportHtml(CompileDesign* compileDesign, const std::string& reportFile, float overallCoverage);
     float reportCoverage(const std::string& reportFile);
     void annotate(CompileDesign* m_compileDesign);

--- a/tests/BitsOp/BitsOp.log
+++ b/tests/BitsOp/BitsOp.log
@@ -1024,7 +1024,7 @@ design: (work@dut)
   |vpiTypedef:
   \_logic_typespec: (flash_ctrl_pkg::sha_word_t), line:71
   |vpiTypedef:
-  \_import: (flash_ctrl_pkg)
+  \_import: (flash_ctrl_pkg), line:76
   |vpiParamAssign:
   \_param_assign: , line:78, parent:work@dut
     |vpiRhs:
@@ -1598,7 +1598,7 @@ design: (work@dut)
     |vpiInstance:
     \_package: flash_ctrl_pkg (flash_ctrl_pkg::) dut.sv:65: , parent:work@dut
   |vpiTypedef:
-  \_import: (flash_ctrl_pkg), parent:work@dut
+  \_import: (flash_ctrl_pkg), line:76, parent:work@dut
   |vpiParamAssign:
   \_param_assign: , line:78, parent:work@dut
     |vpiRhs:

--- a/tests/BlackParrotParam/BlackParrotParam.log
+++ b/tests/BlackParrotParam/BlackParrotParam.log
@@ -14102,9 +14102,9 @@ design: (work@bp_be_ptw)
   |vpiTypedef:
   \_struct_typespec: (bp_common_rv64_pkg::bp_be_pkg::rv64_stvec_s), line:1215
   |vpiTypedef:
-  \_import: (bp_common_pkg)
+  \_import: (bp_common_pkg), line:2531
   |vpiTypedef:
-  \_import: (bp_common_rv64_pkg)
+  \_import: (bp_common_rv64_pkg), line:2532
   |vpiParamAssign:
   \_param_assign: , line:78, parent:bp_be_pkg::
     |vpiRhs:
@@ -23678,9 +23678,9 @@ design: (work@bp_be_ptw)
         |vpiTypedef:
         \_struct_typespec: (bp_common_rv64_pkg::bp_be_pkg::rv64_stvec_s), line:1215
         |vpiTypedef:
-        \_import: (bp_common_pkg)
+        \_import: (bp_common_pkg), line:2531
         |vpiTypedef:
-        \_import: (bp_common_rv64_pkg)
+        \_import: (bp_common_rv64_pkg), line:2532
         |vpiParamAssign:
         \_param_assign: , line:78, parent:bp_be_pkg::
           |vpiRhs:
@@ -28054,6 +28054,16 @@ design: (work@bp_be_ptw)
   \_logic_typespec: (bp_common_rv64_pkg::bp_be_pkg::rv64_stval_s), line:1308
   |vpiTypedef:
   \_struct_typespec: (bp_common_rv64_pkg::bp_be_pkg::rv64_stvec_s), line:1215
+  |vpiTypedef:
+  \_import: (bp_common_pkg), line:4372
+  |vpiTypedef:
+  \_import: (bp_common_rv64_pkg), line:4373
+  |vpiTypedef:
+  \_import: (bp_common_aviary_pkg), line:4374
+  |vpiTypedef:
+  \_import: (bp_be_pkg), line:4375
+  |vpiTypedef:
+  \_import: (bp_be_dcache_pkg), line:4376
   |vpiParamAssign:
   \_param_assign: , line:78, parent:work@bp_be_ptw
     |vpiRhs:
@@ -44445,9 +44455,9 @@ design: (work@bp_be_ptw)
         |vpiTypedef:
         \_struct_typespec: (bp_common_rv64_pkg::bp_be_pkg::rv64_stvec_s), line:1215
         |vpiTypedef:
-        \_import: (bp_common_pkg)
+        \_import: (bp_common_pkg), line:2531
         |vpiTypedef:
-        \_import: (bp_common_rv64_pkg)
+        \_import: (bp_common_rv64_pkg), line:2532
         |vpiParamAssign:
         \_param_assign: , line:78, parent:bp_be_pkg::
           |vpiRhs:
@@ -54971,6 +54981,16 @@ design: (work@bp_be_ptw)
         \_package: bp_common_rv64_pkg (bp_common_rv64_pkg::) dut.sv:927: , parent:work@bp_be_ptw
     |vpiInstance:
     \_package: bp_common_rv64_pkg (bp_common_rv64_pkg::) dut.sv:927: , parent:work@bp_be_ptw
+  |vpiTypedef:
+  \_import: (bp_common_pkg), line:4372, parent:work@bp_be_ptw
+  |vpiTypedef:
+  \_import: (bp_common_rv64_pkg), line:4373, parent:work@bp_be_ptw
+  |vpiTypedef:
+  \_import: (bp_common_aviary_pkg), line:4374, parent:work@bp_be_ptw
+  |vpiTypedef:
+  \_import: (bp_be_pkg), line:4375, parent:work@bp_be_ptw
+  |vpiTypedef:
+  \_import: (bp_be_dcache_pkg), line:4376, parent:work@bp_be_ptw
   |vpiParamAssign:
   \_param_assign: , line:4377, parent:work@bp_be_ptw
     |vpiRhs:

--- a/tests/BlackParrotStructParam/BlackParrotStructParam.log
+++ b/tests/BlackParrotStructParam/BlackParrotStructParam.log
@@ -1091,6 +1091,8 @@ design: (work@top)
       |UINT:0
   |vpiTypedef:
   \_struct_typespec: (bp_common_aviary_pkg::bp_proc_param_s), line:5, parent:work@top.proc_param_lp
+  |vpiTypedef:
+  \_import: (bp_common_aviary_pkg), line:55
   |vpiParamAssign:
   \_param_assign: , line:3, parent:work@top
     |vpiRhs:
@@ -1772,6 +1774,8 @@ design: (work@top)
       \_int_typespec: , line:7, parent:cc_x_dim
         |vpiInstance:
         \_package: bp_common_aviary_pkg (bp_common_aviary_pkg::) dut.sv:1: , parent:work@top
+  |vpiTypedef:
+  \_import: (bp_common_aviary_pkg), line:55, parent:work@top
   |vpiParamAssign:
   \_param_assign: , line:56, parent:work@top
     |vpiRhs:

--- a/tests/ClassExtends/ClassExtends.log
+++ b/tests/ClassExtends/ClassExtends.log
@@ -92,7 +92,7 @@ design: (unnamed)
   |vpiTypedef:
   \_class_typespec: (p2::p1::c3), line:8
   |vpiTypedef:
-  \_import: (p1)
+  \_import: (p1), line:19
 |uhdmallPackages:
 \_package: p3 (p3::) dut.sv:12: , parent:unnamed
   |vpiDefName:p3

--- a/tests/ComplexBitSelect/ComplexBitSelect.log
+++ b/tests/ComplexBitSelect/ComplexBitSelect.log
@@ -617,6 +617,8 @@ design: (work@flash_ctrl_info_cfg)
 \_module: work@flash_ctrl_info_cfg (work@flash_ctrl_info_cfg) dut.sv:12: , parent:work@flash_ctrl_info_cfg
   |vpiDefName:work@flash_ctrl_info_cfg
   |vpiFullName:work@flash_ctrl_info_cfg
+  |vpiTypedef:
+  \_import: (flash_ctrl_pkg), line:12
   |vpiParamAssign:
   \_param_assign: , line:2, parent:work@flash_ctrl_info_cfg
     |vpiRhs:
@@ -1166,6 +1168,8 @@ design: (work@flash_ctrl_info_cfg)
         |vpiName:i
         |vpiFullName:work@flash_ctrl_info_cfg.gen_info_priv[9].i
         |UINT:9
+  |vpiTypedef:
+  \_import: (flash_ctrl_pkg), line:12, parent:work@flash_ctrl_info_cfg
   |vpiParamAssign:
   \_param_assign: , line:2, parent:work@flash_ctrl_info_cfg
     |vpiRhs:

--- a/tests/DollarRoot/DollarRoot.log
+++ b/tests/DollarRoot/DollarRoot.log
@@ -12501,9 +12501,9 @@ design: (work@top)
   |vpiTypedef:
   \_enum_typespec: (Transaction), line:37
   |vpiTypedef:
-  \_import: (verbosity_pkg)
+  \_import: (verbosity_pkg), line:7
   |vpiTypedef:
-  \_import: (avalon_mm_pkg)
+  \_import: (avalon_mm_pkg), line:8
   |vpiParamAssign:
   \_param_assign: , line:13, parent:work@test_program
     |vpiRhs:
@@ -21545,9 +21545,9 @@ design: (work@top)
       |vpiTypedef:
       \_enum_typespec: (Transaction), line:37
       |vpiTypedef:
-      \_import: (verbosity_pkg)
+      \_import: (verbosity_pkg), line:7
       |vpiTypedef:
-      \_import: (avalon_mm_pkg)
+      \_import: (avalon_mm_pkg), line:8
       |vpiParamAssign:
       \_param_assign: , line:13, parent:work@test_program
         |vpiRhs:
@@ -30648,9 +30648,9 @@ design: (work@top)
       |vpiName:WRITE
       |UINT:0
   |vpiTypedef:
-  \_import: (verbosity_pkg), parent:work@test_program
+  \_import: (verbosity_pkg), line:7, parent:work@test_program
   |vpiTypedef:
-  \_import: (avalon_mm_pkg), parent:work@test_program
+  \_import: (avalon_mm_pkg), line:8, parent:work@test_program
   |vpiParamAssign:
   \_param_assign: , line:13, parent:work@test_program
     |vpiRhs:

--- a/tests/EvalFuncNamed/EvalFuncNamed.log
+++ b/tests/EvalFuncNamed/EvalFuncNamed.log
@@ -348,7 +348,7 @@ design: (work@t)
                 |vpiName:value2
                 |vpiFullName:my_module_types::simple_func::value2
       |vpiTypedef:
-      \_import: (my_funcs)
+      \_import: (my_funcs), line:17
       |vpiParamAssign:
       \_param_assign: , line:19, parent:my_module_types::
         |vpiRhs:
@@ -778,7 +778,7 @@ design: (work@t)
                 |vpiName:value2
                 |vpiFullName:my_module_types::simple_func::value2
       |vpiTypedef:
-      \_import: (my_funcs)
+      \_import: (my_funcs), line:17
       |vpiParamAssign:
       \_param_assign: , line:19, parent:my_module_types::
         |vpiRhs:
@@ -857,6 +857,8 @@ design: (work@t)
   \_logic_net: (work@t.i_d), line:27, parent:work@t
   |vpiNet:
   \_logic_net: (work@t.o_q), line:28, parent:work@t
+  |vpiTypedef:
+  \_import: (my_module_types), line:24
   |vpiParamAssign:
   \_param_assign: , line:19, parent:work@t
     |vpiRhs:
@@ -1070,7 +1072,7 @@ design: (work@t)
                 |vpiName:value2
                 |vpiFullName:my_module_types::simple_func::value2
       |vpiTypedef:
-      \_import: (my_funcs)
+      \_import: (my_funcs), line:17
       |vpiParamAssign:
       \_param_assign: , line:19, parent:my_module_types::
         |vpiRhs:
@@ -1199,6 +1201,8 @@ design: (work@t)
   \_logic_net: (work@t.i_d), line:27, parent:work@t
   |vpiNet:
   \_logic_net: (work@t.o_q), line:28, parent:work@t
+  |vpiTypedef:
+  \_import: (my_module_types), line:24, parent:work@t
   |vpiParamAssign:
   \_param_assign: , line:19, parent:work@t
     |vpiRhs:

--- a/tests/EvalFuncPack/EvalFuncPack.log
+++ b/tests/EvalFuncPack/EvalFuncPack.log
@@ -884,7 +884,7 @@ design: (work@flash_ctrl_info_cfg)
   |vpiTaskFunc:
   \_function: (prim_util_pkg::vbits), line:15, parent:prim_util_pkg::
   |vpiTypedef:
-  \_import: (prim_util_pkg)
+  \_import: (prim_util_pkg), line:50
   |vpiParamAssign:
   \_param_assign: , line:54, parent:otp_ctrl_pkg::
     |vpiRhs:
@@ -1344,6 +1344,8 @@ design: (work@flash_ctrl_info_cfg)
     |vpiName:CurPage
     |vpiFullName:work@flash_ctrl_info_cfg.CurPage
     |vpiNetType:36
+  |vpiTypedef:
+  \_import: (flash_ctrl_pkg), line:59
   |vpiParamAssign:
   \_param_assign: , line:26, parent:work@flash_ctrl_info_cfg
     |vpiRhs:
@@ -1738,6 +1740,8 @@ design: (work@flash_ctrl_info_cfg)
         |vpiDecompile:0
         |vpiSize:64
         |UINT:0
+  |vpiTypedef:
+  \_import: (flash_ctrl_pkg), line:59, parent:work@flash_ctrl_info_cfg
   |vpiParamAssign:
   \_param_assign: , line:26, parent:work@flash_ctrl_info_cfg
     |vpiRhs:

--- a/tests/IfGenTypeBinding/IfGenTypeBinding.log
+++ b/tests/IfGenTypeBinding/IfGenTypeBinding.log
@@ -532,7 +532,7 @@ design: (work@top)
         |vpiInstance:
         \_package: ibex_pkg (ibex_pkg::) dut.sv:1: , parent:work@top
   |vpiTypedef:
-  \_import: (ibex_pkg)
+  \_import: (ibex_pkg), line:16
   |vpiParamAssign:
   \_param_assign: , line:13, parent:work@top
     |vpiRhs:
@@ -711,7 +711,7 @@ design: (work@top)
         |vpiInstance:
         \_package: ibex_pkg (ibex_pkg::) dut.sv:1: , parent:work@top
   |vpiTypedef:
-  \_import: (ibex_pkg), parent:work@top
+  \_import: (ibex_pkg), line:16, parent:work@top
   |vpiParamAssign:
   \_param_assign: , line:13, parent:work@top
     |vpiRhs:

--- a/tests/PackImport/PackImport.log
+++ b/tests/PackImport/PackImport.log
@@ -83,7 +83,7 @@ design: (work@top)
   |vpiTypedef:
   \_enum_typespec: (ibex_tracer_pkg::ibex_pkg::opcode_e), line:8
   |vpiTypedef:
-  \_import: (ibex_pkg)
+  \_import: (ibex_pkg), line:12
   |vpiParamAssign:
   \_param_assign: , line:13, parent:ibex_tracer_pkg::
     |vpiRhs:
@@ -190,7 +190,7 @@ design: (work@top)
       |vpiName:OPCODE_LUI
       |UINT:55
   |vpiTypedef:
-  \_import: (ibex_pkg)
+  \_import: (ibex_pkg), line:19
 |uhdmtopModules:
 \_module: work@top (work@top) dut.sv:18: 
   |vpiDefName:work@top
@@ -269,7 +269,7 @@ design: (work@top)
       |vpiName:OPCODE_LUI
       |UINT:55
   |vpiTypedef:
-  \_import: (ibex_pkg)
+  \_import: (ibex_pkg), line:19
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/PackageParam/PackageParam.log
+++ b/tests/PackageParam/PackageParam.log
@@ -385,9 +385,9 @@ design: (unnamed)
   |vpiName:otp_ctrl_pkg
   |vpiFullName:otp_ctrl_pkg::
   |vpiTypedef:
-  \_import: (prim_util_pkg)
+  \_import: (prim_util_pkg), line:30
   |vpiTypedef:
-  \_import: (otp_ctrl_reg_pkg)
+  \_import: (otp_ctrl_reg_pkg), line:31
   |vpiParamAssign:
   \_param_assign: , line:22, parent:otp_ctrl_pkg::
     |vpiRhs:

--- a/tests/PackageValue/PackageValue.log
+++ b/tests/PackageValue/PackageValue.log
@@ -1504,7 +1504,7 @@ design: (work@prim_diff_decode)
       |vpiName:ImplXilinx
       |UINT:0
   |vpiTypedef:
-  \_import: (prim_pkg)
+  \_import: (prim_pkg), line:15
   |vpiParamAssign:
   \_param_assign: , line:12, parent:work@prim_diff_decode
     |vpiRhs:
@@ -1604,7 +1604,7 @@ design: (work@prim_diff_decode)
       |vpiName:ImplXilinx
       |UINT:0
   |vpiTypedef:
-  \_import: (prim_pkg), parent:work@prim_diff_decode
+  \_import: (prim_pkg), line:15, parent:work@prim_diff_decode
   |vpiParamAssign:
   \_param_assign: , line:12, parent:work@prim_diff_decode
     |vpiRhs:

--- a/tests/ParamArray/ParamArray.log
+++ b/tests/ParamArray/ParamArray.log
@@ -369,7 +369,7 @@ design: (work@top)
           |vpiParameter:
           \_parameter: (otp_ctrl_pkg::NumPart), line:5, parent:otp_ctrl_pkg::
   |vpiTypedef:
-  \_import: (otp_ctrl_pkg)
+  \_import: (otp_ctrl_pkg), line:10
   |vpiParamAssign:
   \_param_assign: , line:5, parent:otp_ctrl_part_pkg::
     |vpiRhs:
@@ -778,6 +778,8 @@ design: (work@top)
                 \_package: otp_ctrl_pkg (otp_ctrl_pkg::) dut.sv:1: , parent:work@top
           |vpiParameter:
           \_parameter: (otp_ctrl_pkg::NumPart), line:5, parent:otp_ctrl_pkg::
+  |vpiTypedef:
+  \_import: (otp_ctrl_pkg), line:30
   |vpiParamAssign:
   \_param_assign: , line:5, parent:work@otp_ctrl_lci
     |vpiRhs:
@@ -874,7 +876,7 @@ design: (work@top)
   |vpiTypedef:
   \_struct_typespec: (otp_ctrl_pkg::otp_ctrl_part_pkg::part_info_t), line:2, parent:work@otp_ctrl_lci.Info
   |vpiTypedef:
-  \_import: (otp_ctrl_part_pkg)
+  \_import: (otp_ctrl_part_pkg), line:44
   |vpiParamAssign:
   \_param_assign: , line:5, parent:work@top
     |vpiRhs:
@@ -1144,6 +1146,8 @@ design: (work@top)
                   \_package: otp_ctrl_pkg (otp_ctrl_pkg::) dut.sv:1: , parent:work@top
             |vpiParameter:
             \_parameter: (otp_ctrl_pkg::NumPart), line:5, parent:otp_ctrl_pkg::
+    |vpiTypedef:
+    \_import: (otp_ctrl_pkg), line:30, parent:work@top.u_otp_ctrl_lci
     |vpiParamAssign:
     \_param_assign: , line:33, parent:work@top.u_otp_ctrl_lci
       |vpiRhs:
@@ -1268,7 +1272,7 @@ design: (work@top)
         |vpiInstance:
         \_package: otp_ctrl_pkg (otp_ctrl_pkg::) dut.sv:1: , parent:work@top
   |vpiTypedef:
-  \_import: (otp_ctrl_part_pkg), parent:work@top
+  \_import: (otp_ctrl_part_pkg), line:44, parent:work@top
   |vpiParamAssign:
   \_param_assign: , line:5, parent:work@top
     |vpiRhs:

--- a/tests/ParamArraySelect/ParamArraySelect.log
+++ b/tests/ParamArraySelect/ParamArraySelect.log
@@ -614,7 +614,7 @@ design: (work@top)
           |vpiParameter:
           \_parameter: (otp_ctrl_pkg::NumPart), line:5, parent:otp_ctrl_pkg::
   |vpiTypedef:
-  \_import: (otp_ctrl_pkg)
+  \_import: (otp_ctrl_pkg), line:10
   |vpiParamAssign:
   \_param_assign: , line:5, parent:otp_ctrl_part_pkg::
     |vpiRhs:
@@ -1045,6 +1045,8 @@ design: (work@top)
                 \_package: otp_ctrl_pkg (otp_ctrl_pkg::) dut.sv:1: , parent:work@top
           |vpiParameter:
           \_parameter: (otp_ctrl_pkg::NumPart), line:5, parent:otp_ctrl_pkg::
+  |vpiTypedef:
+  \_import: (otp_ctrl_pkg), line:33
   |vpiParamAssign:
   \_param_assign: , line:5, parent:work@otp_ctrl_lci
     |vpiRhs:
@@ -1146,7 +1148,7 @@ design: (work@top)
   |vpiTypedef:
   \_struct_typespec: (otp_ctrl_pkg::otp_ctrl_part_pkg::part_info_t), line:2, parent:work@otp_ctrl_lci.Info
   |vpiTypedef:
-  \_import: (otp_ctrl_part_pkg)
+  \_import: (otp_ctrl_part_pkg), line:51
   |vpiParamAssign:
   \_param_assign: , line:5, parent:work@top
     |vpiRhs:
@@ -1455,6 +1457,8 @@ design: (work@top)
                   \_package: otp_ctrl_pkg (otp_ctrl_pkg::) dut.sv:1: , parent:work@top
             |vpiParameter:
             \_parameter: (otp_ctrl_pkg::NumPart), line:5, parent:otp_ctrl_pkg::
+    |vpiTypedef:
+    \_import: (otp_ctrl_pkg), line:33, parent:work@top.u_otp_ctrl_lci
     |vpiParamAssign:
     \_param_assign: , line:36, parent:work@top.u_otp_ctrl_lci
       |vpiRhs:
@@ -1761,7 +1765,7 @@ design: (work@top)
         |vpiInstance:
         \_package: otp_ctrl_pkg (otp_ctrl_pkg::) dut.sv:1: , parent:work@top
   |vpiTypedef:
-  \_import: (otp_ctrl_part_pkg), parent:work@top
+  \_import: (otp_ctrl_part_pkg), line:51, parent:work@top
   |vpiParamAssign:
   \_param_assign: , line:5, parent:work@top
     |vpiRhs:

--- a/tests/ParamCast/ParamCast.log
+++ b/tests/ParamCast/ParamCast.log
@@ -471,7 +471,7 @@ design: (work@otp_ctrl)
       |vpiName:NumAgentsIdx
       |INT:3
   |vpiTypedef:
-  \_import: (otp_ctrl_part_pkg)
+  \_import: (otp_ctrl_part_pkg), line:16
   |vpiParamAssign:
   \_param_assign: , line:10, parent:work@otp_ctrl
     |vpiRhs:
@@ -564,7 +564,7 @@ design: (work@otp_ctrl)
       |vpiName:NumAgentsIdx
       |INT:3
   |vpiTypedef:
-  \_import: (otp_ctrl_part_pkg), parent:work@otp_ctrl
+  \_import: (otp_ctrl_part_pkg), line:16, parent:work@otp_ctrl
   |vpiParamAssign:
   \_param_assign: , line:10, parent:work@otp_ctrl
     |vpiRhs:

--- a/tests/PortWildcard/PortWildcard.log
+++ b/tests/PortWildcard/PortWildcard.log
@@ -629,7 +629,7 @@ design: (work@dut)
       |vpiName:rst_l
       |vpiDirection:1
       |vpiHighConn:
-      \_ref_obj: (rst_l), line:7
+      \_ref_obj: (rst_l), line:17
         |vpiName:rst_l
         |vpiActual:
         \_logic_net: (work@dut.rst_l), line:16, parent:work@dut

--- a/tests/StructTypedef/StructTypedef.log
+++ b/tests/StructTypedef/StructTypedef.log
@@ -505,7 +505,7 @@ design: (work@top)
       |vpiTypedef:
       \_struct_typespec: (flash_ctrl_reg_pkg::flash_ctrl_pkg::mp_region_cfg_t), line:3
   |vpiTypedef:
-  \_import: (flash_ctrl_pkg)
+  \_import: (flash_ctrl_pkg), line:22
 |uhdmtopModules:
 \_module: work@top (work@top) dut.sv:21: 
   |vpiDefName:work@top
@@ -597,7 +597,7 @@ design: (work@top)
     |vpiInstance:
     \_package: flash_ctrl_pkg (flash_ctrl_pkg::) dut.sv:15: , parent:work@top
   |vpiTypedef:
-  \_import: (flash_ctrl_pkg), parent:work@top
+  \_import: (flash_ctrl_pkg), line:22, parent:work@top
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/StructVarImp/StructVarImp.log
+++ b/tests/StructVarImp/StructVarImp.log
@@ -856,7 +856,7 @@ design: (work@top)
     |vpiInstance:
     \_package: flash_ctrl_reg_pkg (flash_ctrl_reg_pkg::) dut.sv:1: , parent:work@top
   |vpiTypedef:
-  \_import: (flash_ctrl_reg_pkg)
+  \_import: (flash_ctrl_reg_pkg), line:34
   |vpiParamAssign:
   \_param_assign: , line:4, parent:work@top
     |vpiRhs:
@@ -1227,7 +1227,7 @@ design: (work@top)
     |vpiInstance:
     \_package: flash_ctrl_reg_pkg (flash_ctrl_reg_pkg::) dut.sv:1: , parent:work@top
   |vpiTypedef:
-  \_import: (flash_ctrl_reg_pkg), parent:work@top
+  \_import: (flash_ctrl_reg_pkg), line:34, parent:work@top
   |vpiParamAssign:
   \_param_assign: , line:4, parent:work@top
     |vpiRhs:

--- a/tests/UnitEnum/UnitEnum.log
+++ b/tests/UnitEnum/UnitEnum.log
@@ -507,7 +507,7 @@ design: (work@top)
       |vpiName:WRITE
       |INT:1
   |vpiTypedef:
-  \_import: (pkg)
+  \_import: (pkg), line:15
 |uhdmtopModules:
 \_module: work@top (work@top) top.v:14: 
   |vpiDefName:work@top
@@ -596,7 +596,7 @@ design: (work@top)
   |vpiTypedef:
   \_enum_typespec: (pkg::fsm_t_pkg), line:6
   |vpiTypedef:
-  \_import: (pkg)
+  \_import: (pkg), line:15
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/WildConn/WildConn.log
+++ b/tests/WildConn/WildConn.log
@@ -458,7 +458,7 @@ design: (work@top)
       |vpiName:a
       |vpiDirection:1
       |vpiHighConn:
-      \_ref_obj: (a), line:2
+      \_ref_obj: (a), line:14
         |vpiName:a
         |vpiActual:
         \_logic_net: (work@top.a), line:8, parent:work@top
@@ -474,7 +474,7 @@ design: (work@top)
       |vpiName:b
       |vpiDirection:1
       |vpiHighConn:
-      \_ref_obj: (b), line:3
+      \_ref_obj: (b), line:14
         |vpiName:b
         |vpiActual:
         \_logic_net: (work@top.b), line:9, parent:work@top

--- a/third_party/tests/CoresSweRV/CoresSweRV.log
+++ b/third_party/tests/CoresSweRV/CoresSweRV.log
@@ -4743,12 +4743,6 @@ there are 4 more instances of this message.
 
 [INF:CP0335] ${SURELOG_DIR}/third_party/tests/CoresSweRV/design/lib/beh_lib.sv:217: Compile generate block "work@tb_top.rvtop.swerv.dma_ctrl.rdbuf_addrff.genblock".
 
-
-INTERNAL OUT OF BOUND ERROR
-
-
-INTERNAL OUT OF BOUND ERROR
-
 [INF:CP0335] design/mem.sv:105: Compile generate block "work@tb_top.rvtop.mem.Gen_dccm_enable".
 
 [INF:CP0335] ${SURELOG_DIR}/third_party/tests/CoresSweRV/design/lib/beh_lib.sv:217: Compile generate block "work@tb_top.rvtop.mem.Gen_dccm_enable.dccm.dccm_rd_data_loff.genblock".

--- a/third_party/tests/Sky130Cell/Sky130Cell.log
+++ b/third_party/tests/Sky130Cell/Sky130Cell.log
@@ -99,11 +99,9 @@ design: (unnamed)
     |vpiSize:5
     |STRING:? ? ? ? *  : ? : x 
 ===================
-[ERR:UH0704] sky130_fd_sc_hd__udp_dff_p_pp_pg_n.v:74: UHDM coverage pointing to empty source line.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd models/udp_dff_ps -DUNIT_DELAY -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -d uhdm sky130_fd_sc_hd__udp_dff_ps.v -l sky130_fd_sc_hd__udp_dff_ps.v.log
@@ -191,11 +189,9 @@ design: (unnamed)
     |vpiSize:3
     |STRING:? b ?x : 1 : 1 
 ===================
-[ERR:UH0704] sky130_fd_sc_hd__udp_dff_ps.v:66: UHDM coverage pointing to empty source line.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd models/udp_mux_2to1 -DUNIT_DELAY -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -d uhdm sky130_fd_sc_hd__udp_mux_2to1.v -l sky130_fd_sc_hd__udp_mux_2to1.v.log
@@ -263,11 +259,9 @@ design: (unnamed)
     |vpiSize:3
     |STRING:? 1 1 : 1
 ===================
-[ERR:UH0704] sky130_fd_sc_hd__udp_mux_2to1.v:59: UHDM coverage pointing to empty source line.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd models/udp_dff_nsr -DUNIT_DELAY -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -d uhdm sky130_fd_sc_hd__udp_dff_nsr.v -l sky130_fd_sc_hd__udp_dff_nsr.v.log
@@ -359,11 +353,9 @@ design: (unnamed)
     |vpiSize:4
     |STRING:0 0 ? *  : ? : -
 ===================
-[ERR:UH0704] sky130_fd_sc_hd__udp_dff_nsr.v:68: UHDM coverage pointing to empty source line.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd models/udp_dlatch_pr_pp_pg_n -DUNIT_DELAY -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -d uhdm sky130_fd_sc_hd__udp_dlatch_pr_pp_pg_n.v -l sky130_fd_sc_hd__udp_dlatch_pr_pp_pg_n.v.log
@@ -531,11 +523,9 @@ design: (unnamed)
     |vpiSize:6
     |STRING:1 1 0 ? 1 ?0 : ? : 1 
 ===================
-[ERR:UH0704] sky130_fd_sc_hd__udp_dlatch_pr_pp_pg_n.v:90: UHDM coverage pointing to empty source line.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd models/udp_pwrgood_l_pp_pg -DUNIT_DELAY -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -d uhdm sky130_fd_sc_hd__udp_pwrgood_l_pp_pg.v -l sky130_fd_sc_hd__udp_pwrgood_l_pp_pg.v.log
@@ -607,11 +597,9 @@ design: (unnamed)
     |vpiSize:3
     |STRING:? 1 x : x
 ===================
-[ERR:UH0704] sky130_fd_sc_hd__udp_pwrgood_l_pp_pg.v:62: UHDM coverage pointing to empty source line.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd models/udp_mux_4to2 -DUNIT_DELAY -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -d uhdm sky130_fd_sc_hd__udp_mux_4to2.v -l sky130_fd_sc_hd__udp_mux_4to2.v.log
@@ -751,11 +739,9 @@ design: (unnamed)
     |vpiSize:6
     |STRING:? 1 ? 1 1 ? : 1
 ===================
-[ERR:UH0704] sky130_fd_sc_hd__udp_mux_4to2.v:77: UHDM coverage pointing to empty source line.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd models/udp_dff_p -DUNIT_DELAY -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -d uhdm sky130_fd_sc_hd__udp_dff_p.v -l sky130_fd_sc_hd__udp_dff_p.v.log
@@ -827,11 +813,9 @@ design: (unnamed)
     |vpiSize:2
     |STRING:*  ? : ? : -
 ===================
-[ERR:UH0704] sky130_fd_sc_hd__udp_dff_p.v:62: UHDM coverage pointing to empty source line.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd models/udp_dlatch_p_pp_pg_n -DUNIT_DELAY -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -d uhdm sky130_fd_sc_hd__udp_dlatch_p_pp_pg_n.v -l sky130_fd_sc_hd__udp_dlatch_p_pp_pg_n.v.log
@@ -955,11 +939,9 @@ design: (unnamed)
     |vpiSize:5
     |STRING:1 1 ? 1 ?0 : ? : 1 
 ===================
-[ERR:UH0704] sky130_fd_sc_hd__udp_dlatch_p_pp_pg_n.v:79: UHDM coverage pointing to empty source line.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd models/udp_dff_nsr_pp_pg_n -DUNIT_DELAY -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -d uhdm sky130_fd_sc_hd__udp_dff_nsr_pp_pg_n.v -l sky130_fd_sc_hd__udp_dff_nsr_pp_pg_n.v.log
@@ -1103,11 +1085,9 @@ design: (unnamed)
     |vpiSize:7
     |STRING:? ? ? ? ? ? *  : ? : X 
 ===================
-[ERR:UH0704] sky130_fd_sc_hd__udp_dff_nsr_pp_pg_n.v:86: UHDM coverage pointing to empty source line.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd models/udp_pwrgood_l_pp_pg_s -DUNIT_DELAY -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -d uhdm sky130_fd_sc_hd__udp_pwrgood_l_pp_pg_s.v -l sky130_fd_sc_hd__udp_pwrgood_l_pp_pg_s.v.log
@@ -1199,11 +1179,9 @@ design: (unnamed)
     |vpiSize:4
     |STRING:? ? x 1 : x
 ===================
-[ERR:UH0704] sky130_fd_sc_hd__udp_pwrgood_l_pp_pg_s.v:67: UHDM coverage pointing to empty source line.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd models/udp_pwrgood_pp_g -DUNIT_DELAY -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -d uhdm sky130_fd_sc_hd__udp_pwrgood_pp_g.v -l sky130_fd_sc_hd__udp_pwrgood_pp_g.v.log
@@ -1255,11 +1233,9 @@ design: (unnamed)
     |vpiSize:2
     |STRING:? x : x
 ===================
-[ERR:UH0704] sky130_fd_sc_hd__udp_pwrgood_pp_g.v:57: UHDM coverage pointing to empty source line.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd models/udp_mux_2to1_n -DUNIT_DELAY -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -d uhdm sky130_fd_sc_hd__udp_mux_2to1_n.v -l sky130_fd_sc_hd__udp_mux_2to1_n.v.log
@@ -1327,11 +1303,9 @@ design: (unnamed)
     |vpiSize:3
     |STRING:1 1 ? : 0
 ===================
-[ERR:UH0704] sky130_fd_sc_hd__udp_mux_2to1_n.v:59: UHDM coverage pointing to empty source line.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd models/udp_dff_pr -DUNIT_DELAY -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -d uhdm sky130_fd_sc_hd__udp_dff_pr.v -l sky130_fd_sc_hd__udp_dff_pr.v.log
@@ -1419,11 +1393,9 @@ design: (unnamed)
     |vpiSize:3
     |STRING:? b ?x : 0 : 0 
 ===================
-[ERR:UH0704] sky130_fd_sc_hd__udp_dff_pr.v:66: UHDM coverage pointing to empty source line.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd models/udp_pwrgood_pp_pg -DUNIT_DELAY -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -d uhdm sky130_fd_sc_hd__udp_pwrgood_pp_pg.v -l sky130_fd_sc_hd__udp_pwrgood_pp_pg.v.log
@@ -1495,11 +1467,9 @@ design: (unnamed)
     |vpiSize:3
     |STRING:? 1 x : x
 ===================
-[ERR:UH0704] sky130_fd_sc_hd__udp_pwrgood_pp_pg.v:62: UHDM coverage pointing to empty source line.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd models/udp_dlatch_lp -DUNIT_DELAY -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -d uhdm sky130_fd_sc_hd__udp_dlatch_lp.v -l sky130_fd_sc_hd__udp_dlatch_lp.v.log
@@ -1555,11 +1525,9 @@ design: (unnamed)
     |vpiSize:2
     |STRING:1 x : 1 : 1 
 ===================
-[ERR:UH0704] sky130_fd_sc_hd__udp_dlatch_lp.v:59: UHDM coverage pointing to empty source line.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd models/udp_dff_pr_pp_pg_n -DUNIT_DELAY -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -d uhdm sky130_fd_sc_hd__udp_dff_pr_pp_pg_n.v -l sky130_fd_sc_hd__udp_dff_pr_pp_pg_n.v.log
@@ -1679,11 +1647,9 @@ design: (unnamed)
     |vpiSize:6
     |STRING:? ? ? ? ? *  : ? : x 
 ===================
-[ERR:UH0704] sky130_fd_sc_hd__udp_dff_pr_pp_pg_n.v:78: UHDM coverage pointing to empty source line.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd models/udp_pwrgood_pp_p -DUNIT_DELAY -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -d uhdm sky130_fd_sc_hd__udp_pwrgood_pp_p.v -l sky130_fd_sc_hd__udp_pwrgood_pp_p.v.log
@@ -1735,11 +1701,9 @@ design: (unnamed)
     |vpiSize:2
     |STRING:? x : x
 ===================
-[ERR:UH0704] sky130_fd_sc_hd__udp_pwrgood_pp_p.v:57: UHDM coverage pointing to empty source line.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd models/udp_dlatch_lp_pp_pg_n -DUNIT_DELAY -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -d uhdm sky130_fd_sc_hd__udp_dlatch_lp_pp_pg_n.v -l sky130_fd_sc_hd__udp_dlatch_lp_pp_pg_n.v.log
@@ -1855,11 +1819,9 @@ design: (unnamed)
     |vpiSize:5
     |STRING:? ? ? ? *  : ? : x 
 ===================
-[ERR:UH0704] sky130_fd_sc_hd__udp_dlatch_lp_pp_pg_n.v:77: UHDM coverage pointing to empty source line.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd models/udp_pwrgood_l_pp_g -DUNIT_DELAY -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -d uhdm sky130_fd_sc_hd__udp_pwrgood_l_pp_g.v -l sky130_fd_sc_hd__udp_pwrgood_l_pp_g.v.log
@@ -1915,11 +1877,9 @@ design: (unnamed)
     |vpiSize:2
     |STRING:? x : x
 ===================
-[ERR:UH0704] sky130_fd_sc_hd__udp_pwrgood_l_pp_g.v:58: UHDM coverage pointing to empty source line.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd models/udp_dlatch_pr -DUNIT_DELAY -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -d uhdm sky130_fd_sc_hd__udp_dlatch_pr.v -l sky130_fd_sc_hd__udp_dlatch_pr.v.log
@@ -1999,11 +1959,9 @@ design: (unnamed)
     |vpiSize:3
     |STRING:0 x x : 0 : 0 
 ===================
-[ERR:UH0704] sky130_fd_sc_hd__udp_dlatch_pr.v:65: UHDM coverage pointing to empty source line.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd models/udp_dff_ps_pp_pg_n -DUNIT_DELAY -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -d uhdm sky130_fd_sc_hd__udp_dff_ps_pp_pg_n.v -l sky130_fd_sc_hd__udp_dff_ps_pp_pg_n.v.log
@@ -2123,11 +2081,9 @@ design: (unnamed)
     |vpiSize:6
     |STRING:? ? ? ? ? *  : ? : x 
 ===================
-[ERR:UH0704] sky130_fd_sc_hd__udp_dff_ps_pp_pg_n.v:78: UHDM coverage pointing to empty source line.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd models/udp_dlatch_p -DUNIT_DELAY -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -d uhdm sky130_fd_sc_hd__udp_dlatch_p.v -l sky130_fd_sc_hd__udp_dlatch_p.v.log
@@ -2183,11 +2139,9 @@ design: (unnamed)
     |vpiSize:2
     |STRING:1 x : 1 : 1 
 ===================
-[ERR:UH0704] sky130_fd_sc_hd__udp_dlatch_p.v:59: UHDM coverage pointing to empty source line.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd cells/cells -DUNIT_DELAY -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -d uhdm sky130_fd_sc_hd__tapvgnd2.functional.v -l sky130_fd_sc_hd__tapvgnd2.functional.v.log
@@ -43510,7 +43464,7 @@ design: (work@sky130_fd_sc_hd__dlygate4sd3)
 Processed 186 tests.
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 165
+[  ERROR] : 142
 [WARNING] : 9
 [   NOTE] : 0
 

--- a/third_party/tests/Sky130Udp/Sky130Udp.log
+++ b/third_party/tests/Sky130Udp/Sky130Udp.log
@@ -99,11 +99,9 @@ design: (unnamed)
     |vpiSize:5
     |STRING:? ? ? ? *  : ? : x 
 ===================
-[ERR:UH0704] sky130_fd_sc_hd__udp_dff_p_pp_pg_n.v:74: UHDM coverage pointing to empty source line.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd udp_dff_ps -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -d uhdm sky130_fd_sc_hd__udp_dff_ps.v -l sky130_fd_sc_hd__udp_dff_ps.v.log
@@ -191,11 +189,9 @@ design: (unnamed)
     |vpiSize:3
     |STRING:? b ?x : 1 : 1 
 ===================
-[ERR:UH0704] sky130_fd_sc_hd__udp_dff_ps.v:66: UHDM coverage pointing to empty source line.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd udp_mux_2to1 -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -d uhdm sky130_fd_sc_hd__udp_mux_2to1.v -l sky130_fd_sc_hd__udp_mux_2to1.v.log
@@ -263,11 +259,9 @@ design: (unnamed)
     |vpiSize:3
     |STRING:? 1 1 : 1
 ===================
-[ERR:UH0704] sky130_fd_sc_hd__udp_mux_2to1.v:59: UHDM coverage pointing to empty source line.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd udp_dff_nsr -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -d uhdm sky130_fd_sc_hd__udp_dff_nsr.v -l sky130_fd_sc_hd__udp_dff_nsr.v.log
@@ -359,11 +353,9 @@ design: (unnamed)
     |vpiSize:4
     |STRING:0 0 ? *  : ? : -
 ===================
-[ERR:UH0704] sky130_fd_sc_hd__udp_dff_nsr.v:68: UHDM coverage pointing to empty source line.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd udp_dlatch_pr_pp_pg_n -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -d uhdm sky130_fd_sc_hd__udp_dlatch_pr_pp_pg_n.v -l sky130_fd_sc_hd__udp_dlatch_pr_pp_pg_n.v.log
@@ -531,11 +523,9 @@ design: (unnamed)
     |vpiSize:6
     |STRING:1 1 0 ? 1 ?0 : ? : 1 
 ===================
-[ERR:UH0704] sky130_fd_sc_hd__udp_dlatch_pr_pp_pg_n.v:90: UHDM coverage pointing to empty source line.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd udp_pwrgood_l_pp_pg -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -d uhdm sky130_fd_sc_hd__udp_pwrgood_l_pp_pg.v -l sky130_fd_sc_hd__udp_pwrgood_l_pp_pg.v.log
@@ -607,11 +597,9 @@ design: (unnamed)
     |vpiSize:3
     |STRING:? 1 x : x
 ===================
-[ERR:UH0704] sky130_fd_sc_hd__udp_pwrgood_l_pp_pg.v:62: UHDM coverage pointing to empty source line.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd udp_mux_4to2 -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -d uhdm sky130_fd_sc_hd__udp_mux_4to2.v -l sky130_fd_sc_hd__udp_mux_4to2.v.log
@@ -751,11 +739,9 @@ design: (unnamed)
     |vpiSize:6
     |STRING:? 1 ? 1 1 ? : 1
 ===================
-[ERR:UH0704] sky130_fd_sc_hd__udp_mux_4to2.v:77: UHDM coverage pointing to empty source line.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd udp_dff_p -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -d uhdm sky130_fd_sc_hd__udp_dff_p.v -l sky130_fd_sc_hd__udp_dff_p.v.log
@@ -827,11 +813,9 @@ design: (unnamed)
     |vpiSize:2
     |STRING:*  ? : ? : -
 ===================
-[ERR:UH0704] sky130_fd_sc_hd__udp_dff_p.v:62: UHDM coverage pointing to empty source line.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd udp_dlatch_p_pp_pg_n -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -d uhdm sky130_fd_sc_hd__udp_dlatch_p_pp_pg_n.v -l sky130_fd_sc_hd__udp_dlatch_p_pp_pg_n.v.log
@@ -955,11 +939,9 @@ design: (unnamed)
     |vpiSize:5
     |STRING:1 1 ? 1 ?0 : ? : 1 
 ===================
-[ERR:UH0704] sky130_fd_sc_hd__udp_dlatch_p_pp_pg_n.v:79: UHDM coverage pointing to empty source line.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd udp_dff_nsr_pp_pg_n -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -d uhdm sky130_fd_sc_hd__udp_dff_nsr_pp_pg_n.v -l sky130_fd_sc_hd__udp_dff_nsr_pp_pg_n.v.log
@@ -1103,11 +1085,9 @@ design: (unnamed)
     |vpiSize:7
     |STRING:? ? ? ? ? ? *  : ? : X 
 ===================
-[ERR:UH0704] sky130_fd_sc_hd__udp_dff_nsr_pp_pg_n.v:86: UHDM coverage pointing to empty source line.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd udp_pwrgood_l_pp_pg_s -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -d uhdm sky130_fd_sc_hd__udp_pwrgood_l_pp_pg_s.v -l sky130_fd_sc_hd__udp_pwrgood_l_pp_pg_s.v.log
@@ -1199,11 +1179,9 @@ design: (unnamed)
     |vpiSize:4
     |STRING:? ? x 1 : x
 ===================
-[ERR:UH0704] sky130_fd_sc_hd__udp_pwrgood_l_pp_pg_s.v:67: UHDM coverage pointing to empty source line.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd udp_pwrgood_pp_g -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -d uhdm sky130_fd_sc_hd__udp_pwrgood_pp_g.v -l sky130_fd_sc_hd__udp_pwrgood_pp_g.v.log
@@ -1255,11 +1233,9 @@ design: (unnamed)
     |vpiSize:2
     |STRING:? x : x
 ===================
-[ERR:UH0704] sky130_fd_sc_hd__udp_pwrgood_pp_g.v:57: UHDM coverage pointing to empty source line.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd udp_mux_2to1_n -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -d uhdm sky130_fd_sc_hd__udp_mux_2to1_n.v -l sky130_fd_sc_hd__udp_mux_2to1_n.v.log
@@ -1327,11 +1303,9 @@ design: (unnamed)
     |vpiSize:3
     |STRING:1 1 ? : 0
 ===================
-[ERR:UH0704] sky130_fd_sc_hd__udp_mux_2to1_n.v:59: UHDM coverage pointing to empty source line.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd udp_dff_pr -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -d uhdm sky130_fd_sc_hd__udp_dff_pr.v -l sky130_fd_sc_hd__udp_dff_pr.v.log
@@ -1419,11 +1393,9 @@ design: (unnamed)
     |vpiSize:3
     |STRING:? b ?x : 0 : 0 
 ===================
-[ERR:UH0704] sky130_fd_sc_hd__udp_dff_pr.v:66: UHDM coverage pointing to empty source line.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd udp_pwrgood_pp_pg -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -d uhdm sky130_fd_sc_hd__udp_pwrgood_pp_pg.v -l sky130_fd_sc_hd__udp_pwrgood_pp_pg.v.log
@@ -1495,11 +1467,9 @@ design: (unnamed)
     |vpiSize:3
     |STRING:? 1 x : x
 ===================
-[ERR:UH0704] sky130_fd_sc_hd__udp_pwrgood_pp_pg.v:62: UHDM coverage pointing to empty source line.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd udp_dlatch_lp -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -d uhdm sky130_fd_sc_hd__udp_dlatch_lp.v -l sky130_fd_sc_hd__udp_dlatch_lp.v.log
@@ -1555,11 +1525,9 @@ design: (unnamed)
     |vpiSize:2
     |STRING:1 x : 1 : 1 
 ===================
-[ERR:UH0704] sky130_fd_sc_hd__udp_dlatch_lp.v:59: UHDM coverage pointing to empty source line.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd udp_dff_pr_pp_pg_n -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -d uhdm sky130_fd_sc_hd__udp_dff_pr_pp_pg_n.v -l sky130_fd_sc_hd__udp_dff_pr_pp_pg_n.v.log
@@ -1679,11 +1647,9 @@ design: (unnamed)
     |vpiSize:6
     |STRING:? ? ? ? ? *  : ? : x 
 ===================
-[ERR:UH0704] sky130_fd_sc_hd__udp_dff_pr_pp_pg_n.v:78: UHDM coverage pointing to empty source line.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd udp_pwrgood_pp_p -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -d uhdm sky130_fd_sc_hd__udp_pwrgood_pp_p.v -l sky130_fd_sc_hd__udp_pwrgood_pp_p.v.log
@@ -1735,11 +1701,9 @@ design: (unnamed)
     |vpiSize:2
     |STRING:? x : x
 ===================
-[ERR:UH0704] sky130_fd_sc_hd__udp_pwrgood_pp_p.v:57: UHDM coverage pointing to empty source line.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd udp_dlatch_lp_pp_pg_n -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -d uhdm sky130_fd_sc_hd__udp_dlatch_lp_pp_pg_n.v -l sky130_fd_sc_hd__udp_dlatch_lp_pp_pg_n.v.log
@@ -1855,11 +1819,9 @@ design: (unnamed)
     |vpiSize:5
     |STRING:? ? ? ? *  : ? : x 
 ===================
-[ERR:UH0704] sky130_fd_sc_hd__udp_dlatch_lp_pp_pg_n.v:77: UHDM coverage pointing to empty source line.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd udp_pwrgood_l_pp_g -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -d uhdm sky130_fd_sc_hd__udp_pwrgood_l_pp_g.v -l sky130_fd_sc_hd__udp_pwrgood_l_pp_g.v.log
@@ -1915,11 +1877,9 @@ design: (unnamed)
     |vpiSize:2
     |STRING:? x : x
 ===================
-[ERR:UH0704] sky130_fd_sc_hd__udp_pwrgood_l_pp_g.v:58: UHDM coverage pointing to empty source line.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd udp_dlatch_pr -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -d uhdm sky130_fd_sc_hd__udp_dlatch_pr.v -l sky130_fd_sc_hd__udp_dlatch_pr.v.log
@@ -1999,11 +1959,9 @@ design: (unnamed)
     |vpiSize:3
     |STRING:0 x x : 0 : 0 
 ===================
-[ERR:UH0704] sky130_fd_sc_hd__udp_dlatch_pr.v:65: UHDM coverage pointing to empty source line.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd udp_dff_ps_pp_pg_n -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -d uhdm sky130_fd_sc_hd__udp_dff_ps_pp_pg_n.v -l sky130_fd_sc_hd__udp_dff_ps_pp_pg_n.v.log
@@ -2123,11 +2081,9 @@ design: (unnamed)
     |vpiSize:6
     |STRING:? ? ? ? ? *  : ? : x 
 ===================
-[ERR:UH0704] sky130_fd_sc_hd__udp_dff_ps_pp_pg_n.v:78: UHDM coverage pointing to empty source line.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd udp_dlatch_p -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -d uhdm sky130_fd_sc_hd__udp_dlatch_p.v -l sky130_fd_sc_hd__udp_dlatch_p.v.log
@@ -2183,17 +2139,15 @@ design: (unnamed)
     |vpiSize:2
     |STRING:1 x : 1 : 1 
 ===================
-[ERR:UH0704] sky130_fd_sc_hd__udp_dlatch_p.v:59: UHDM coverage pointing to empty source line.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processed 23 tests.
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 23
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 

--- a/third_party/tests/ariane/Ariane.log
+++ b/third_party/tests/ariane/Ariane.log
@@ -3929,27 +3929,11 @@ there are 1 more instances of this message.
 [WRN:EL0513] Nb undefined instances: 3.
 
 UHDM HTML COVERAGE REPORT: work-ver/slpp_all//surelog.uhdm.chk.html
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_divsqrt_multi.sv:126: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:206: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma_multi.sv:209: UHDM coverage pointing to empty source line.
-
 [ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/ariane.sv:743: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_fma.sv:207: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_opgroup_multifmt_slice.sv:127: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:127: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_noncomp.sv:210: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] ${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpnew_cast_multi.sv:206: UHDM coverage pointing to empty source line.
 
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 12
+[  ERROR] : 4
 [WARNING] : 21
 [   NOTE] : 23
 make[5]: Entering directory '${SURELOG_DIR}/third_party/tests/ariane/work-ver'


### PR DESCRIPTION
Restrict UHDM Code Coverage to the modules used in the design. Add coverage for import and .* statements.