### PR TITLE
Fix setting parameter to 0 from command-line

### DIFF
--- a/src/Expression/ExprBuilder.cpp
+++ b/src/Expression/ExprBuilder.cpp
@@ -802,7 +802,9 @@ Value* ExprBuilder::fromVpiValue(const std::string& s) {
 Value* ExprBuilder::fromString(const std::string& value) {
   Value* val = nullptr;
   std::string sval;
-  if (strstr(value.c_str(), "'")) {
+  const char *value_ptr = value.c_str();
+  char *end_parse_ptr;
+  if (strstr(value_ptr, "'")) {
     char base = 'b';
     unsigned int i = 0;
     for (i = 0; i < value.size(); i++) {
@@ -860,20 +862,23 @@ Value* ExprBuilder::fromString(const std::string& value) {
         break;
       }
     }
-  } else if (strstr(value.c_str(), ".")) {
-    long double v = std::strtold(value.c_str(), 0);
+  } else if (strstr(value_ptr, ".")) {
+    long double v = std::strtold(value_ptr, 0);
     val = m_valueFactory.newLValue();
     val->set((double) v);  
   } else if (value.size() && value[0] == '-') {
-    int64_t v = std::strtoll(value.c_str(), 0, 10);
+    int64_t v = std::strtoll(value_ptr, 0, 10);
     val = m_valueFactory.newLValue();
     val->set(v);  
-  } else if (uint64_t v = std::strtoull(value.c_str(), 0, 10)) {
-    val = m_valueFactory.newLValue();
-    val->set(v);
   } else {
-    val = m_valueFactory.newStValue();
-    val->set(value);
+    uint64_t v = std::strtoull(value_ptr, &end_parse_ptr, 10);
+    if (value_ptr != end_parse_ptr) {
+      val = m_valueFactory.newLValue();
+      val->set(v);
+    } else {
+      val = m_valueFactory.newStValue();
+      val->set(value);
+    }
   }
   return val;
 }

--- a/tests/ParamLine/ParamLine.log
+++ b/tests/ParamLine/ParamLine.log
@@ -11,21 +11,25 @@ Processing: -parse -d uhdm -elabuhdm dut.sv -nobuiltin -Pp="BLAH"
 
 [INF:CP0335] dut.sv:3: Compile generate block "work@top.genblk1".
 
+[INF:CP0335] dut.sv:24: Compile generate block "work@top.genblk8".
+
 [NTE:EL0503] dut.sv:1: Top level module "work@top".
 
 [WRN:EL0500] dut.sv:4: Cannot find a module definition for "work@top.genblk1::GOOD_BLAH".
+
+[WRN:EL0500] dut.sv:25: Cannot find a module definition for "work@top.genblk8::GOOD_0".
 
 [NTE:EL0508] Nb Top level modules: 1.
 
 [NTE:EL0509] Max instance depth: 3.
 
-[NTE:EL0510] Nb instances: 2.
+[NTE:EL0510] Nb instances: 3.
 
-[NTE:EL0511] Nb leaf instances: 1.
+[NTE:EL0511] Nb leaf instances: 2.
 
-[WRN:EL0512] Nb undefined modules: 1.
+[WRN:EL0512] Nb undefined modules: 2.
 
-[WRN:EL0513] Nb undefined instances: 1.
+[WRN:EL0513] Nb undefined instances: 2.
 
 UHDM HTML COVERAGE REPORT: ./slpp_all//surelog.uhdm.chk.html
 ====== UHDM =======
@@ -65,6 +69,18 @@ design: (work@top)
         |vpiDefName:work@top.genblk1::GOOD_BLAH
         |vpiName:good
         |vpiFullName:work@top.genblk1.good
+  |vpiGenScopeArray:
+  \_gen_scope_array: (work@top.genblk8), line:24, parent:work@top
+    |vpiName:genblk8
+    |vpiFullName:work@top.genblk8
+    |vpiGenScope:
+    \_gen_scope: (work@top.genblk8), parent:work@top.genblk8
+      |vpiFullName:work@top.genblk8
+      |vpiModule:
+      \_module: work@top.genblk8::GOOD_0 (work@top.genblk8.good) dut.sv:25: , parent:work@top.genblk8
+        |vpiDefName:work@top.genblk8::GOOD_0
+        |vpiName:good
+        |vpiFullName:work@top.genblk8.good
   |vpiParamAssign:
   \_param_assign: , line:2, parent:work@top
     |vpiRhs:
@@ -84,7 +100,7 @@ design: (work@top)
 [  FATAL] : 0
 [ SYNTAX] : 0
 [  ERROR] : 0
-[WARNING] : 4
+[WARNING] : 5
 [   NOTE] : 5
 Processing: -parse -d uhdm -elabuhdm dut.sv -nobuiltin -Pp=4'b1001
 [INF:CM0023] Creating log file ./slpp_all/surelog.log.
@@ -592,6 +608,110 @@ design: (work@top)
 [  ERROR] : 0
 [WARNING] : 4
 [   NOTE] : 5
+Processing: -parse -d uhdm -elabuhdm dut.sv -nobuiltin -Pp=0
+[INF:CM0023] Creating log file ./slpp_all/surelog.log.
+
+[WRN:PA0205] dut.sv:1: No timescale set for "top".
+
+[INF:CP0300] Compilation...
+
+[INF:CP0303] dut.sv:1: Compile module "work@top".
+
+[INF:EL0526] Design Elaboration...
+
+[INF:CP0335] dut.sv:3: Compile generate block "work@top.genblk1".
+
+[INF:CP0335] dut.sv:24: Compile generate block "work@top.genblk8".
+
+[NTE:EL0503] dut.sv:1: Top level module "work@top".
+
+[WRN:EL0500] dut.sv:4: Cannot find a module definition for "work@top.genblk1::GOOD_BLAH".
+
+[WRN:EL0500] dut.sv:25: Cannot find a module definition for "work@top.genblk8::GOOD_0".
+
+[NTE:EL0508] Nb Top level modules: 1.
+
+[NTE:EL0509] Max instance depth: 3.
+
+[NTE:EL0510] Nb instances: 3.
+
+[NTE:EL0511] Nb leaf instances: 2.
+
+[WRN:EL0512] Nb undefined modules: 2.
+
+[WRN:EL0513] Nb undefined instances: 2.
+
+UHDM HTML COVERAGE REPORT: ./slpp_all//surelog.uhdm.chk.html
+====== UHDM =======
+design: (work@top)
+|vpiName:work@top
+|uhdmallModules:
+\_module: work@top (work@top) dut.sv:1: , parent:work@top
+  |vpiDefName:work@top
+  |vpiFullName:work@top
+  |vpiParamAssign:
+  \_param_assign: , line:2, parent:work@top
+    |vpiRhs:
+    \_constant: , line:2
+      |vpiConstType:3
+      |vpiDecompile:1'b0
+      |vpiSize:1
+      |BIN:0
+    |vpiLhs:
+    \_parameter: (work@top.p), line:2, parent:work@top
+      |vpiName:p
+      |vpiFullName:work@top.p
+  |vpiParameter:
+  \_parameter: (work@top.p), line:2, parent:work@top
+|uhdmtopModules:
+\_module: work@top (work@top) dut.sv:1: 
+  |vpiDefName:work@top
+  |vpiName:work@top
+  |vpiGenScopeArray:
+  \_gen_scope_array: (work@top.genblk1), line:3, parent:work@top
+    |vpiName:genblk1
+    |vpiFullName:work@top.genblk1
+    |vpiGenScope:
+    \_gen_scope: (work@top.genblk1), parent:work@top.genblk1
+      |vpiFullName:work@top.genblk1
+      |vpiModule:
+      \_module: work@top.genblk1::GOOD_BLAH (work@top.genblk1.good) dut.sv:4: , parent:work@top.genblk1
+        |vpiDefName:work@top.genblk1::GOOD_BLAH
+        |vpiName:good
+        |vpiFullName:work@top.genblk1.good
+  |vpiGenScopeArray:
+  \_gen_scope_array: (work@top.genblk8), line:24, parent:work@top
+    |vpiName:genblk8
+    |vpiFullName:work@top.genblk8
+    |vpiGenScope:
+    \_gen_scope: (work@top.genblk8), parent:work@top.genblk8
+      |vpiFullName:work@top.genblk8
+      |vpiModule:
+      \_module: work@top.genblk8::GOOD_0 (work@top.genblk8.good) dut.sv:25: , parent:work@top.genblk8
+        |vpiDefName:work@top.genblk8::GOOD_0
+        |vpiName:good
+        |vpiFullName:work@top.genblk8.good
+  |vpiParamAssign:
+  \_param_assign: , line:2, parent:work@top
+    |vpiRhs:
+    \_constant: , line:2
+      |vpiConstType:9
+      |vpiDecompile:0
+      |vpiSize:64
+      |UINT:0
+    |vpiLhs:
+    \_parameter: (work@top.p), line:2, parent:work@top
+      |vpiName:p
+      |vpiFullName:work@top.p
+      |UINT:0
+  |vpiParameter:
+  \_parameter: (work@top.p), line:2, parent:work@top
+===================
+[  FATAL] : 0
+[ SYNTAX] : 0
+[  ERROR] : 0
+[WARNING] : 5
+[   NOTE] : 5
 Processing: 
 [INF:CM0023] Creating log file ./slpp_all/surelog.log.
 
@@ -600,10 +720,10 @@ Processing:
 [  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
-Processed 8 tests.
+Processed 9 tests.
 [  FATAL] : 0
 [ SYNTAX] : 0
 [  ERROR] : 0
-[WARNING] : 25
-[   NOTE] : 35
+[WARNING] : 31
+[   NOTE] : 40
 

--- a/tests/ParamLine/batch.txt
+++ b/tests/ParamLine/batch.txt
@@ -5,4 +5,5 @@
 -parse -d uhdm -elabuhdm dut.sv -nobuiltin -Pp=-12
 -parse -d uhdm -elabuhdm dut.sv -nobuiltin -Pp=12
 -parse -d uhdm -elabuhdm dut.sv -nobuiltin -Pp=12.12
+-parse -d uhdm -elabuhdm dut.sv -nobuiltin -Pp=0
 

--- a/tests/ParamLine/dut.sv
+++ b/tests/ParamLine/dut.sv
@@ -21,4 +21,7 @@ module top();
    if (p == 12.12) begin
       GOOD_REAL12 good();
    end
+   if (p == 0) begin
+      GOOD_0 good();
+   end
 endmodule


### PR DESCRIPTION
Currently Surelog returns value ``48`` (ASCII ``0``) for parameters set using ``-Pparam=0``. This PR fixes this.

``strtoull`` is returning ``0`` if no valid conversion can be performed, but it is also returning ``0`` if it converts string to ``0``. Proper way of detecting if conversion was possible is comparison between pointer where comparison started and ended.

Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>