### PR TITLE
Change in io_decl modeling

### DIFF
--- a/src/DesignCompile/CompileType.cpp
+++ b/src/DesignCompile/CompileType.cpp
@@ -158,8 +158,6 @@ variables* CompileHelper::getSimpleVarFromTypespec(UHDM::typespec* spec,
   return var;
 }
 
-
-
 UHDM::any* CompileHelper::compileVariable(
   DesignComponent* component, const FileContent* fC, NodeId variable,
   CompileDesign* compileDesign,
@@ -187,26 +185,11 @@ UHDM::any* CompileHelper::compileVariable(
   if (the_type == VObjectType::slStringConst ||
       the_type == VObjectType::slChandle_type) {
     const std::string& typeName = fC->SymName(variable);
-    /*
-    const any* ptmp = pstmt;
-    while (ptmp) {
-      if (const scope* s = dynamic_cast<const scope*>(ptmp)) {
-      }
-      ptmp = ptmp->VpiParent();
-    }
-    */
+   
     if (const DataType* dt = component->getDataType(typeName)) {
       dt = dt->getActual();
       typespec* tps = dt->getTypespec();
       if (tps) {
-        if (ranges == nullptr) {
-          UHDM_OBJECT_TYPE ttype = tps->UhdmType();
-          if (ttype == uhdmbit_typespec) { 
-            ranges = ((bit_typespec*)tps)->Ranges();
-          } else if (ttype == uhdmlogic_typespec) { 
-            ranges = ((logic_typespec*)tps)->Ranges();
-          } 
-        }
         variables* var = getSimpleVarFromTypespec(tps, ranges, compileDesign);
         if (var) var->VpiName(fC->SymName(variable));
         result = var;

--- a/tests/AlwaysNoElab/AlwaysNoElab.log
+++ b/tests/AlwaysNoElab/AlwaysNoElab.log
@@ -214,9 +214,14 @@ design: (work@dut)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -408,9 +413,14 @@ design: (work@dut)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -421,9 +431,14 @@ design: (work@dut)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -434,9 +449,14 @@ design: (work@dut)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -449,9 +469,14 @@ design: (work@dut)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@dut (work@dut) dut.sv:1: , endline:12:9: , parent:work@dut
   |vpiDefName:work@dut

--- a/tests/Assignments/Assignments.log
+++ b/tests/Assignments/Assignments.log
@@ -386,9 +386,14 @@ design: (work@dut)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -580,9 +585,14 @@ design: (work@dut)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -593,9 +603,14 @@ design: (work@dut)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -606,9 +621,14 @@ design: (work@dut)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -621,9 +641,14 @@ design: (work@dut)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@dut (work@dut) dut.sv:1: , endline:22:9: , parent:work@dut
   |vpiDefName:work@dut
@@ -761,9 +786,8 @@ design: (work@dut)
     \_io_decl: (stream)
       |vpiName:stream
       |vpiDirection:6
-      |vpiExpr:
-      \_bit_var: (stream), line:5, col:48, parent:stream
-        |vpiFullName:stream
+      |vpiTypedef:
+      \_bit_typespec: , line:5, col:48
     |vpiStmt:
     \_begin: (work@dut.uvm_packer::get_packed_bits), parent:work@dut.uvm_packer::get_packed_bits
       |vpiFullName:work@dut.uvm_packer::get_packed_bits
@@ -1183,9 +1207,8 @@ design: (work@dut)
         \_io_decl: (stream)
           |vpiName:stream
           |vpiDirection:6
-          |vpiExpr:
-          \_bit_var: (stream), line:5, col:48, parent:stream
-            |vpiFullName:stream
+          |vpiTypedef:
+          \_bit_typespec: , line:5, col:48
         |vpiStmt:
         \_begin: (work@dut.uvm_packer::get_packed_bits), parent:work@dut.uvm_packer::get_packed_bits
           |vpiFullName:work@dut.uvm_packer::get_packed_bits
@@ -1349,9 +1372,8 @@ design: (work@dut)
     \_io_decl: (stream), parent:work@dut.uvm_packer::get_packed_bits
       |vpiName:stream
       |vpiDirection:6
-      |vpiExpr:
-      \_bit_var: (work@dut.uvm_packer::get_packed_bits.stream), line:5, col:48, parent:stream
-        |vpiFullName:work@dut.uvm_packer::get_packed_bits.stream
+      |vpiTypedef:
+      \_bit_typespec: , line:5, col:48, parent:stream
     |vpiStmt:
     \_begin: (work@dut.uvm_packer::get_packed_bits), parent:work@dut.uvm_packer::get_packed_bits
       |vpiFullName:work@dut.uvm_packer::get_packed_bits
@@ -1396,8 +1418,6 @@ design: (work@dut)
         \_ref_obj: (work@dut.uvm_packer::get_packed_bits.stream), line:7, col:4
           |vpiName:stream
           |vpiFullName:work@dut.uvm_packer::get_packed_bits.stream
-          |vpiActual:
-          \_bit_var: (stream), line:5, col:48, parent:stream
         |vpiRhs:
         \_method_func_call: (new), line:7, col:20
           |vpiName:new

--- a/tests/Attributes/Attributes.log
+++ b/tests/Attributes/Attributes.log
@@ -702,9 +702,14 @@ design: (work@foo)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -896,9 +901,14 @@ design: (work@foo)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -909,9 +919,14 @@ design: (work@foo)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -922,9 +937,14 @@ design: (work@foo)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -937,9 +957,14 @@ design: (work@foo)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallClasses:
 \_class_defn: (work@toto) test_attributes.sv:42:22: , parent:work@foo
   |vpiName:work@toto

--- a/tests/BiasValue/BiasValue.log
+++ b/tests/BiasValue/BiasValue.log
@@ -211,9 +211,14 @@ design: (work@bp_be_rec_to_fp)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -405,9 +410,14 @@ design: (work@bp_be_rec_to_fp)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -418,9 +428,14 @@ design: (work@bp_be_rec_to_fp)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -431,9 +446,14 @@ design: (work@bp_be_rec_to_fp)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -446,9 +466,14 @@ design: (work@bp_be_rec_to_fp)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@bp_be_rec_to_fp (work@bp_be_rec_to_fp) dut.sv:1: , endline:10:9: , parent:work@bp_be_rec_to_fp
   |vpiDefName:work@bp_be_rec_to_fp

--- a/tests/BindVarsAndEnum/BindVarsAndEnum.log
+++ b/tests/BindVarsAndEnum/BindVarsAndEnum.log
@@ -233,9 +233,14 @@ design: (work@conditional_Fsm)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -427,9 +432,14 @@ design: (work@conditional_Fsm)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -440,9 +450,14 @@ design: (work@conditional_Fsm)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -453,9 +468,14 @@ design: (work@conditional_Fsm)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -468,9 +488,14 @@ design: (work@conditional_Fsm)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@conditional_Fsm (work@conditional_Fsm) dut.sv:1: , endline:18:9: , parent:work@conditional_Fsm
   |vpiDefName:work@conditional_Fsm

--- a/tests/Bindings/Bindings.log
+++ b/tests/Bindings/Bindings.log
@@ -1241,9 +1241,14 @@ design: (work@dut1)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -1435,9 +1440,14 @@ design: (work@dut1)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -1448,9 +1458,14 @@ design: (work@dut1)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -1461,9 +1476,14 @@ design: (work@dut1)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -1476,9 +1496,14 @@ design: (work@dut1)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@bsg_dff_reset (work@bsg_dff_reset) dut.sv:67: , endline:80:9: , parent:work@dut1
   |vpiDefName:work@bsg_dff_reset

--- a/tests/BlackParrotComplex/BlackParrotComplex.log
+++ b/tests/BlackParrotComplex/BlackParrotComplex.log
@@ -2951,9 +2951,14 @@ design: (work@top)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -3145,9 +3150,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -3158,9 +3168,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -3171,9 +3186,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -3186,9 +3206,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@bottom (work@bottom) dut.sv:79: , endline:88:9: , parent:work@top
   |vpiDefName:work@bottom

--- a/tests/BlackParrotParam/BlackParrotParam.log
+++ b/tests/BlackParrotParam/BlackParrotParam.log
@@ -18284,9 +18284,14 @@ design: (work@bp_be_ptw)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -18478,9 +18483,14 @@ design: (work@bp_be_ptw)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -18491,9 +18501,14 @@ design: (work@bp_be_ptw)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -18504,9 +18519,14 @@ design: (work@bp_be_ptw)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -18519,9 +18539,14 @@ design: (work@bp_be_ptw)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@bp_be_ptw (work@bp_be_ptw) dut.sv:4371: , endline:4628:9: , parent:work@bp_be_ptw
   |vpiDefName:work@bp_be_ptw

--- a/tests/BlackParrotSkipParam/BlackParrotSkipParam.log
+++ b/tests/BlackParrotSkipParam/BlackParrotSkipParam.log
@@ -169,9 +169,14 @@ design: (work@top)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -363,9 +368,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -376,9 +386,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -389,9 +404,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -404,9 +424,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@bsg_counter_set_en (work@bsg_counter_set_en) dut.sv:2: , endline:7:9: , parent:work@top
   |vpiDefName:work@bsg_counter_set_en

--- a/tests/BlackParrotStructParam/BlackParrotStructParam.log
+++ b/tests/BlackParrotStructParam/BlackParrotStructParam.log
@@ -640,9 +640,14 @@ design: (work@top)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -834,9 +839,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -847,9 +857,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -860,9 +875,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -875,9 +895,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@top (work@top) dut.sv:55: , endline:66:9: , parent:work@top
   |vpiDefName:work@top

--- a/tests/CarryTrans/CarryTrans.log
+++ b/tests/CarryTrans/CarryTrans.log
@@ -624,9 +624,14 @@ design: (work@carry_rtl)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -818,9 +823,14 @@ design: (work@carry_rtl)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -831,9 +841,14 @@ design: (work@carry_rtl)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -844,9 +859,14 @@ design: (work@carry_rtl)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -859,9 +879,14 @@ design: (work@carry_rtl)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@carry_gate (work@carry_gate) dut.sv:8: , endline:16:9: , parent:work@carry_rtl
   |vpiDefName:work@carry_gate

--- a/tests/CaseFullElab/CaseFullElab.log
+++ b/tests/CaseFullElab/CaseFullElab.log
@@ -446,9 +446,14 @@ design: (work@FSM)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -640,9 +645,14 @@ design: (work@FSM)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -653,9 +663,14 @@ design: (work@FSM)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -666,9 +681,14 @@ design: (work@FSM)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -681,9 +701,14 @@ design: (work@FSM)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@FSM (work@FSM) top.sv:1: , endline:42:11: , parent:work@FSM
   |vpiDefName:work@FSM

--- a/tests/CaseInside/CaseInside.log
+++ b/tests/CaseInside/CaseInside.log
@@ -271,9 +271,14 @@ design: (work@dm_csrs)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -465,9 +470,14 @@ design: (work@dm_csrs)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -478,9 +488,14 @@ design: (work@dm_csrs)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -491,9 +506,14 @@ design: (work@dm_csrs)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -506,9 +526,14 @@ design: (work@dm_csrs)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@dm_csrs (work@dm_csrs) top.sv:12: , endline:29:19: , parent:work@dm_csrs
   |vpiDefName:work@dm_csrs

--- a/tests/CastEnum/CastEnum.log
+++ b/tests/CastEnum/CastEnum.log
@@ -205,9 +205,14 @@ design: (work@dm_csrs)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -399,9 +404,14 @@ design: (work@dm_csrs)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -412,9 +422,14 @@ design: (work@dm_csrs)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -425,9 +440,14 @@ design: (work@dm_csrs)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -440,9 +460,14 @@ design: (work@dm_csrs)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@dm_csrs (work@dm_csrs) dut.sv:12: , endline:17:9: , parent:work@dm_csrs
   |vpiDefName:work@dm_csrs

--- a/tests/CastPartSelect/CastPartSelect.log
+++ b/tests/CastPartSelect/CastPartSelect.log
@@ -161,9 +161,14 @@ design: (work@top)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -355,9 +360,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -368,9 +378,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -381,9 +396,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -396,9 +416,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@top (work@top) dut.sv:1: , endline:10:9: , parent:work@top
   |vpiDefName:work@top

--- a/tests/CastShift/CastShift.log
+++ b/tests/CastShift/CastShift.log
@@ -397,9 +397,14 @@ design: (work@dut)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -591,9 +596,14 @@ design: (work@dut)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -604,9 +614,14 @@ design: (work@dut)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -617,9 +632,14 @@ design: (work@dut)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -632,9 +652,14 @@ design: (work@dut)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@dut (work@dut) dut.sv:1: , endline:23:9: , parent:work@dut
   |vpiDefName:work@dut

--- a/tests/CastTypespec/CastTypespec.log
+++ b/tests/CastTypespec/CastTypespec.log
@@ -668,9 +668,14 @@ design: (work@tlul_adapter_host)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -862,9 +867,14 @@ design: (work@tlul_adapter_host)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -875,9 +885,14 @@ design: (work@tlul_adapter_host)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -888,9 +903,14 @@ design: (work@tlul_adapter_host)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -903,9 +923,14 @@ design: (work@tlul_adapter_host)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@tlul_adapter_host (work@tlul_adapter_host) dut.sv:14:2: , endline:23:11: , parent:work@tlul_adapter_host
   |vpiDefName:work@tlul_adapter_host

--- a/tests/CastUnsigned/CastUnsigned.log
+++ b/tests/CastUnsigned/CastUnsigned.log
@@ -175,9 +175,14 @@ design: (work@top)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -369,9 +374,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -382,9 +392,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -395,9 +410,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -410,9 +430,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@top (work@top) dut.sv:2: , endline:13:9: , parent:work@top
   |vpiDefName:work@top

--- a/tests/Cell/Cell.log
+++ b/tests/Cell/Cell.log
@@ -93,9 +93,14 @@ design: (work@top)
     \_io_decl: (bound)
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16
       |vpiExpr:
-      \_int_var: (bound), line:6, col:16, parent:bound
-        |vpiFullName:bound
+      \_constant: , line:6, col:28
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -266,9 +271,14 @@ design: (work@top)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15
       |vpiExpr:
-      \_int_var: (keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:60, col:30
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -279,9 +289,14 @@ design: (work@top)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11
       |vpiExpr:
-      \_int_var: (keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:63, col:26
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -292,9 +307,14 @@ design: (work@top)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11
       |vpiExpr:
-      \_int_var: (keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:66, col:26
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -307,9 +327,14 @@ design: (work@top)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23
       |vpiExpr:
-      \_int_var: (keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:69, col:38
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@assigner (work@assigner) ${SURELOG_DIR}/tests/Cell/cell.v:1: , endline:6:9: , parent:work@top
   |vpiDefName:work@assigner

--- a/tests/ClassFsm/ClassFsm.log
+++ b/tests/ClassFsm/ClassFsm.log
@@ -128,9 +128,8 @@ design: (work@fsm_class)
       \_io_decl: (state_to_bit), parent:work@fsm_class::baseFsm::next_state_transition
         |vpiName:state_to_bit
         |vpiDirection:1
-        |vpiExpr:
-        \_int_var: (work@fsm_class::baseFsm::next_state_transition::state_to_bit), line:8, col:38, parent:state_to_bit
-          |vpiFullName:work@fsm_class::baseFsm::next_state_transition::state_to_bit
+        |vpiTypedef:
+        \_int_typespec: , line:8, col:38, parent:state_to_bit
       |vpiStmt:
       \_begin: (work@fsm_class::baseFsm::next_state_transition), line:10, col:6, parent:work@fsm_class::baseFsm::next_state_transition
         |vpiFullName:work@fsm_class::baseFsm::next_state_transition
@@ -182,9 +181,8 @@ design: (work@fsm_class)
       \_io_decl: (reset), parent:work@fsm_class::baseFsm::current_state_transition
         |vpiName:reset
         |vpiDirection:1
-        |vpiExpr:
-        \_logic_var: (work@fsm_class::baseFsm::current_state_transition::reset), line:15, col:41, parent:reset
-          |vpiFullName:work@fsm_class::baseFsm::current_state_transition::reset
+        |vpiTypedef:
+        \_logic_typespec: , line:15, col:41, parent:reset
       |vpiStmt:
       \_begin: (work@fsm_class::baseFsm::current_state_transition), line:17, col:6, parent:work@fsm_class::baseFsm::current_state_transition
         |vpiFullName:work@fsm_class::baseFsm::current_state_transition
@@ -880,9 +878,8 @@ design: (work@fsm_class)
                           \_io_decl: (state_to_bit), parent:work@fsm_class::baseFsm::next_state_transition
                             |vpiName:state_to_bit
                             |vpiDirection:1
-                            |vpiExpr:
-                            \_int_var: (work@fsm_class::baseFsm::next_state_transition::state_to_bit), line:8, col:38, parent:state_to_bit
-                              |vpiFullName:work@fsm_class::baseFsm::next_state_transition::state_to_bit
+                            |vpiTypedef:
+                            \_int_typespec: , line:8, col:38, parent:state_to_bit
                           |vpiStmt:
                           \_begin: (work@fsm_class::baseFsm::next_state_transition), line:10, col:6, parent:work@fsm_class::baseFsm::next_state_transition
                             |vpiFullName:work@fsm_class::baseFsm::next_state_transition
@@ -934,9 +931,8 @@ design: (work@fsm_class)
                           \_io_decl: (reset), parent:work@fsm_class::baseFsm::current_state_transition
                             |vpiName:reset
                             |vpiDirection:1
-                            |vpiExpr:
-                            \_logic_var: (work@fsm_class::baseFsm::current_state_transition::reset), line:15, col:41, parent:reset
-                              |vpiFullName:work@fsm_class::baseFsm::current_state_transition::reset
+                            |vpiTypedef:
+                            \_logic_typespec: , line:15, col:41, parent:reset
                           |vpiStmt:
                           \_begin: (work@fsm_class::baseFsm::current_state_transition), line:17, col:6, parent:work@fsm_class::baseFsm::current_state_transition
                             |vpiFullName:work@fsm_class::baseFsm::current_state_transition
@@ -1113,9 +1109,8 @@ design: (work@fsm_class)
       \_io_decl: (state_to_bit), parent:work@fsm_class::baseFsm::next_state_transition
         |vpiName:state_to_bit
         |vpiDirection:1
-        |vpiExpr:
-        \_int_var: (work@fsm_class::baseFsm::next_state_transition::state_to_bit), line:8, col:38, parent:state_to_bit
-          |vpiFullName:work@fsm_class::baseFsm::next_state_transition::state_to_bit
+        |vpiTypedef:
+        \_int_typespec: , line:8, col:38, parent:state_to_bit
       |vpiStmt:
       \_begin: (work@fsm_class::baseFsm::next_state_transition), line:10, col:6, parent:work@fsm_class::baseFsm::next_state_transition
         |vpiFullName:work@fsm_class::baseFsm::next_state_transition
@@ -1167,9 +1162,8 @@ design: (work@fsm_class)
       \_io_decl: (reset), parent:work@fsm_class::baseFsm::current_state_transition
         |vpiName:reset
         |vpiDirection:1
-        |vpiExpr:
-        \_logic_var: (work@fsm_class::baseFsm::current_state_transition::reset), line:15, col:41, parent:reset
-          |vpiFullName:work@fsm_class::baseFsm::current_state_transition::reset
+        |vpiTypedef:
+        \_logic_typespec: , line:15, col:41, parent:reset
       |vpiStmt:
       \_begin: (work@fsm_class::baseFsm::current_state_transition), line:17, col:6, parent:work@fsm_class::baseFsm::current_state_transition
         |vpiFullName:work@fsm_class::baseFsm::current_state_transition

--- a/tests/ClassFuncProto/ClassFuncProto.log
+++ b/tests/ClassFuncProto/ClassFuncProto.log
@@ -288,9 +288,14 @@ design: (work@toto)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -482,9 +487,14 @@ design: (work@toto)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -495,9 +505,14 @@ design: (work@toto)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -508,9 +523,14 @@ design: (work@toto)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -523,9 +543,14 @@ design: (work@toto)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@toto (work@toto) top.v:6: , endline:52:9: , parent:work@toto
   |vpiDefName:work@toto
@@ -560,10 +585,9 @@ design: (work@toto)
       \_io_decl: (provider), parent:work@toto::c1::connect
         |vpiName:provider
         |vpiDirection:1
-        |vpiExpr:
-        \_chandle_var: (work@toto::c1::connect::provider::this_type), line:35, col:23, parent:provider
+        |vpiTypedef:
+        \_unsupported_typespec: (this_type), line:35, col:23, parent:provider
           |vpiName:this_type
-          |vpiFullName:work@toto::c1::connect::provider::this_type
     |vpiMethod:
     \_function: (work@toto::c1::get_verbosity_level), line:38, col:3, parent:work@toto::c1
       |vpiMethod:1
@@ -576,67 +600,48 @@ design: (work@toto)
       \_io_decl: (severity), parent:work@toto::c1::get_verbosity_level
         |vpiName:severity
         |vpiDirection:1
-        |vpiExpr:
-        \_bit_var: (work@toto::c1::get_verbosity_level::severity::uvm_severity), line:38, col:36, parent:severity
+        |vpiTypedef:
+        \_enum_typespec: (uvm_severity), line:27, col:2, parent:severity
           |vpiName:uvm_severity
-          |vpiFullName:work@toto::c1::get_verbosity_level::severity::uvm_severity
-          |vpiRange:
-          \_range: , line:21, col:18, parent:work@toto::c1::get_verbosity_level::severity::uvm_severity
-            |vpiLeftRange:
-            \_constant: , line:21, col:18
-              |vpiConstType:9
-              |vpiDecompile:1
-              |vpiSize:64
-              |UINT:1
-            |vpiRightRange:
-            \_constant: , line:21, col:20
-              |vpiConstType:9
-              |vpiDecompile:0
-              |vpiSize:64
-              |UINT:0
-          |vpiTypespec:
-          \_enum_typespec: (uvm_severity), line:27, col:2, parent:work@toto::c1::get_verbosity_level::severity::uvm_severity
-            |vpiName:uvm_severity
-            |vpiBaseTypespec:
-            \_bit_typespec: , line:21, col:13, parent:uvm_severity
-              |vpiRange:
-              \_range: , line:21, col:18
-                |vpiLeftRange:
-                \_constant: , line:21, col:18
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-                |vpiRightRange:
-                \_constant: , line:21, col:20
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
-            |vpiEnumConst:
-            \_enum_const: (UVM_ERROR), line:25, parent:uvm_severity
-              |vpiName:UVM_ERROR
-              |STRING:toto
-            |vpiEnumConst:
-            \_enum_const: (UVM_FATAL), line:26, parent:uvm_severity
-              |vpiName:UVM_FATAL
-              |INT:3
-            |vpiEnumConst:
-            \_enum_const: (UVM_INFO), line:23, parent:uvm_severity
-              |vpiName:UVM_INFO
-              |INT:0
-            |vpiEnumConst:
-            \_enum_const: (UVM_WARNING), line:24, parent:uvm_severity
-              |vpiName:UVM_WARNING
-              |INT:1
+          |vpiBaseTypespec:
+          \_bit_typespec: , line:21, col:13, parent:uvm_severity
+            |vpiRange:
+            \_range: , line:21, col:18
+              |vpiLeftRange:
+              \_constant: , line:21, col:18
+                |vpiConstType:9
+                |vpiDecompile:1
+                |vpiSize:64
+                |UINT:1
+              |vpiRightRange:
+              \_constant: , line:21, col:20
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+          |vpiEnumConst:
+          \_enum_const: (UVM_ERROR), line:25, parent:uvm_severity
+            |vpiName:UVM_ERROR
+            |STRING:toto
+          |vpiEnumConst:
+          \_enum_const: (UVM_FATAL), line:26, parent:uvm_severity
+            |vpiName:UVM_FATAL
+            |INT:3
+          |vpiEnumConst:
+          \_enum_const: (UVM_INFO), line:23, parent:uvm_severity
+            |vpiName:UVM_INFO
+            |INT:0
+          |vpiEnumConst:
+          \_enum_const: (UVM_WARNING), line:24, parent:uvm_severity
+            |vpiName:UVM_WARNING
+            |INT:1
       |vpiIODecl:
       \_io_decl: (reg_a), parent:work@toto::c1::get_verbosity_level
         |vpiName:reg_a
         |vpiDirection:1
-        |vpiExpr:
-        \_chandle_var: (work@toto::c1::get_verbosity_level::reg_a::uvm_reg), line:38, col:70, parent:reg_a
+        |vpiTypedef:
+        \_unsupported_typespec: (uvm_reg), line:38, col:70, parent:reg_a
           |vpiName:uvm_reg
-          |vpiFullName:work@toto::c1::get_verbosity_level::reg_a::uvm_reg
     |vpiMethod:
     \_function: (work@toto::c1::set_verbosity_level), line:41, col:1, parent:work@toto::c1
       |vpiMethod:1
@@ -649,67 +654,48 @@ design: (work@toto)
       \_io_decl: (severity), parent:work@toto::c1::set_verbosity_level
         |vpiName:severity
         |vpiDirection:1
-        |vpiExpr:
-        \_bit_var: (work@toto::c1::set_verbosity_level::severity::uvm_severity), line:41, col:34, parent:severity
+        |vpiTypedef:
+        \_enum_typespec: (uvm_severity), line:27, col:2, parent:severity
           |vpiName:uvm_severity
-          |vpiFullName:work@toto::c1::set_verbosity_level::severity::uvm_severity
-          |vpiRange:
-          \_range: , line:21, col:18, parent:work@toto::c1::set_verbosity_level::severity::uvm_severity
-            |vpiLeftRange:
-            \_constant: , line:21, col:18
-              |vpiConstType:9
-              |vpiDecompile:1
-              |vpiSize:64
-              |UINT:1
-            |vpiRightRange:
-            \_constant: , line:21, col:20
-              |vpiConstType:9
-              |vpiDecompile:0
-              |vpiSize:64
-              |UINT:0
-          |vpiTypespec:
-          \_enum_typespec: (uvm_severity), line:27, col:2, parent:work@toto::c1::set_verbosity_level::severity::uvm_severity
-            |vpiName:uvm_severity
-            |vpiBaseTypespec:
-            \_bit_typespec: , line:21, col:13, parent:uvm_severity
-              |vpiRange:
-              \_range: , line:21, col:18
-                |vpiLeftRange:
-                \_constant: , line:21, col:18
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-                |vpiRightRange:
-                \_constant: , line:21, col:20
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
-            |vpiEnumConst:
-            \_enum_const: (UVM_ERROR), line:25, parent:uvm_severity
-              |vpiName:UVM_ERROR
-              |STRING:toto
-            |vpiEnumConst:
-            \_enum_const: (UVM_FATAL), line:26, parent:uvm_severity
-              |vpiName:UVM_FATAL
-              |INT:3
-            |vpiEnumConst:
-            \_enum_const: (UVM_INFO), line:23, parent:uvm_severity
-              |vpiName:UVM_INFO
-              |INT:0
-            |vpiEnumConst:
-            \_enum_const: (UVM_WARNING), line:24, parent:uvm_severity
-              |vpiName:UVM_WARNING
-              |INT:1
+          |vpiBaseTypespec:
+          \_bit_typespec: , line:21, col:13, parent:uvm_severity
+            |vpiRange:
+            \_range: , line:21, col:18
+              |vpiLeftRange:
+              \_constant: , line:21, col:18
+                |vpiConstType:9
+                |vpiDecompile:1
+                |vpiSize:64
+                |UINT:1
+              |vpiRightRange:
+              \_constant: , line:21, col:20
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+          |vpiEnumConst:
+          \_enum_const: (UVM_ERROR), line:25, parent:uvm_severity
+            |vpiName:UVM_ERROR
+            |STRING:toto
+          |vpiEnumConst:
+          \_enum_const: (UVM_FATAL), line:26, parent:uvm_severity
+            |vpiName:UVM_FATAL
+            |INT:3
+          |vpiEnumConst:
+          \_enum_const: (UVM_INFO), line:23, parent:uvm_severity
+            |vpiName:UVM_INFO
+            |INT:0
+          |vpiEnumConst:
+          \_enum_const: (UVM_WARNING), line:24, parent:uvm_severity
+            |vpiName:UVM_WARNING
+            |INT:1
       |vpiIODecl:
       \_io_decl: (reg_a), parent:work@toto::c1::set_verbosity_level
         |vpiName:reg_a
         |vpiDirection:1
-        |vpiExpr:
-        \_chandle_var: (work@toto::c1::set_verbosity_level::reg_a::uvm_reg), line:41, col:70, parent:reg_a
+        |vpiTypedef:
+        \_unsupported_typespec: (uvm_reg), line:41, col:70, parent:reg_a
           |vpiName:uvm_reg
-          |vpiFullName:work@toto::c1::set_verbosity_level::reg_a::uvm_reg
     |vpiMethod:
     \_task: (work@toto::c1::wait_for_total_count), line:44, col:1, parent:work@toto::c1
       |vpiMethod:1
@@ -720,40 +706,46 @@ design: (work@toto)
       \_io_decl: (obj), parent:work@toto::c1::wait_for_total_count
         |vpiName:obj
         |vpiDirection:1
-        |vpiExpr:
-        \_chandle_var: (work@toto::c1::wait_for_total_count::obj::c2), line:44, col:27, parent:obj
+        |vpiTypedef:
+        \_class_typespec: (c2), line:44, col:27, parent:obj
           |vpiName:c2
-          |vpiFullName:work@toto::c1::wait_for_total_count::obj::c2
+          |vpiClassDefn:
+          \_class_defn: (work@toto::c2) top.v:8: , parent:work@toto
+            |vpiName:c2
+            |vpiFullName:work@toto::c2
+            |vpiDerivedClasses:
+            \_class_defn: (work@toto::c3) top.v:15: , parent:work@toto
+              |vpiName:c3
+              |vpiFullName:work@toto::c3
+              |vpiExtends:
+              \_extends: , line:15, col:17, parent:work@toto::c3
+                |vpiClassTypespec:
+                \_class_typespec: 
+                  |vpiClassDefn:
+                  \_class_defn: (work@toto::c2) top.v:8: , parent:work@toto
+              |vpiDerivedClasses:
+              \_class_defn: (work@toto::c1) top.v:18: , parent:work@toto
+            |vpiTypedef:
+            \_int_typespec: (this_type), line:10, col:8, parent:work@toto::c2
+              |vpiName:this_type
       |vpiIODecl:
       \_io_decl: (count), parent:work@toto::c1::wait_for_total_count
         |vpiName:count
         |vpiDirection:1
+        |vpiTypedef:
+        \_int_typespec: , line:44, col:40, parent:count
         |vpiExpr:
-        \_int_var: (work@toto::c1::wait_for_total_count::count), line:44, col:40, parent:count
-          |vpiFullName:work@toto::c1::wait_for_total_count::count
+        \_constant: , line:44, col:50, parent:count
+          |vpiConstType:9
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
     |vpiExtends:
     \_extends: , line:18, col:17, parent:work@toto::c1
       |vpiClassTypespec:
       \_class_typespec: 
         |vpiClassDefn:
         \_class_defn: (work@toto::c3) top.v:15: , parent:work@toto
-          |vpiName:c3
-          |vpiFullName:work@toto::c3
-          |vpiExtends:
-          \_extends: , line:15, col:17, parent:work@toto::c3
-            |vpiClassTypespec:
-            \_class_typespec: 
-              |vpiClassDefn:
-              \_class_defn: (work@toto::c2) top.v:8: , parent:work@toto
-                |vpiName:c2
-                |vpiFullName:work@toto::c2
-                |vpiDerivedClasses:
-                \_class_defn: (work@toto::c3) top.v:15: , parent:work@toto
-                |vpiTypedef:
-                \_int_typespec: (this_type), line:10, col:8, parent:work@toto::c2
-                  |vpiName:this_type
-          |vpiDerivedClasses:
-          \_class_defn: (work@toto::c1) top.v:18: , parent:work@toto
     |vpiTypedef:
     \_enum_typespec: (uvm_severity), line:27, col:2, parent:work@toto::c1
       |vpiName:uvm_severity
@@ -827,10 +819,9 @@ design: (work@toto)
       \_io_decl: (provider), parent:work@toto::c1::connect
         |vpiName:provider
         |vpiDirection:1
-        |vpiExpr:
-        \_chandle_var: (work@toto::c1::connect::provider::this_type), line:35, col:23, parent:provider
+        |vpiTypedef:
+        \_unsupported_typespec: (this_type), line:35, col:23, parent:provider
           |vpiName:this_type
-          |vpiFullName:work@toto::c1::connect::provider::this_type
     |vpiMethod:
     \_function: (work@toto::c1::get_verbosity_level), line:38, col:3, parent:work@toto::c1
       |vpiMethod:1
@@ -843,67 +834,48 @@ design: (work@toto)
       \_io_decl: (severity), parent:work@toto::c1::get_verbosity_level
         |vpiName:severity
         |vpiDirection:1
-        |vpiExpr:
-        \_bit_var: (work@toto::c1::get_verbosity_level::severity::uvm_severity), line:38, col:36, parent:severity
+        |vpiTypedef:
+        \_enum_typespec: (uvm_severity), line:27, col:2, parent:severity
           |vpiName:uvm_severity
-          |vpiFullName:work@toto::c1::get_verbosity_level::severity::uvm_severity
-          |vpiRange:
-          \_range: , line:21, col:18, parent:work@toto::c1::get_verbosity_level::severity::uvm_severity
-            |vpiLeftRange:
-            \_constant: , line:21, col:18
-              |vpiConstType:9
-              |vpiDecompile:1
-              |vpiSize:64
-              |UINT:1
-            |vpiRightRange:
-            \_constant: , line:21, col:20
-              |vpiConstType:9
-              |vpiDecompile:0
-              |vpiSize:64
-              |UINT:0
-          |vpiTypespec:
-          \_enum_typespec: (uvm_severity), line:27, col:2, parent:work@toto::c1::get_verbosity_level::severity::uvm_severity
-            |vpiName:uvm_severity
-            |vpiBaseTypespec:
-            \_bit_typespec: , line:21, col:13, parent:uvm_severity
-              |vpiRange:
-              \_range: , line:21, col:18
-                |vpiLeftRange:
-                \_constant: , line:21, col:18
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-                |vpiRightRange:
-                \_constant: , line:21, col:20
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
-            |vpiEnumConst:
-            \_enum_const: (UVM_ERROR), line:25, parent:uvm_severity
-              |vpiName:UVM_ERROR
-              |STRING:toto
-            |vpiEnumConst:
-            \_enum_const: (UVM_FATAL), line:26, parent:uvm_severity
-              |vpiName:UVM_FATAL
-              |INT:3
-            |vpiEnumConst:
-            \_enum_const: (UVM_INFO), line:23, parent:uvm_severity
-              |vpiName:UVM_INFO
-              |INT:0
-            |vpiEnumConst:
-            \_enum_const: (UVM_WARNING), line:24, parent:uvm_severity
-              |vpiName:UVM_WARNING
-              |INT:1
+          |vpiBaseTypespec:
+          \_bit_typespec: , line:21, col:13, parent:uvm_severity
+            |vpiRange:
+            \_range: , line:21, col:18
+              |vpiLeftRange:
+              \_constant: , line:21, col:18
+                |vpiConstType:9
+                |vpiDecompile:1
+                |vpiSize:64
+                |UINT:1
+              |vpiRightRange:
+              \_constant: , line:21, col:20
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+          |vpiEnumConst:
+          \_enum_const: (UVM_ERROR), line:25, parent:uvm_severity
+            |vpiName:UVM_ERROR
+            |STRING:toto
+          |vpiEnumConst:
+          \_enum_const: (UVM_FATAL), line:26, parent:uvm_severity
+            |vpiName:UVM_FATAL
+            |INT:3
+          |vpiEnumConst:
+          \_enum_const: (UVM_INFO), line:23, parent:uvm_severity
+            |vpiName:UVM_INFO
+            |INT:0
+          |vpiEnumConst:
+          \_enum_const: (UVM_WARNING), line:24, parent:uvm_severity
+            |vpiName:UVM_WARNING
+            |INT:1
       |vpiIODecl:
       \_io_decl: (reg_a), parent:work@toto::c1::get_verbosity_level
         |vpiName:reg_a
         |vpiDirection:1
-        |vpiExpr:
-        \_chandle_var: (work@toto::c1::get_verbosity_level::reg_a::uvm_reg), line:38, col:70, parent:reg_a
+        |vpiTypedef:
+        \_unsupported_typespec: (uvm_reg), line:38, col:70, parent:reg_a
           |vpiName:uvm_reg
-          |vpiFullName:work@toto::c1::get_verbosity_level::reg_a::uvm_reg
     |vpiMethod:
     \_function: (work@toto::c1::set_verbosity_level), line:41, col:1, parent:work@toto::c1
       |vpiMethod:1
@@ -916,67 +888,48 @@ design: (work@toto)
       \_io_decl: (severity), parent:work@toto::c1::set_verbosity_level
         |vpiName:severity
         |vpiDirection:1
-        |vpiExpr:
-        \_bit_var: (work@toto::c1::set_verbosity_level::severity::uvm_severity), line:41, col:34, parent:severity
+        |vpiTypedef:
+        \_enum_typespec: (uvm_severity), line:27, col:2, parent:severity
           |vpiName:uvm_severity
-          |vpiFullName:work@toto::c1::set_verbosity_level::severity::uvm_severity
-          |vpiRange:
-          \_range: , line:21, col:18, parent:work@toto::c1::set_verbosity_level::severity::uvm_severity
-            |vpiLeftRange:
-            \_constant: , line:21, col:18
-              |vpiConstType:9
-              |vpiDecompile:1
-              |vpiSize:64
-              |UINT:1
-            |vpiRightRange:
-            \_constant: , line:21, col:20
-              |vpiConstType:9
-              |vpiDecompile:0
-              |vpiSize:64
-              |UINT:0
-          |vpiTypespec:
-          \_enum_typespec: (uvm_severity), line:27, col:2, parent:work@toto::c1::set_verbosity_level::severity::uvm_severity
-            |vpiName:uvm_severity
-            |vpiBaseTypespec:
-            \_bit_typespec: , line:21, col:13, parent:uvm_severity
-              |vpiRange:
-              \_range: , line:21, col:18
-                |vpiLeftRange:
-                \_constant: , line:21, col:18
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-                |vpiRightRange:
-                \_constant: , line:21, col:20
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
-            |vpiEnumConst:
-            \_enum_const: (UVM_ERROR), line:25, parent:uvm_severity
-              |vpiName:UVM_ERROR
-              |STRING:toto
-            |vpiEnumConst:
-            \_enum_const: (UVM_FATAL), line:26, parent:uvm_severity
-              |vpiName:UVM_FATAL
-              |INT:3
-            |vpiEnumConst:
-            \_enum_const: (UVM_INFO), line:23, parent:uvm_severity
-              |vpiName:UVM_INFO
-              |INT:0
-            |vpiEnumConst:
-            \_enum_const: (UVM_WARNING), line:24, parent:uvm_severity
-              |vpiName:UVM_WARNING
-              |INT:1
+          |vpiBaseTypespec:
+          \_bit_typespec: , line:21, col:13, parent:uvm_severity
+            |vpiRange:
+            \_range: , line:21, col:18
+              |vpiLeftRange:
+              \_constant: , line:21, col:18
+                |vpiConstType:9
+                |vpiDecompile:1
+                |vpiSize:64
+                |UINT:1
+              |vpiRightRange:
+              \_constant: , line:21, col:20
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+          |vpiEnumConst:
+          \_enum_const: (UVM_ERROR), line:25, parent:uvm_severity
+            |vpiName:UVM_ERROR
+            |STRING:toto
+          |vpiEnumConst:
+          \_enum_const: (UVM_FATAL), line:26, parent:uvm_severity
+            |vpiName:UVM_FATAL
+            |INT:3
+          |vpiEnumConst:
+          \_enum_const: (UVM_INFO), line:23, parent:uvm_severity
+            |vpiName:UVM_INFO
+            |INT:0
+          |vpiEnumConst:
+          \_enum_const: (UVM_WARNING), line:24, parent:uvm_severity
+            |vpiName:UVM_WARNING
+            |INT:1
       |vpiIODecl:
       \_io_decl: (reg_a), parent:work@toto::c1::set_verbosity_level
         |vpiName:reg_a
         |vpiDirection:1
-        |vpiExpr:
-        \_chandle_var: (work@toto::c1::set_verbosity_level::reg_a::uvm_reg), line:41, col:70, parent:reg_a
+        |vpiTypedef:
+        \_unsupported_typespec: (uvm_reg), line:41, col:70, parent:reg_a
           |vpiName:uvm_reg
-          |vpiFullName:work@toto::c1::set_verbosity_level::reg_a::uvm_reg
     |vpiMethod:
     \_task: (work@toto::c1::wait_for_total_count), line:44, col:1, parent:work@toto::c1
       |vpiMethod:1
@@ -987,276 +940,249 @@ design: (work@toto)
       \_io_decl: (obj), parent:work@toto::c1::wait_for_total_count
         |vpiName:obj
         |vpiDirection:1
-        |vpiExpr:
-        \_chandle_var: (work@toto::c1::wait_for_total_count::obj::c2), line:44, col:27, parent:obj
+        |vpiTypedef:
+        \_class_typespec: (c2), line:44, col:27, parent:obj
           |vpiName:c2
-          |vpiFullName:work@toto::c1::wait_for_total_count::obj::c2
+          |vpiClassDefn:
+          \_class_defn: (work@toto::c2) top.v:8: , parent:work@toto
+            |vpiName:c2
+            |vpiFullName:work@toto::c2
+            |vpiDerivedClasses:
+            \_class_defn: (work@toto::c3) top.v:15: , parent:work@toto
+              |vpiName:c3
+              |vpiFullName:work@toto::c3
+              |vpiExtends:
+              \_extends: , line:15, col:17, parent:work@toto::c3
+                |vpiClassTypespec:
+                \_class_typespec: 
+                  |vpiClassDefn:
+                  \_class_defn: (work@toto::c2) top.v:8: , parent:work@toto
+              |vpiDerivedClasses:
+              \_class_defn: (work@toto::c1) top.v:18: , parent:work@toto
+                |vpiName:c1
+                |vpiFullName:work@toto::c1
+                |vpiMethod:
+                \_function: (work@toto::c1::get_current_item), line:30, parent:work@toto::c1
+                  |vpiMethod:1
+                  |vpiVisibility:1
+                  |vpiName:get_current_item
+                  |vpiFullName:work@toto::c1::get_current_item
+                  |vpiReturn:
+                  \_chandle_var: , line:30, col:9
+                  |vpiVariables:
+                  \_chandle_var: (work@toto::c1::get_current_item::t), line:31, col:4, parent:work@toto::c1::get_current_item
+                    |vpiName:t
+                    |vpiFullName:work@toto::c1::get_current_item::t
+                |vpiMethod:
+                \_function: (work@toto::c1::connect), line:35, col:1, parent:work@toto::c1
+                  |vpiMethod:1
+                  |vpiVisibility:1
+                  |vpiName:connect
+                  |vpiFullName:work@toto::c1::connect
+                  |vpiIODecl:
+                  \_io_decl: (provider), parent:work@toto::c1::connect
+                    |vpiName:provider
+                    |vpiDirection:1
+                    |vpiTypedef:
+                    \_unsupported_typespec: (this_type), line:35, col:23, parent:provider
+                      |vpiName:this_type
+                |vpiMethod:
+                \_function: (work@toto::c1::get_verbosity_level), line:38, col:3, parent:work@toto::c1
+                  |vpiMethod:1
+                  |vpiVisibility:1
+                  |vpiName:get_verbosity_level
+                  |vpiFullName:work@toto::c1::get_verbosity_level
+                  |vpiReturn:
+                  \_int_var: , line:38, col:12
+                  |vpiIODecl:
+                  \_io_decl: (severity), parent:work@toto::c1::get_verbosity_level
+                    |vpiName:severity
+                    |vpiDirection:1
+                    |vpiTypedef:
+                    \_enum_typespec: (uvm_severity), line:27, col:2, parent:severity
+                      |vpiName:uvm_severity
+                      |vpiBaseTypespec:
+                      \_bit_typespec: , line:21, col:13, parent:uvm_severity
+                        |vpiRange:
+                        \_range: , line:21, col:18
+                          |vpiLeftRange:
+                          \_constant: , line:21, col:18
+                            |vpiConstType:9
+                            |vpiDecompile:1
+                            |vpiSize:64
+                            |UINT:1
+                          |vpiRightRange:
+                          \_constant: , line:21, col:20
+                            |vpiConstType:9
+                            |vpiDecompile:0
+                            |vpiSize:64
+                            |UINT:0
+                      |vpiEnumConst:
+                      \_enum_const: (UVM_ERROR), line:25, parent:uvm_severity
+                        |vpiName:UVM_ERROR
+                        |STRING:toto
+                      |vpiEnumConst:
+                      \_enum_const: (UVM_FATAL), line:26, parent:uvm_severity
+                        |vpiName:UVM_FATAL
+                        |INT:3
+                      |vpiEnumConst:
+                      \_enum_const: (UVM_INFO), line:23, parent:uvm_severity
+                        |vpiName:UVM_INFO
+                        |INT:0
+                      |vpiEnumConst:
+                      \_enum_const: (UVM_WARNING), line:24, parent:uvm_severity
+                        |vpiName:UVM_WARNING
+                        |INT:1
+                  |vpiIODecl:
+                  \_io_decl: (reg_a), parent:work@toto::c1::get_verbosity_level
+                    |vpiName:reg_a
+                    |vpiDirection:1
+                    |vpiTypedef:
+                    \_unsupported_typespec: (uvm_reg), line:38, col:70, parent:reg_a
+                      |vpiName:uvm_reg
+                |vpiMethod:
+                \_function: (work@toto::c1::set_verbosity_level), line:41, col:1, parent:work@toto::c1
+                  |vpiMethod:1
+                  |vpiVisibility:1
+                  |vpiName:set_verbosity_level
+                  |vpiFullName:work@toto::c1::set_verbosity_level
+                  |vpiReturn:
+                  \_int_var: , line:41, col:10
+                  |vpiIODecl:
+                  \_io_decl: (severity), parent:work@toto::c1::set_verbosity_level
+                    |vpiName:severity
+                    |vpiDirection:1
+                    |vpiTypedef:
+                    \_enum_typespec: (uvm_severity), line:27, col:2, parent:severity
+                      |vpiName:uvm_severity
+                      |vpiBaseTypespec:
+                      \_bit_typespec: , line:21, col:13, parent:uvm_severity
+                        |vpiRange:
+                        \_range: , line:21, col:18
+                          |vpiLeftRange:
+                          \_constant: , line:21, col:18
+                            |vpiConstType:9
+                            |vpiDecompile:1
+                            |vpiSize:64
+                            |UINT:1
+                          |vpiRightRange:
+                          \_constant: , line:21, col:20
+                            |vpiConstType:9
+                            |vpiDecompile:0
+                            |vpiSize:64
+                            |UINT:0
+                      |vpiEnumConst:
+                      \_enum_const: (UVM_ERROR), line:25, parent:uvm_severity
+                        |vpiName:UVM_ERROR
+                        |STRING:toto
+                      |vpiEnumConst:
+                      \_enum_const: (UVM_FATAL), line:26, parent:uvm_severity
+                        |vpiName:UVM_FATAL
+                        |INT:3
+                      |vpiEnumConst:
+                      \_enum_const: (UVM_INFO), line:23, parent:uvm_severity
+                        |vpiName:UVM_INFO
+                        |INT:0
+                      |vpiEnumConst:
+                      \_enum_const: (UVM_WARNING), line:24, parent:uvm_severity
+                        |vpiName:UVM_WARNING
+                        |INT:1
+                  |vpiIODecl:
+                  \_io_decl: (reg_a), parent:work@toto::c1::set_verbosity_level
+                    |vpiName:reg_a
+                    |vpiDirection:1
+                    |vpiTypedef:
+                    \_unsupported_typespec: (uvm_reg), line:41, col:70, parent:reg_a
+                      |vpiName:uvm_reg
+                |vpiMethod:
+                \_task: (work@toto::c1::wait_for_total_count), line:44, col:1, parent:work@toto::c1
+                  |vpiMethod:1
+                  |vpiVisibility:1
+                  |vpiName:wait_for_total_count
+                  |vpiFullName:work@toto::c1::wait_for_total_count
+                  |vpiIODecl:
+                  \_io_decl: (obj), parent:work@toto::c1::wait_for_total_count
+                    |vpiName:obj
+                    |vpiDirection:1
+                    |vpiTypedef:
+                    \_class_typespec: (c2), line:44, col:27, parent:obj
+                      |vpiName:c2
+                      |vpiClassDefn:
+                      \_class_defn: (work@toto::c2) top.v:8: , parent:work@toto
+                  |vpiIODecl:
+                  \_io_decl: (count), parent:work@toto::c1::wait_for_total_count
+                    |vpiName:count
+                    |vpiDirection:1
+                    |vpiTypedef:
+                    \_int_typespec: , line:44, col:40, parent:count
+                    |vpiExpr:
+                    \_constant: , line:44, col:50, parent:count
+                      |vpiConstType:9
+                      |vpiDecompile:0
+                      |vpiSize:64
+                      |UINT:0
+                |vpiExtends:
+                \_extends: , line:18, col:17, parent:work@toto::c1
+                  |vpiClassTypespec:
+                  \_class_typespec: 
+                    |vpiClassDefn:
+                    \_class_defn: (work@toto::c3) top.v:15: , parent:work@toto
+                |vpiTypedef:
+                \_enum_typespec: (uvm_severity), line:27, col:2, parent:work@toto::c1
+                  |vpiName:uvm_severity
+                  |vpiBaseTypespec:
+                  \_bit_typespec: , line:21, col:13, parent:uvm_severity
+                    |vpiRange:
+                    \_range: , line:21, col:18
+                      |vpiLeftRange:
+                      \_constant: , line:21, col:18
+                        |vpiConstType:9
+                        |vpiDecompile:1
+                        |vpiSize:64
+                        |UINT:1
+                      |vpiRightRange:
+                      \_constant: , line:21, col:20
+                        |vpiConstType:9
+                        |vpiDecompile:0
+                        |vpiSize:64
+                        |UINT:0
+                  |vpiEnumConst:
+                  \_enum_const: (UVM_ERROR), line:25, parent:uvm_severity
+                    |vpiName:UVM_ERROR
+                    |STRING:toto
+                  |vpiEnumConst:
+                  \_enum_const: (UVM_FATAL), line:26, parent:uvm_severity
+                    |vpiName:UVM_FATAL
+                    |INT:3
+                  |vpiEnumConst:
+                  \_enum_const: (UVM_INFO), line:23, parent:uvm_severity
+                    |vpiName:UVM_INFO
+                    |INT:0
+                  |vpiEnumConst:
+                  \_enum_const: (UVM_WARNING), line:24, parent:uvm_severity
+                    |vpiName:UVM_WARNING
+                    |INT:1
+            |vpiTypedef:
+            \_int_typespec: (this_type), line:10, col:8, parent:work@toto::c2
+              |vpiName:this_type
       |vpiIODecl:
       \_io_decl: (count), parent:work@toto::c1::wait_for_total_count
         |vpiName:count
         |vpiDirection:1
+        |vpiTypedef:
+        \_int_typespec: , line:44, col:40, parent:count
         |vpiExpr:
-        \_int_var: (work@toto::c1::wait_for_total_count::count), line:44, col:40, parent:count
-          |vpiFullName:work@toto::c1::wait_for_total_count::count
+        \_constant: , line:44, col:50, parent:count
+          |vpiConstType:9
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
     |vpiExtends:
     \_extends: , line:18, col:17, parent:work@toto::c1
       |vpiClassTypespec:
       \_class_typespec: 
         |vpiClassDefn:
         \_class_defn: (work@toto::c3) top.v:15: , parent:work@toto
-          |vpiName:c3
-          |vpiFullName:work@toto::c3
-          |vpiExtends:
-          \_extends: , line:15, col:17, parent:work@toto::c3
-            |vpiClassTypespec:
-            \_class_typespec: 
-              |vpiClassDefn:
-              \_class_defn: (work@toto::c2) top.v:8: , parent:work@toto
-                |vpiName:c2
-                |vpiFullName:work@toto::c2
-                |vpiDerivedClasses:
-                \_class_defn: (work@toto::c3) top.v:15: , parent:work@toto
-                |vpiTypedef:
-                \_int_typespec: (this_type), line:10, col:8, parent:work@toto::c2
-                  |vpiName:this_type
-          |vpiDerivedClasses:
-          \_class_defn: (work@toto::c1) top.v:18: , parent:work@toto
-            |vpiName:c1
-            |vpiFullName:work@toto::c1
-            |vpiMethod:
-            \_function: (work@toto::c1::get_current_item), line:30, parent:work@toto::c1
-              |vpiMethod:1
-              |vpiVisibility:1
-              |vpiName:get_current_item
-              |vpiFullName:work@toto::c1::get_current_item
-              |vpiReturn:
-              \_chandle_var: , line:30, col:9
-              |vpiVariables:
-              \_chandle_var: (work@toto::c1::get_current_item::t), line:31, col:4, parent:work@toto::c1::get_current_item
-                |vpiName:t
-                |vpiFullName:work@toto::c1::get_current_item::t
-            |vpiMethod:
-            \_function: (work@toto::c1::connect), line:35, col:1, parent:work@toto::c1
-              |vpiMethod:1
-              |vpiVisibility:1
-              |vpiName:connect
-              |vpiFullName:work@toto::c1::connect
-              |vpiIODecl:
-              \_io_decl: (provider), parent:work@toto::c1::connect
-                |vpiName:provider
-                |vpiDirection:1
-                |vpiExpr:
-                \_chandle_var: (work@toto::c1::connect::provider::this_type), line:35, col:23, parent:provider
-                  |vpiName:this_type
-                  |vpiFullName:work@toto::c1::connect::provider::this_type
-            |vpiMethod:
-            \_function: (work@toto::c1::get_verbosity_level), line:38, col:3, parent:work@toto::c1
-              |vpiMethod:1
-              |vpiVisibility:1
-              |vpiName:get_verbosity_level
-              |vpiFullName:work@toto::c1::get_verbosity_level
-              |vpiReturn:
-              \_int_var: , line:38, col:12
-              |vpiIODecl:
-              \_io_decl: (severity), parent:work@toto::c1::get_verbosity_level
-                |vpiName:severity
-                |vpiDirection:1
-                |vpiExpr:
-                \_bit_var: (work@toto::c1::get_verbosity_level::severity::uvm_severity), line:38, col:36, parent:severity
-                  |vpiName:uvm_severity
-                  |vpiFullName:work@toto::c1::get_verbosity_level::severity::uvm_severity
-                  |vpiRange:
-                  \_range: , line:21, col:18, parent:work@toto::c1::get_verbosity_level::severity::uvm_severity
-                    |vpiLeftRange:
-                    \_constant: , line:21, col:18
-                      |vpiConstType:9
-                      |vpiDecompile:1
-                      |vpiSize:64
-                      |UINT:1
-                    |vpiRightRange:
-                    \_constant: , line:21, col:20
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-                  |vpiTypespec:
-                  \_enum_typespec: (uvm_severity), line:27, col:2, parent:work@toto::c1::get_verbosity_level::severity::uvm_severity
-                    |vpiName:uvm_severity
-                    |vpiBaseTypespec:
-                    \_bit_typespec: , line:21, col:13, parent:uvm_severity
-                      |vpiRange:
-                      \_range: , line:21, col:18
-                        |vpiLeftRange:
-                        \_constant: , line:21, col:18
-                          |vpiConstType:9
-                          |vpiDecompile:1
-                          |vpiSize:64
-                          |UINT:1
-                        |vpiRightRange:
-                        \_constant: , line:21, col:20
-                          |vpiConstType:9
-                          |vpiDecompile:0
-                          |vpiSize:64
-                          |UINT:0
-                    |vpiEnumConst:
-                    \_enum_const: (UVM_ERROR), line:25, parent:uvm_severity
-                      |vpiName:UVM_ERROR
-                      |STRING:toto
-                    |vpiEnumConst:
-                    \_enum_const: (UVM_FATAL), line:26, parent:uvm_severity
-                      |vpiName:UVM_FATAL
-                      |INT:3
-                    |vpiEnumConst:
-                    \_enum_const: (UVM_INFO), line:23, parent:uvm_severity
-                      |vpiName:UVM_INFO
-                      |INT:0
-                    |vpiEnumConst:
-                    \_enum_const: (UVM_WARNING), line:24, parent:uvm_severity
-                      |vpiName:UVM_WARNING
-                      |INT:1
-              |vpiIODecl:
-              \_io_decl: (reg_a), parent:work@toto::c1::get_verbosity_level
-                |vpiName:reg_a
-                |vpiDirection:1
-                |vpiExpr:
-                \_chandle_var: (work@toto::c1::get_verbosity_level::reg_a::uvm_reg), line:38, col:70, parent:reg_a
-                  |vpiName:uvm_reg
-                  |vpiFullName:work@toto::c1::get_verbosity_level::reg_a::uvm_reg
-            |vpiMethod:
-            \_function: (work@toto::c1::set_verbosity_level), line:41, col:1, parent:work@toto::c1
-              |vpiMethod:1
-              |vpiVisibility:1
-              |vpiName:set_verbosity_level
-              |vpiFullName:work@toto::c1::set_verbosity_level
-              |vpiReturn:
-              \_int_var: , line:41, col:10
-              |vpiIODecl:
-              \_io_decl: (severity), parent:work@toto::c1::set_verbosity_level
-                |vpiName:severity
-                |vpiDirection:1
-                |vpiExpr:
-                \_bit_var: (work@toto::c1::set_verbosity_level::severity::uvm_severity), line:41, col:34, parent:severity
-                  |vpiName:uvm_severity
-                  |vpiFullName:work@toto::c1::set_verbosity_level::severity::uvm_severity
-                  |vpiRange:
-                  \_range: , line:21, col:18, parent:work@toto::c1::set_verbosity_level::severity::uvm_severity
-                    |vpiLeftRange:
-                    \_constant: , line:21, col:18
-                      |vpiConstType:9
-                      |vpiDecompile:1
-                      |vpiSize:64
-                      |UINT:1
-                    |vpiRightRange:
-                    \_constant: , line:21, col:20
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-                  |vpiTypespec:
-                  \_enum_typespec: (uvm_severity), line:27, col:2, parent:work@toto::c1::set_verbosity_level::severity::uvm_severity
-                    |vpiName:uvm_severity
-                    |vpiBaseTypespec:
-                    \_bit_typespec: , line:21, col:13, parent:uvm_severity
-                      |vpiRange:
-                      \_range: , line:21, col:18
-                        |vpiLeftRange:
-                        \_constant: , line:21, col:18
-                          |vpiConstType:9
-                          |vpiDecompile:1
-                          |vpiSize:64
-                          |UINT:1
-                        |vpiRightRange:
-                        \_constant: , line:21, col:20
-                          |vpiConstType:9
-                          |vpiDecompile:0
-                          |vpiSize:64
-                          |UINT:0
-                    |vpiEnumConst:
-                    \_enum_const: (UVM_ERROR), line:25, parent:uvm_severity
-                      |vpiName:UVM_ERROR
-                      |STRING:toto
-                    |vpiEnumConst:
-                    \_enum_const: (UVM_FATAL), line:26, parent:uvm_severity
-                      |vpiName:UVM_FATAL
-                      |INT:3
-                    |vpiEnumConst:
-                    \_enum_const: (UVM_INFO), line:23, parent:uvm_severity
-                      |vpiName:UVM_INFO
-                      |INT:0
-                    |vpiEnumConst:
-                    \_enum_const: (UVM_WARNING), line:24, parent:uvm_severity
-                      |vpiName:UVM_WARNING
-                      |INT:1
-              |vpiIODecl:
-              \_io_decl: (reg_a), parent:work@toto::c1::set_verbosity_level
-                |vpiName:reg_a
-                |vpiDirection:1
-                |vpiExpr:
-                \_chandle_var: (work@toto::c1::set_verbosity_level::reg_a::uvm_reg), line:41, col:70, parent:reg_a
-                  |vpiName:uvm_reg
-                  |vpiFullName:work@toto::c1::set_verbosity_level::reg_a::uvm_reg
-            |vpiMethod:
-            \_task: (work@toto::c1::wait_for_total_count), line:44, col:1, parent:work@toto::c1
-              |vpiMethod:1
-              |vpiVisibility:1
-              |vpiName:wait_for_total_count
-              |vpiFullName:work@toto::c1::wait_for_total_count
-              |vpiIODecl:
-              \_io_decl: (obj), parent:work@toto::c1::wait_for_total_count
-                |vpiName:obj
-                |vpiDirection:1
-                |vpiExpr:
-                \_chandle_var: (work@toto::c1::wait_for_total_count::obj::c2), line:44, col:27, parent:obj
-                  |vpiName:c2
-                  |vpiFullName:work@toto::c1::wait_for_total_count::obj::c2
-              |vpiIODecl:
-              \_io_decl: (count), parent:work@toto::c1::wait_for_total_count
-                |vpiName:count
-                |vpiDirection:1
-                |vpiExpr:
-                \_int_var: (work@toto::c1::wait_for_total_count::count), line:44, col:40, parent:count
-                  |vpiFullName:work@toto::c1::wait_for_total_count::count
-            |vpiExtends:
-            \_extends: , line:18, col:17, parent:work@toto::c1
-              |vpiClassTypespec:
-              \_class_typespec: 
-                |vpiClassDefn:
-                \_class_defn: (work@toto::c3) top.v:15: , parent:work@toto
-            |vpiTypedef:
-            \_enum_typespec: (uvm_severity), line:27, col:2, parent:work@toto::c1
-              |vpiName:uvm_severity
-              |vpiBaseTypespec:
-              \_bit_typespec: , line:21, col:13, parent:uvm_severity
-                |vpiRange:
-                \_range: , line:21, col:18
-                  |vpiLeftRange:
-                  \_constant: , line:21, col:18
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                  |vpiRightRange:
-                  \_constant: , line:21, col:20
-                    |vpiConstType:9
-                    |vpiDecompile:0
-                    |vpiSize:64
-                    |UINT:0
-              |vpiEnumConst:
-              \_enum_const: (UVM_ERROR), line:25, parent:uvm_severity
-                |vpiName:UVM_ERROR
-                |STRING:toto
-              |vpiEnumConst:
-              \_enum_const: (UVM_FATAL), line:26, parent:uvm_severity
-                |vpiName:UVM_FATAL
-                |INT:3
-              |vpiEnumConst:
-              \_enum_const: (UVM_INFO), line:23, parent:uvm_severity
-                |vpiName:UVM_INFO
-                |INT:0
-              |vpiEnumConst:
-              \_enum_const: (UVM_WARNING), line:24, parent:uvm_severity
-                |vpiName:UVM_WARNING
-                |INT:1
     |vpiTypedef:
     \_enum_typespec: (uvm_severity), line:27, col:2, parent:work@toto::c1
       |vpiName:uvm_severity

--- a/tests/ClassFuncTask/ClassFuncTask.log
+++ b/tests/ClassFuncTask/ClassFuncTask.log
@@ -54,9 +54,14 @@ design: (unnamed)
       \_io_decl: (bound), parent:pack::C::new
         |vpiName:bound
         |vpiDirection:1
+        |vpiTypedef:
+        \_int_typespec: , line:15, col:16, parent:bound
         |vpiExpr:
-        \_int_var: (pack::C::new::bound), line:15, col:16, parent:bound
-          |vpiFullName:pack::C::new::bound
+        \_constant: , line:15, col:28, parent:bound
+          |vpiConstType:9
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
       |vpiStmt:
       \_method_func_call: (super.new), parent:pack::C::new
         |vpiName:super.new
@@ -90,9 +95,8 @@ design: (unnamed)
       \_io_decl: (i), parent:pack::C::set
         |vpiName:i
         |vpiDirection:1
-        |vpiExpr:
-        \_int_var: (pack::C::set::i), line:19, col:12, parent:i
-          |vpiFullName:pack::C::set::i
+        |vpiTypedef:
+        \_int_typespec: , line:19, col:12, parent:i
       |vpiStmt:
       \_assignment: , line:20, col:4, parent:pack::C::set
         |vpiOpType:82

--- a/tests/ClassMethodCall/ClassMethodCall.log
+++ b/tests/ClassMethodCall/ClassMethodCall.log
@@ -90,9 +90,8 @@ design: (work@door_mod)
         \_io_decl: (a), parent:pack::doorOpen::new
           |vpiName:a
           |vpiDirection:1
-          |vpiExpr:
-          \_int_var: (pack::doorOpen::new::a), line:23, col:25, parent:a
-            |vpiFullName:pack::doorOpen::new::a
+          |vpiTypedef:
+          \_int_typespec: , line:23, col:25, parent:a
         |vpiStmt:
         \_begin: (pack::doorOpen::new), parent:pack::doorOpen::new
           |vpiFullName:pack::doorOpen::new
@@ -122,9 +121,8 @@ design: (work@door_mod)
         \_io_decl: (b), parent:pack::doorOpen::new
           |vpiName:b
           |vpiDirection:1
-          |vpiExpr:
-          \_int_var: (pack::doorOpen::new::b), line:29, col:18, parent:b
-            |vpiFullName:pack::doorOpen::new::b
+          |vpiTypedef:
+          \_int_typespec: , line:29, col:18, parent:b
         |vpiStmt:
         \_begin: (pack::doorOpen::new), parent:pack::doorOpen::new
           |vpiFullName:pack::doorOpen::new
@@ -291,9 +289,8 @@ design: (work@door_mod)
                   \_io_decl: (a), parent:pack::doorOpen::new
                     |vpiName:a
                     |vpiDirection:1
-                    |vpiExpr:
-                    \_int_var: (pack::doorOpen::new::a), line:23, col:25, parent:a
-                      |vpiFullName:pack::doorOpen::new::a
+                    |vpiTypedef:
+                    \_int_typespec: , line:23, col:25, parent:a
                   |vpiStmt:
                   \_begin: (pack::doorOpen::new), parent:pack::doorOpen::new
                     |vpiFullName:pack::doorOpen::new
@@ -323,9 +320,8 @@ design: (work@door_mod)
                   \_io_decl: (b), parent:pack::doorOpen::new
                     |vpiName:b
                     |vpiDirection:1
-                    |vpiExpr:
-                    \_int_var: (pack::doorOpen::new::b), line:29, col:18, parent:b
-                      |vpiFullName:pack::doorOpen::new::b
+                    |vpiTypedef:
+                    \_int_typespec: , line:29, col:18, parent:b
                   |vpiStmt:
                   \_begin: (pack::doorOpen::new), parent:pack::doorOpen::new
                     |vpiFullName:pack::doorOpen::new
@@ -534,9 +530,8 @@ design: (work@door_mod)
                   \_io_decl: (a), parent:pack::doorOpen::new
                     |vpiName:a
                     |vpiDirection:1
-                    |vpiExpr:
-                    \_int_var: (pack::doorOpen::new::a), line:23, col:25, parent:a
-                      |vpiFullName:pack::doorOpen::new::a
+                    |vpiTypedef:
+                    \_int_typespec: , line:23, col:25, parent:a
                   |vpiStmt:
                   \_begin: (pack::doorOpen::new), parent:pack::doorOpen::new
                     |vpiFullName:pack::doorOpen::new
@@ -566,9 +561,8 @@ design: (work@door_mod)
                   \_io_decl: (b), parent:pack::doorOpen::new
                     |vpiName:b
                     |vpiDirection:1
-                    |vpiExpr:
-                    \_int_var: (pack::doorOpen::new::b), line:29, col:18, parent:b
-                      |vpiFullName:pack::doorOpen::new::b
+                    |vpiTypedef:
+                    \_int_typespec: , line:29, col:18, parent:b
                   |vpiStmt:
                   \_begin: (pack::doorOpen::new), parent:pack::doorOpen::new
                     |vpiFullName:pack::doorOpen::new

--- a/tests/ClassParam/ClassParam.log
+++ b/tests/ClassParam/ClassParam.log
@@ -64,16 +64,26 @@ design: (unnamed)
                 \_io_decl: (bound)
                   |vpiName:bound
                   |vpiDirection:1
+                  |vpiTypedef:
+                  \_int_typespec: , line:8, col:19
                   |vpiExpr:
-                  \_int_var: (bound), line:8, col:19, parent:bound
-                    |vpiFullName:bound
+                  \_constant: , line:8, col:31
+                    |vpiConstType:9
+                    |vpiDecompile:0
+                    |vpiSize:64
+                    |UINT:0
         |vpiIODecl:
         \_io_decl: (bound), parent:pack::uvm_port_base::embedded::new
           |vpiName:bound
           |vpiDirection:1
+          |vpiTypedef:
+          \_int_typespec: , line:8, col:19, parent:bound
           |vpiExpr:
-          \_int_var: (pack::uvm_port_base::embedded::new::bound), line:8, col:19, parent:bound
-            |vpiFullName:pack::uvm_port_base::embedded::new::bound
+          \_constant: , line:8, col:31, parent:bound
+            |vpiConstType:9
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
     |vpiParamAssign:
     \_param_assign: , line:4, col:10, parent:pack::uvm_port_base
       |vpiRhs:

--- a/tests/ClassTypeParam/ClassTypeParam.log
+++ b/tests/ClassTypeParam/ClassTypeParam.log
@@ -89,9 +89,8 @@ design: (work@top)
             \_io_decl: (a_error_msg), parent:work@uvm_resource_db::check_all_sva_passed
               |vpiName:a_error_msg
               |vpiDirection:1
-              |vpiExpr:
-              \_string_var: (work@uvm_resource_db::check_all_sva_passed::a_error_msg), line:11, col:44, parent:a_error_msg
-                |vpiFullName:work@uvm_resource_db::check_all_sva_passed::a_error_msg
+              |vpiTypedef:
+              \_string_typespec: , line:11, col:44, parent:a_error_msg
           |vpiDerivedClasses:
           \_class_defn: (work@uvm_config_db) dut.sv:16: , parent:work@top
           |vpiVariables:
@@ -222,9 +221,8 @@ design: (work@top)
           \_io_decl: (a_error_msg), parent:work@uvm_resource_db::check_all_sva_passed
             |vpiName:a_error_msg
             |vpiDirection:1
-            |vpiExpr:
-            \_string_var: (work@uvm_resource_db::check_all_sva_passed::a_error_msg), line:11, col:44, parent:a_error_msg
-              |vpiFullName:work@uvm_resource_db::check_all_sva_passed::a_error_msg
+            |vpiTypedef:
+            \_string_typespec: , line:11, col:44, parent:a_error_msg
         |vpiDerivedClasses:
         \_class_defn: (work@uvm_config_db) dut.sv:16: , parent:work@top
         |vpiVariables:
@@ -428,9 +426,8 @@ design: (work@top)
                 \_io_decl: (a_error_msg), parent:work@uvm_resource_db::check_all_sva_passed
                   |vpiName:a_error_msg
                   |vpiDirection:1
-                  |vpiExpr:
-                  \_string_var: (work@uvm_resource_db::check_all_sva_passed::a_error_msg), line:11, col:44, parent:a_error_msg
-                    |vpiFullName:work@uvm_resource_db::check_all_sva_passed::a_error_msg
+                  |vpiTypedef:
+                  \_string_typespec: , line:11, col:44, parent:a_error_msg
               |vpiDerivedClasses:
               \_class_defn: (work@uvm_config_db) dut.sv:16: , parent:work@top
               |vpiVariables:

--- a/tests/ClassTypeParamAlias/ClassTypeParamAlias.log
+++ b/tests/ClassTypeParamAlias/ClassTypeParamAlias.log
@@ -165,9 +165,14 @@ design: (unnamed)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -419,9 +424,14 @@ design: (unnamed)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -432,9 +442,14 @@ design: (unnamed)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -445,9 +460,14 @@ design: (unnamed)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -460,9 +480,14 @@ design: (unnamed)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/ClockingBlock/ClockingBlock.log
+++ b/tests/ClockingBlock/ClockingBlock.log
@@ -162,9 +162,14 @@ design: (work@top)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -356,9 +361,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -369,9 +379,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -382,9 +397,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -397,9 +417,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@top (work@top) dut.sv:1: , endline:17:9: , parent:work@top
   |vpiDefName:work@top

--- a/tests/ClogCast/ClogCast.log
+++ b/tests/ClogCast/ClogCast.log
@@ -459,9 +459,14 @@ design: (work@debug_rom)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -653,9 +658,14 @@ design: (work@debug_rom)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -666,9 +676,14 @@ design: (work@debug_rom)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -679,9 +694,14 @@ design: (work@debug_rom)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -694,9 +714,14 @@ design: (work@debug_rom)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@debug_rom (work@debug_rom) dut.sv:3:1: , endline:51:10: , parent:work@debug_rom
   |vpiDefName:work@debug_rom

--- a/tests/ComplexBitSelect/ComplexBitSelect.log
+++ b/tests/ComplexBitSelect/ComplexBitSelect.log
@@ -375,9 +375,14 @@ design: (work@flash_ctrl_info_cfg)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -569,9 +574,14 @@ design: (work@flash_ctrl_info_cfg)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -582,9 +592,14 @@ design: (work@flash_ctrl_info_cfg)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -595,9 +610,14 @@ design: (work@flash_ctrl_info_cfg)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -610,9 +630,14 @@ design: (work@flash_ctrl_info_cfg)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@flash_ctrl_info_cfg (work@flash_ctrl_info_cfg) dut.sv:12: , endline:24:9: , parent:work@flash_ctrl_info_cfg
   |vpiDefName:work@flash_ctrl_info_cfg

--- a/tests/ConcatVal/ConcatVal.log
+++ b/tests/ConcatVal/ConcatVal.log
@@ -278,9 +278,14 @@ design: (work@dut)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -472,9 +477,14 @@ design: (work@dut)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -485,9 +495,14 @@ design: (work@dut)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -498,9 +513,14 @@ design: (work@dut)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -513,9 +533,14 @@ design: (work@dut)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@dut (work@dut) dut.sv:1: , endline:15:9: , parent:work@dut
   |vpiDefName:work@dut
@@ -602,9 +627,8 @@ design: (work@dut)
     \_io_decl: (state_in)
       |vpiName:state_in
       |vpiDirection:1
-      |vpiExpr:
-      \_logic_var: (state_in), line:4, col:45, parent:state_in
-        |vpiFullName:state_in
+      |vpiTypedef:
+      \_logic_typespec: , line:4, col:45
         |vpiRange:
         \_range: , line:4, col:52
           |vpiLeftRange:
@@ -623,9 +647,8 @@ design: (work@dut)
     \_io_decl: (sbox4)
       |vpiName:sbox4
       |vpiDirection:1
-      |vpiExpr:
-      \_logic_var: (sbox4), line:4, col:68, parent:sbox4
-        |vpiFullName:sbox4
+      |vpiTypedef:
+      \_logic_typespec: , line:4, col:68
         |vpiRange:
         \_range: , line:4, col:75
           |vpiLeftRange:
@@ -861,9 +884,8 @@ design: (work@dut)
         \_io_decl: (state_in)
           |vpiName:state_in
           |vpiDirection:1
-          |vpiExpr:
-          \_logic_var: (state_in), line:4, col:45, parent:state_in
-            |vpiFullName:state_in
+          |vpiTypedef:
+          \_logic_typespec: , line:4, col:45
             |vpiRange:
             \_range: , line:4, col:52
               |vpiLeftRange:
@@ -882,9 +904,8 @@ design: (work@dut)
         \_io_decl: (sbox4)
           |vpiName:sbox4
           |vpiDirection:1
-          |vpiExpr:
-          \_logic_var: (sbox4), line:4, col:68, parent:sbox4
-            |vpiFullName:sbox4
+          |vpiTypedef:
+          \_logic_typespec: , line:4, col:68
             |vpiRange:
             \_range: , line:4, col:75
               |vpiLeftRange:
@@ -1005,11 +1026,10 @@ design: (work@dut)
     \_io_decl: (state_in), parent:work@dut.sbox4_64bit
       |vpiName:state_in
       |vpiDirection:1
-      |vpiExpr:
-      \_logic_var: (work@dut.sbox4_64bit.state_in), line:4, col:45, parent:state_in
-        |vpiFullName:work@dut.sbox4_64bit.state_in
+      |vpiTypedef:
+      \_logic_typespec: , line:4, col:45, parent:state_in
         |vpiRange:
-        \_range: , line:4, col:52, parent:work@dut.sbox4_64bit.state_in
+        \_range: , line:4, col:52
           |vpiLeftRange:
           \_constant: , line:4, col:52
             |vpiConstType:9
@@ -1026,11 +1046,10 @@ design: (work@dut)
     \_io_decl: (sbox4), parent:work@dut.sbox4_64bit
       |vpiName:sbox4
       |vpiDirection:1
-      |vpiExpr:
-      \_logic_var: (work@dut.sbox4_64bit.sbox4), line:4, col:68, parent:sbox4
-        |vpiFullName:work@dut.sbox4_64bit.sbox4
+      |vpiTypedef:
+      \_logic_typespec: , line:4, col:68, parent:sbox4
         |vpiRange:
-        \_range: , line:4, col:75, parent:work@dut.sbox4_64bit.sbox4
+        \_range: , line:4, col:75
           |vpiLeftRange:
           \_constant: , line:4, col:75
             |vpiConstType:9
@@ -1044,7 +1063,7 @@ design: (work@dut)
             |vpiSize:64
             |UINT:0
         |vpiRange:
-        \_range: , line:4, col:81, parent:work@dut.sbox4_64bit.sbox4
+        \_range: , line:4, col:81
           |vpiLeftRange:
           \_constant: , line:4, col:81
             |vpiConstType:9

--- a/tests/ConcatWidth/ConcatWidth.log
+++ b/tests/ConcatWidth/ConcatWidth.log
@@ -290,9 +290,14 @@ design: (work@top)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -484,9 +489,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -497,9 +507,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -510,9 +525,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -525,9 +545,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@top (work@top) dut.sv:1: , endline:18:9: , parent:work@top
   |vpiDefName:work@top

--- a/tests/ConditionalOp/ConditionalOp.log
+++ b/tests/ConditionalOp/ConditionalOp.log
@@ -458,9 +458,14 @@ design: (work@top)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -652,9 +657,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -665,9 +675,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -678,9 +693,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -693,9 +713,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@ibex_register_file (work@ibex_register_file) dut.sv:14: , endline:24:9: , parent:work@top
   |vpiDefName:work@ibex_register_file

--- a/tests/Connection/Connection.log
+++ b/tests/Connection/Connection.log
@@ -89,9 +89,14 @@ design: (work@top)
     \_io_decl: (bound)
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16
       |vpiExpr:
-      \_int_var: (bound), line:6, col:16, parent:bound
-        |vpiFullName:bound
+      \_constant: , line:6, col:28
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -262,9 +267,14 @@ design: (work@top)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15
       |vpiExpr:
-      \_int_var: (keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:60, col:30
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -275,9 +285,14 @@ design: (work@top)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11
       |vpiExpr:
-      \_int_var: (keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:63, col:26
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -288,9 +303,14 @@ design: (work@top)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11
       |vpiExpr:
-      \_int_var: (keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:66, col:26
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -303,9 +323,14 @@ design: (work@top)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23
       |vpiExpr:
-      \_int_var: (keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:69, col:38
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@ibex_csr (work@ibex_csr) dut.sv:12: , endline:19:9: , parent:work@top
   |vpiDefName:work@ibex_csr

--- a/tests/ContAssign/ContAssign.log
+++ b/tests/ContAssign/ContAssign.log
@@ -162,9 +162,14 @@ design: (work@top)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -356,9 +361,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -369,9 +379,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -382,9 +397,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -397,9 +417,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@top (work@top) dut.sv:1: , endline:14:9: , parent:work@top
   |vpiDefName:work@top

--- a/tests/DelayAssign/DelayAssign.log
+++ b/tests/DelayAssign/DelayAssign.log
@@ -754,9 +754,14 @@ design: (work@SimDTM)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -948,9 +953,14 @@ design: (work@SimDTM)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -961,9 +971,14 @@ design: (work@SimDTM)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -974,9 +989,14 @@ design: (work@SimDTM)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -989,9 +1009,14 @@ design: (work@SimDTM)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@SimDTM (work@SimDTM) dut.sv:16: , endline:79:9: , parent:work@SimDTM
   |vpiDefName:work@SimDTM

--- a/tests/DoWhile/DoWhile.log
+++ b/tests/DoWhile/DoWhile.log
@@ -199,9 +199,14 @@ design: (unnamed)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -393,9 +398,14 @@ design: (unnamed)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -406,9 +416,14 @@ design: (unnamed)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -419,9 +434,14 @@ design: (unnamed)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -434,9 +454,14 @@ design: (unnamed)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/DollarRoot/DollarRoot.log
+++ b/tests/DollarRoot/DollarRoot.log
@@ -6439,9 +6439,14 @@ design: (work@top)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -6633,9 +6638,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -6646,9 +6656,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -6659,9 +6674,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -6674,9 +6694,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@test_program (work@test_program) dut.sv:5: , endline:797:9: , parent:work@top
   |vpiDefName:work@test_program
@@ -8076,12 +8101,8 @@ design: (work@top)
     \_io_decl: (cmd)
       |vpiName:cmd
       |vpiDirection:1
-      |vpiExpr:
-      \_struct_var: (cmd.Command), line:225, col:6, parent:cmd
-        |vpiName:Command
-        |vpiFullName:cmd.Command
-        |vpiTypespec:
-        \_struct_typespec: (Command), line:45, col:11
+      |vpiTypedef:
+      \_struct_typespec: (Command), line:45, col:11
     |vpiStmt:
     \_begin: (work@test_program.configure_and_push_command_to_master_0), parent:work@test_program.configure_and_push_command_to_master_0
       |vpiFullName:work@test_program.configure_and_push_command_to_master_0
@@ -8688,12 +8709,8 @@ design: (work@top)
     \_io_decl: (rsp)
       |vpiName:rsp
       |vpiDirection:1
-      |vpiExpr:
-      \_struct_var: (rsp.Response), line:341, col:6, parent:rsp
-        |vpiName:Response
-        |vpiFullName:rsp.Response
-        |vpiTypespec:
-        \_struct_typespec: (Response), line:56, col:11
+      |vpiTypedef:
+      \_struct_typespec: (Response), line:56, col:11
     |vpiStmt:
     \_begin: (work@test_program.configure_and_push_response_to_slave_0), parent:work@test_program.configure_and_push_response_to_slave_0
       |vpiFullName:work@test_program.configure_and_push_response_to_slave_0
@@ -8960,12 +8977,8 @@ design: (work@top)
     \_io_decl: (cmd)
       |vpiName:cmd
       |vpiDirection:1
-      |vpiExpr:
-      \_struct_var: (cmd.Command), line:368, col:6, parent:cmd
-        |vpiName:Command
-        |vpiFullName:cmd.Command
-        |vpiTypespec:
-        \_struct_typespec: (Command), line:45, col:11
+      |vpiTypedef:
+      \_struct_typespec: (Command), line:45, col:11
     |vpiStmt:
     \_begin: (work@test_program.configure_and_push_command_to_master_1), parent:work@test_program.configure_and_push_command_to_master_1
       |vpiFullName:work@test_program.configure_and_push_command_to_master_1
@@ -9572,12 +9585,8 @@ design: (work@top)
     \_io_decl: (rsp)
       |vpiName:rsp
       |vpiDirection:1
-      |vpiExpr:
-      \_struct_var: (rsp.Response), line:484, col:6, parent:rsp
-        |vpiName:Response
-        |vpiFullName:rsp.Response
-        |vpiTypespec:
-        \_struct_typespec: (Response), line:56, col:11
+      |vpiTypedef:
+      \_struct_typespec: (Response), line:56, col:11
     |vpiStmt:
     \_begin: (work@test_program.configure_and_push_response_to_slave_1), parent:work@test_program.configure_and_push_response_to_slave_1
       |vpiFullName:work@test_program.configure_and_push_response_to_slave_1
@@ -9844,36 +9853,27 @@ design: (work@top)
     \_io_decl: (num_command)
       |vpiName:num_command
       |vpiDirection:1
-      |vpiExpr:
-      \_int_var: (num_command), line:545, col:6, parent:num_command
-        |vpiFullName:num_command
+      |vpiTypedef:
+      \_int_typespec: , line:545, col:6
     |vpiIODecl:
     \_io_decl: (trans)
       |vpiName:trans
       |vpiDirection:1
-      |vpiExpr:
-      \_bit_var: (trans.Transaction), line:546, col:6, parent:trans
-        |vpiName:Transaction
-        |vpiFullName:trans.Transaction
-        |vpiTypespec:
-        \_enum_typespec: (Transaction), line:37, col:5
+      |vpiTypedef:
+      \_enum_typespec: (Transaction), line:37, col:5
     |vpiIODecl:
     \_io_decl: (burstmode)
       |vpiName:burstmode
       |vpiDirection:1
-      |vpiExpr:
-      \_bit_var: (burstmode.Burstmode), line:547, col:6, parent:burstmode
+      |vpiTypedef:
+      \_enum_typespec: (Burstmode), line:43, col:5
         |vpiName:Burstmode
-        |vpiFullName:burstmode.Burstmode
-        |vpiTypespec:
-        \_enum_typespec: (Burstmode), line:43, col:5
-          |vpiName:Burstmode
-          |vpiBaseTypespec:
-          \_bit_typespec: , line:39, col:16
-          |vpiEnumConst:
-          \_enum_const: (BURST), line:42
-          |vpiEnumConst:
-          \_enum_const: (NOBURST), line:41
+        |vpiBaseTypespec:
+        \_bit_typespec: , line:39, col:16
+        |vpiEnumConst:
+        \_enum_const: (BURST), line:42
+        |vpiEnumConst:
+        \_enum_const: (NOBURST), line:41
     |vpiStmt:
     \_begin: (work@test_program.master_send_commands), parent:work@test_program.master_send_commands
       |vpiFullName:work@test_program.master_send_commands
@@ -10060,29 +10060,20 @@ design: (work@top)
     \_io_decl: (trans)
       |vpiName:trans
       |vpiDirection:1
-      |vpiExpr:
-      \_bit_var: (trans.Transaction), line:571, col:6, parent:trans
-        |vpiName:Transaction
-        |vpiFullName:trans.Transaction
-        |vpiTypespec:
-        \_enum_typespec: (Transaction), line:37, col:5
+      |vpiTypedef:
+      \_enum_typespec: (Transaction), line:37, col:5
     |vpiIODecl:
     \_io_decl: (burstmode)
       |vpiName:burstmode
       |vpiDirection:1
-      |vpiExpr:
-      \_bit_var: (burstmode.Burstmode), line:572, col:6, parent:burstmode
-        |vpiName:Burstmode
-        |vpiFullName:burstmode.Burstmode
-        |vpiTypespec:
-        \_enum_typespec: (Burstmode), line:43, col:5
+      |vpiTypedef:
+      \_enum_typespec: (Burstmode), line:43, col:5
     |vpiIODecl:
     \_io_decl: (slave_id)
       |vpiName:slave_id
       |vpiDirection:1
-      |vpiExpr:
-      \_int_var: (slave_id), line:573, col:6, parent:slave_id
-        |vpiFullName:slave_id
+      |vpiTypedef:
+      \_int_typespec: , line:573, col:6
     |vpiStmt:
     \_begin: (work@test_program.create_command), parent:work@test_program.create_command
       |vpiFullName:work@test_program.create_command
@@ -10382,8 +10373,6 @@ design: (work@top)
     |vpiFullName:work@test_program.randomize_burstcount
     |vpiReturn:
     \_logic_var: , line:601, col:22
-      |vpiRange:
-      \_range: , line:31, col:18
       |vpiTypespec:
       \_logic_typespec: (Burstcount), line:31, col:11
     |vpiInstance:
@@ -10403,8 +10392,6 @@ design: (work@top)
           \_logic_var: (work@test_program.randomize_burstcount.burstcount), line:603, col:6
             |vpiName:burstcount
             |vpiFullName:work@test_program.randomize_burstcount.burstcount
-            |vpiRange:
-            \_range: , line:31, col:18
             |vpiTypespec:
             \_logic_typespec: (Burstcount), line:31, col:11
         |vpiRhs:
@@ -10458,9 +10445,8 @@ design: (work@top)
     \_io_decl: (slave_id)
       |vpiName:slave_id
       |vpiDirection:1
-      |vpiExpr:
-      \_int_var: (slave_id), line:610, col:6, parent:slave_id
-        |vpiFullName:slave_id
+      |vpiTypedef:
+      \_int_typespec: , line:610, col:6
     |vpiStmt:
     \_begin: (work@test_program.generate_random_aligned_address), parent:work@test_program.generate_random_aligned_address
       |vpiFullName:work@test_program.generate_random_aligned_address
@@ -10614,26 +10600,20 @@ design: (work@top)
     \_io_decl: (cmd)
       |vpiName:cmd
       |vpiDirection:1
-      |vpiExpr:
-      \_struct_var: (cmd.Command), line:621, col:6, parent:cmd
-        |vpiName:Command
-        |vpiFullName:cmd.Command
-        |vpiTypespec:
-        \_struct_typespec: (Command), line:45, col:11
+      |vpiTypedef:
+      \_struct_typespec: (Command), line:45, col:11
     |vpiIODecl:
     \_io_decl: (master_id)
       |vpiName:master_id
       |vpiDirection:1
-      |vpiExpr:
-      \_int_var: (master_id), line:622, col:6, parent:master_id
-        |vpiFullName:master_id
+      |vpiTypedef:
+      \_int_typespec: , line:622, col:6
     |vpiIODecl:
     \_io_decl: (slave_id)
       |vpiName:slave_id
       |vpiDirection:1
-      |vpiExpr:
-      \_int_var: (slave_id), line:623, col:6, parent:slave_id
-        |vpiFullName:slave_id
+      |vpiTypedef:
+      \_int_typespec: , line:623, col:6
     |vpiStmt:
     \_begin: (work@test_program.queue_command), parent:work@test_program.queue_command
       |vpiFullName:work@test_program.queue_command
@@ -10688,19 +10668,14 @@ design: (work@top)
     \_io_decl: (cmd)
       |vpiName:cmd
       |vpiDirection:1
-      |vpiExpr:
-      \_struct_var: (cmd.Command), line:632, col:6, parent:cmd
-        |vpiName:Command
-        |vpiFullName:cmd.Command
-        |vpiTypespec:
-        \_struct_typespec: (Command), line:45, col:11
+      |vpiTypedef:
+      \_struct_typespec: (Command), line:45, col:11
     |vpiIODecl:
     \_io_decl: (master_id)
       |vpiName:master_id
       |vpiDirection:1
-      |vpiExpr:
-      \_int_var: (master_id), line:633, col:6, parent:master_id
-        |vpiFullName:master_id
+      |vpiTypedef:
+      \_int_typespec: , line:633, col:6
     |vpiStmt:
     \_if_else: , line:636, col:9, parent:work@test_program.save_command_master
       |vpiCondition:
@@ -10759,19 +10734,14 @@ design: (work@top)
     \_io_decl: (cmd)
       |vpiName:cmd
       |vpiDirection:1
-      |vpiExpr:
-      \_struct_var: (cmd.Command), line:645, col:6, parent:cmd
-        |vpiName:Command
-        |vpiFullName:cmd.Command
-        |vpiTypespec:
-        \_struct_typespec: (Command), line:45, col:11
+      |vpiTypedef:
+      \_struct_typespec: (Command), line:45, col:11
     |vpiIODecl:
     \_io_decl: (slave_id)
       |vpiName:slave_id
       |vpiDirection:1
-      |vpiExpr:
-      \_int_var: (slave_id), line:646, col:6, parent:slave_id
-        |vpiFullName:slave_id
+      |vpiTypedef:
+      \_int_typespec: , line:646, col:6
     |vpiStmt:
     \_begin: (work@test_program.save_command_slave), parent:work@test_program.save_command_slave
       |vpiFullName:work@test_program.save_command_slave
@@ -10871,17 +10841,22 @@ design: (work@top)
     \_io_decl: (addr)
       |vpiName:addr
       |vpiDirection:1
-      |vpiExpr:
-      \_logic_var: (addr), line:659, col:6, parent:addr
-        |vpiFullName:addr
+      |vpiTypedef:
+      \_logic_typespec: , line:659, col:6
         |vpiRange:
         \_range: , line:659, col:13
           |vpiLeftRange:
-          \_constant: , line:659, col:13
-            |vpiConstType:7
-            |vpiDecompile:12
-            |vpiSize:64
-            |INT:12
+          \_operation: , line:659, col:13
+            |vpiOpType:11
+            |vpiOperand:
+            \_ref_obj: (ADDR_W), line:659, col:13
+              |vpiName:ADDR_W
+            |vpiOperand:
+            \_constant: , line:659, col:20
+              |vpiConstType:9
+              |vpiDecompile:1
+              |vpiSize:64
+              |UINT:1
           |vpiRightRange:
           \_constant: , line:659, col:23
             |vpiConstType:9
@@ -11039,19 +11014,14 @@ design: (work@top)
     \_io_decl: (cmd)
       |vpiName:cmd
       |vpiDirection:1
-      |vpiExpr:
-      \_struct_var: (cmd.Command), line:671, col:6, parent:cmd
-        |vpiName:Command
-        |vpiFullName:cmd.Command
-        |vpiTypespec:
-        \_struct_typespec: (Command), line:45, col:11
+      |vpiTypedef:
+      \_struct_typespec: (Command), line:45, col:11
     |vpiIODecl:
     \_io_decl: (master_id)
       |vpiName:master_id
       |vpiDirection:1
-      |vpiExpr:
-      \_int_var: (master_id), line:672, col:6, parent:master_id
-        |vpiFullName:master_id
+      |vpiTypedef:
+      \_int_typespec: , line:672, col:6
     |vpiStmt:
     \_if_else: , line:674, col:6, parent:work@test_program.configure_and_push_command_to_master
       |vpiCondition:
@@ -11124,19 +11094,14 @@ design: (work@top)
     \_io_decl: (cmd)
       |vpiName:cmd
       |vpiDirection:1
-      |vpiExpr:
-      \_struct_var: (cmd.Command), line:683, col:6, parent:cmd
-        |vpiName:Command
-        |vpiFullName:cmd.Command
-        |vpiTypespec:
-        \_struct_typespec: (Command), line:45, col:11
+      |vpiTypedef:
+      \_struct_typespec: (Command), line:45, col:11
     |vpiIODecl:
     \_io_decl: (slave_id)
       |vpiName:slave_id
       |vpiDirection:1
-      |vpiExpr:
-      \_int_var: (slave_id), line:684, col:6, parent:slave_id
-        |vpiFullName:slave_id
+      |vpiTypedef:
+      \_int_typespec: , line:684, col:6
     |vpiStmt:
     \_begin: (work@test_program.get_expected_command_for_slave), parent:work@test_program.get_expected_command_for_slave
       |vpiFullName:work@test_program.get_expected_command_for_slave
@@ -11452,206 +11417,14 @@ design: (work@top)
     \_io_decl: (actual_cmd)
       |vpiName:actual_cmd
       |vpiDirection:1
-      |vpiExpr:
-      \_struct_var: (actual_cmd.Command), line:720, col:6, parent:actual_cmd
-        |vpiName:Command
-        |vpiFullName:actual_cmd.Command
-        |vpiTypespec:
-        \_struct_typespec: (Command), line:45, col:11
+      |vpiTypedef:
+      \_struct_typespec: (Command), line:45, col:11
     |vpiIODecl:
     \_io_decl: (exp_cmd)
       |vpiName:exp_cmd
       |vpiDirection:1
-      |vpiExpr:
-      \_struct_var: (exp_cmd.Command), line:720, col:6, parent:exp_cmd
-        |vpiName:Command
-        |vpiFullName:exp_cmd.Command
-        |vpiTypespec:
-        \_struct_typespec: (Command), line:45, col:11, parent:exp_cmd.Command
-          |vpiName:Command
-          |vpiTypespecMember:
-          \_typespec_member: (trans), line:47, col:36, parent:Command
-            |vpiName:trans
-            |vpiTypespec:
-            \_enum_typespec: (Transaction), line:37, col:5, parent:trans
-              |vpiName:Transaction
-              |vpiBaseTypespec:
-              \_bit_typespec: , line:33, col:16, parent:Transaction
-              |vpiEnumConst:
-              \_enum_const: (READ), line:36, parent:Transaction
-                |vpiName:READ
-                |UINT:1
-              |vpiEnumConst:
-              \_enum_const: (WRITE), line:35, parent:Transaction
-                |vpiName:WRITE
-                |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (burstcount), line:48, col:36, parent:Command
-            |vpiName:burstcount
-            |vpiTypespec:
-            \_logic_typespec: (Burstcount), line:31, col:11, parent:burstcount
-              |vpiName:Burstcount
-              |vpiRange:
-              \_range: , line:31, col:18, parent:Burstcount
-                |vpiLeftRange:
-                \_operation: , line:31, col:18
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (exp_cmd.Command.Command.burstcount.Burstcount.BURST_W), line:31, col:18
-                    |vpiName:BURST_W
-                    |vpiFullName:exp_cmd.Command.Command.burstcount.Burstcount.BURST_W
-                  |vpiOperand:
-                  \_constant: , line:31, col:26
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:31, col:28
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
-              |vpiTypedefAlias:
-              \_logic_typespec: (Burstcount), line:31, col:11, parent:Burstcount
-                |vpiName:Burstcount
-                |vpiRange:
-                \_range: , line:31, col:18, parent:Burstcount
-                  |vpiLeftRange:
-                  \_operation: , line:31, col:18
-                    |vpiOpType:11
-                    |vpiOperand:
-                    \_ref_obj: (exp_cmd.Command.Command.burstcount.Burstcount.Burstcount.BURST_W), line:31, col:18
-                      |vpiName:BURST_W
-                      |vpiFullName:exp_cmd.Command.Command.burstcount.Burstcount.Burstcount.BURST_W
-                    |vpiOperand:
-                    \_constant: , line:31, col:26
-                      |vpiConstType:9
-                      |vpiDecompile:1
-                      |vpiSize:64
-                      |UINT:1
-                  |vpiRightRange:
-                  \_constant: , line:31, col:28
-                    |vpiConstType:9
-                    |vpiDecompile:0
-                    |vpiSize:64
-                    |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (addr), line:49, col:36, parent:Command
-            |vpiName:addr
-            |vpiTypespec:
-            \_logic_typespec: , line:49, col:7, parent:addr
-              |vpiRange:
-              \_range: , line:49, col:14
-                |vpiLeftRange:
-                \_operation: , line:49, col:14
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (exp_cmd.Command.Command.addr.ADDR_W), line:49, col:14
-                    |vpiName:ADDR_W
-                    |vpiFullName:exp_cmd.Command.Command.addr.ADDR_W
-                  |vpiOperand:
-                  \_constant: , line:49, col:21
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:49, col:24
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (data), line:50, col:36, parent:Command
-            |vpiName:data
-            |vpiTypespec:
-            \_logic_typespec: , line:50, col:7, parent:data
-              |vpiRange:
-              \_range: , line:50, col:14
-                |vpiLeftRange:
-                \_operation: , line:50, col:14
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (exp_cmd.Command.Command.data.DATA_W), line:50, col:14
-                    |vpiName:DATA_W
-                    |vpiFullName:exp_cmd.Command.Command.data.DATA_W
-                  |vpiOperand:
-                  \_constant: , line:50, col:21
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:50, col:23
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (byteenable), line:51, col:36, parent:Command
-            |vpiName:byteenable
-            |vpiTypespec:
-            \_logic_typespec: , line:51, col:7, parent:byteenable
-              |vpiRange:
-              \_range: , line:51, col:14
-                |vpiLeftRange:
-                \_operation: , line:51, col:14
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (exp_cmd.Command.Command.byteenable.NUM_SYMBOLS), line:51, col:14
-                    |vpiName:NUM_SYMBOLS
-                    |vpiFullName:exp_cmd.Command.Command.byteenable.NUM_SYMBOLS
-                  |vpiOperand:
-                  \_constant: , line:51, col:26
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:51, col:28
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (cmd_delay), line:52, col:36, parent:Command
-            |vpiName:cmd_delay
-            |vpiTypespec:
-            \_bit_typespec: , line:52, col:7, parent:cmd_delay
-              |vpiRange:
-              \_range: , line:52, col:12
-                |vpiLeftRange:
-                \_constant: , line:52, col:12
-                  |vpiConstType:9
-                  |vpiDecompile:31
-                  |vpiSize:64
-                  |UINT:31
-                |vpiRightRange:
-                \_constant: , line:52, col:15
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (data_idles), line:53, col:36, parent:Command
-            |vpiName:data_idles
-            |vpiTypespec:
-            \_bit_typespec: , line:53, col:7, parent:data_idles
-              |vpiRange:
-              \_range: , line:53, col:12
-                |vpiLeftRange:
-                \_constant: , line:53, col:12
-                  |vpiConstType:9
-                  |vpiDecompile:31
-                  |vpiSize:64
-                  |UINT:31
-                |vpiRightRange:
-                \_constant: , line:53, col:15
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
+      |vpiTypedef:
+      \_struct_typespec: (Command), line:45, col:11
     |vpiStmt:
     \_begin: (work@test_program.verify_command), parent:work@test_program.verify_command
       |vpiFullName:work@test_program.verify_command
@@ -11862,16 +11635,14 @@ design: (work@top)
     \_io_decl: (message)
       |vpiName:message
       |vpiDirection:1
-      |vpiExpr:
-      \_string_var: (message), line:736, col:6, parent:message
-        |vpiFullName:message
+      |vpiTypedef:
+      \_string_typespec: , line:736, col:6
     |vpiIODecl:
     \_io_decl: (expected_obj)
       |vpiName:expected_obj
       |vpiDirection:1
-      |vpiExpr:
-      \_logic_var: (expected_obj), line:737, col:6, parent:expected_obj
-        |vpiFullName:expected_obj
+      |vpiTypedef:
+      \_logic_typespec: , line:737, col:6
         |vpiRange:
         \_range: , line:737, col:13
           |vpiLeftRange:
@@ -11890,9 +11661,8 @@ design: (work@top)
     \_io_decl: (actual_obj)
       |vpiName:actual_obj
       |vpiDirection:1
-      |vpiExpr:
-      \_logic_var: (actual_obj), line:738, col:6, parent:actual_obj
-        |vpiFullName:actual_obj
+      |vpiTypedef:
+      \_logic_typespec: , line:738, col:6
         |vpiRange:
         \_range: , line:738, col:13
           |vpiLeftRange:
@@ -12022,13 +11792,31 @@ design: (work@top)
     \_io_decl: (burstcount)
       |vpiName:burstcount
       |vpiDirection:1
-      |vpiExpr:
-      \_logic_var: (burstcount.Burstcount), line:760, col:6, parent:burstcount
+      |vpiTypedef:
+      \_logic_typespec: (Burstcount), line:31, col:11
         |vpiName:Burstcount
-        |vpiFullName:burstcount.Burstcount
         |vpiRange:
-        \_range: , line:31, col:18
-        |vpiTypespec:
+        \_range: , line:31, col:18, parent:Burstcount
+          |vpiLeftRange:
+          \_operation: , line:31, col:18
+            |vpiOpType:11
+            |vpiOperand:
+            \_ref_obj: (Burstcount.BURST_W), line:31, col:18
+              |vpiName:BURST_W
+              |vpiFullName:Burstcount.BURST_W
+            |vpiOperand:
+            \_constant: , line:31, col:26
+              |vpiConstType:9
+              |vpiDecompile:1
+              |vpiSize:64
+              |UINT:1
+          |vpiRightRange:
+          \_constant: , line:31, col:28
+            |vpiConstType:9
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+        |vpiTypedefAlias:
         \_logic_typespec: (Burstcount), line:31, col:11
     |vpiStmt:
     \_begin: (work@test_program.create_response), parent:work@test_program.create_response
@@ -12152,12 +11940,8 @@ design: (work@top)
     \_io_decl: (cmd)
       |vpiName:cmd
       |vpiDirection:1
-      |vpiExpr:
-      \_struct_var: (cmd.Command), line:775, col:6, parent:cmd
-        |vpiName:Command
-        |vpiFullName:cmd.Command
-        |vpiTypespec:
-        \_struct_typespec: (Command), line:45, col:11
+      |vpiTypedef:
+      \_struct_typespec: (Command), line:45, col:11
     |vpiStmt:
     \_begin: (work@test_program.get_expected_read_response), parent:work@test_program.get_expected_read_response
       |vpiFullName:work@test_program.get_expected_read_response
@@ -12232,119 +12016,14 @@ design: (work@top)
     \_io_decl: (actual_rsp)
       |vpiName:actual_rsp
       |vpiDirection:1
-      |vpiExpr:
-      \_struct_var: (actual_rsp.Response), line:787, col:6, parent:actual_rsp
-        |vpiName:Response
-        |vpiFullName:actual_rsp.Response
-        |vpiTypespec:
-        \_struct_typespec: (Response), line:56, col:11
+      |vpiTypedef:
+      \_struct_typespec: (Response), line:56, col:11
     |vpiIODecl:
     \_io_decl: (exp_rsp)
       |vpiName:exp_rsp
       |vpiDirection:1
-      |vpiExpr:
-      \_struct_var: (exp_rsp.Response), line:787, col:6, parent:exp_rsp
-        |vpiName:Response
-        |vpiFullName:exp_rsp.Response
-        |vpiTypespec:
-        \_struct_typespec: (Response), line:56, col:11, parent:exp_rsp.Response
-          |vpiName:Response
-          |vpiTypespecMember:
-          \_typespec_member: (burstcount), line:58, col:36, parent:Response
-            |vpiName:burstcount
-            |vpiTypespec:
-            \_logic_typespec: (Burstcount), line:31, col:11, parent:burstcount
-              |vpiName:Burstcount
-              |vpiRange:
-              \_range: , line:31, col:18, parent:Burstcount
-                |vpiLeftRange:
-                \_operation: , line:31, col:18
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (exp_rsp.Response.Response.burstcount.Burstcount.BURST_W), line:31, col:18
-                    |vpiName:BURST_W
-                    |vpiFullName:exp_rsp.Response.Response.burstcount.Burstcount.BURST_W
-                  |vpiOperand:
-                  \_constant: , line:31, col:26
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:31, col:28
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
-              |vpiTypedefAlias:
-              \_logic_typespec: (Burstcount), line:31, col:11, parent:Burstcount
-                |vpiName:Burstcount
-                |vpiRange:
-                \_range: , line:31, col:18, parent:Burstcount
-                  |vpiLeftRange:
-                  \_operation: , line:31, col:18
-                    |vpiOpType:11
-                    |vpiOperand:
-                    \_ref_obj: (exp_rsp.Response.Response.burstcount.Burstcount.Burstcount.BURST_W), line:31, col:18
-                      |vpiName:BURST_W
-                      |vpiFullName:exp_rsp.Response.Response.burstcount.Burstcount.Burstcount.BURST_W
-                    |vpiOperand:
-                    \_constant: , line:31, col:26
-                      |vpiConstType:9
-                      |vpiDecompile:1
-                      |vpiSize:64
-                      |UINT:1
-                  |vpiRightRange:
-                  \_constant: , line:31, col:28
-                    |vpiConstType:9
-                    |vpiDecompile:0
-                    |vpiSize:64
-                    |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (data), line:59, col:36, parent:Response
-            |vpiName:data
-            |vpiTypespec:
-            \_logic_typespec: , line:59, col:6, parent:data
-              |vpiRange:
-              \_range: , line:59, col:13
-                |vpiLeftRange:
-                \_operation: , line:59, col:13
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (exp_rsp.Response.Response.data.DATA_W), line:59, col:13
-                    |vpiName:DATA_W
-                    |vpiFullName:exp_rsp.Response.Response.data.DATA_W
-                  |vpiOperand:
-                  \_constant: , line:59, col:20
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:59, col:22
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (latency), line:60, col:36, parent:Response
-            |vpiName:latency
-            |vpiTypespec:
-            \_bit_typespec: , line:60, col:6, parent:latency
-              |vpiRange:
-              \_range: , line:60, col:11
-                |vpiLeftRange:
-                \_constant: , line:60, col:11
-                  |vpiConstType:9
-                  |vpiDecompile:31
-                  |vpiSize:64
-                  |UINT:31
-                |vpiRightRange:
-                \_constant: , line:60, col:14
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
+      |vpiTypedef:
+      \_struct_typespec: (Response), line:56, col:11
     |vpiStmt:
     \_begin: (work@test_program.verify_response), parent:work@test_program.verify_response
       |vpiFullName:work@test_program.verify_response
@@ -17120,12 +16799,8 @@ design: (work@top)
         \_io_decl: (cmd)
           |vpiName:cmd
           |vpiDirection:1
-          |vpiExpr:
-          \_struct_var: (cmd.Command), line:225, col:6, parent:cmd
-            |vpiName:Command
-            |vpiFullName:cmd.Command
-            |vpiTypespec:
-            \_struct_typespec: (Command), line:45, col:11
+          |vpiTypedef:
+          \_struct_typespec: (Command), line:45, col:11
         |vpiStmt:
         \_begin: (work@test_program.configure_and_push_command_to_master_0), parent:work@test_program.configure_and_push_command_to_master_0
           |vpiFullName:work@test_program.configure_and_push_command_to_master_0
@@ -17732,12 +17407,8 @@ design: (work@top)
         \_io_decl: (rsp)
           |vpiName:rsp
           |vpiDirection:1
-          |vpiExpr:
-          \_struct_var: (rsp.Response), line:341, col:6, parent:rsp
-            |vpiName:Response
-            |vpiFullName:rsp.Response
-            |vpiTypespec:
-            \_struct_typespec: (Response), line:56, col:11
+          |vpiTypedef:
+          \_struct_typespec: (Response), line:56, col:11
         |vpiStmt:
         \_begin: (work@test_program.configure_and_push_response_to_slave_0), parent:work@test_program.configure_and_push_response_to_slave_0
           |vpiFullName:work@test_program.configure_and_push_response_to_slave_0
@@ -18004,12 +17675,8 @@ design: (work@top)
         \_io_decl: (cmd)
           |vpiName:cmd
           |vpiDirection:1
-          |vpiExpr:
-          \_struct_var: (cmd.Command), line:368, col:6, parent:cmd
-            |vpiName:Command
-            |vpiFullName:cmd.Command
-            |vpiTypespec:
-            \_struct_typespec: (Command), line:45, col:11
+          |vpiTypedef:
+          \_struct_typespec: (Command), line:45, col:11
         |vpiStmt:
         \_begin: (work@test_program.configure_and_push_command_to_master_1), parent:work@test_program.configure_and_push_command_to_master_1
           |vpiFullName:work@test_program.configure_and_push_command_to_master_1
@@ -18616,12 +18283,8 @@ design: (work@top)
         \_io_decl: (rsp)
           |vpiName:rsp
           |vpiDirection:1
-          |vpiExpr:
-          \_struct_var: (rsp.Response), line:484, col:6, parent:rsp
-            |vpiName:Response
-            |vpiFullName:rsp.Response
-            |vpiTypespec:
-            \_struct_typespec: (Response), line:56, col:11
+          |vpiTypedef:
+          \_struct_typespec: (Response), line:56, col:11
         |vpiStmt:
         \_begin: (work@test_program.configure_and_push_response_to_slave_1), parent:work@test_program.configure_and_push_response_to_slave_1
           |vpiFullName:work@test_program.configure_and_push_response_to_slave_1
@@ -18888,36 +18551,27 @@ design: (work@top)
         \_io_decl: (num_command)
           |vpiName:num_command
           |vpiDirection:1
-          |vpiExpr:
-          \_int_var: (num_command), line:545, col:6, parent:num_command
-            |vpiFullName:num_command
+          |vpiTypedef:
+          \_int_typespec: , line:545, col:6
         |vpiIODecl:
         \_io_decl: (trans)
           |vpiName:trans
           |vpiDirection:1
-          |vpiExpr:
-          \_bit_var: (trans.Transaction), line:546, col:6, parent:trans
-            |vpiName:Transaction
-            |vpiFullName:trans.Transaction
-            |vpiTypespec:
-            \_enum_typespec: (Transaction), line:37, col:5
+          |vpiTypedef:
+          \_enum_typespec: (Transaction), line:37, col:5
         |vpiIODecl:
         \_io_decl: (burstmode)
           |vpiName:burstmode
           |vpiDirection:1
-          |vpiExpr:
-          \_bit_var: (burstmode.Burstmode), line:547, col:6, parent:burstmode
+          |vpiTypedef:
+          \_enum_typespec: (Burstmode), line:43, col:5
             |vpiName:Burstmode
-            |vpiFullName:burstmode.Burstmode
-            |vpiTypespec:
-            \_enum_typespec: (Burstmode), line:43, col:5
-              |vpiName:Burstmode
-              |vpiBaseTypespec:
-              \_bit_typespec: , line:39, col:16
-              |vpiEnumConst:
-              \_enum_const: (BURST), line:42
-              |vpiEnumConst:
-              \_enum_const: (NOBURST), line:41
+            |vpiBaseTypespec:
+            \_bit_typespec: , line:39, col:16
+            |vpiEnumConst:
+            \_enum_const: (BURST), line:42
+            |vpiEnumConst:
+            \_enum_const: (NOBURST), line:41
         |vpiStmt:
         \_begin: (work@test_program.master_send_commands), parent:work@test_program.master_send_commands
           |vpiFullName:work@test_program.master_send_commands
@@ -19104,29 +18758,20 @@ design: (work@top)
         \_io_decl: (trans)
           |vpiName:trans
           |vpiDirection:1
-          |vpiExpr:
-          \_bit_var: (trans.Transaction), line:571, col:6, parent:trans
-            |vpiName:Transaction
-            |vpiFullName:trans.Transaction
-            |vpiTypespec:
-            \_enum_typespec: (Transaction), line:37, col:5
+          |vpiTypedef:
+          \_enum_typespec: (Transaction), line:37, col:5
         |vpiIODecl:
         \_io_decl: (burstmode)
           |vpiName:burstmode
           |vpiDirection:1
-          |vpiExpr:
-          \_bit_var: (burstmode.Burstmode), line:572, col:6, parent:burstmode
-            |vpiName:Burstmode
-            |vpiFullName:burstmode.Burstmode
-            |vpiTypespec:
-            \_enum_typespec: (Burstmode), line:43, col:5
+          |vpiTypedef:
+          \_enum_typespec: (Burstmode), line:43, col:5
         |vpiIODecl:
         \_io_decl: (slave_id)
           |vpiName:slave_id
           |vpiDirection:1
-          |vpiExpr:
-          \_int_var: (slave_id), line:573, col:6, parent:slave_id
-            |vpiFullName:slave_id
+          |vpiTypedef:
+          \_int_typespec: , line:573, col:6
         |vpiStmt:
         \_begin: (work@test_program.create_command), parent:work@test_program.create_command
           |vpiFullName:work@test_program.create_command
@@ -19426,8 +19071,6 @@ design: (work@top)
         |vpiFullName:work@test_program.randomize_burstcount
         |vpiReturn:
         \_logic_var: , line:601, col:22
-          |vpiRange:
-          \_range: , line:31, col:18
           |vpiTypespec:
           \_logic_typespec: (Burstcount), line:31, col:11
         |vpiInstance:
@@ -19447,8 +19090,6 @@ design: (work@top)
               \_logic_var: (work@test_program.randomize_burstcount.burstcount), line:603, col:6
                 |vpiName:burstcount
                 |vpiFullName:work@test_program.randomize_burstcount.burstcount
-                |vpiRange:
-                \_range: , line:31, col:18
                 |vpiTypespec:
                 \_logic_typespec: (Burstcount), line:31, col:11
             |vpiRhs:
@@ -19502,9 +19143,8 @@ design: (work@top)
         \_io_decl: (slave_id)
           |vpiName:slave_id
           |vpiDirection:1
-          |vpiExpr:
-          \_int_var: (slave_id), line:610, col:6, parent:slave_id
-            |vpiFullName:slave_id
+          |vpiTypedef:
+          \_int_typespec: , line:610, col:6
         |vpiStmt:
         \_begin: (work@test_program.generate_random_aligned_address), parent:work@test_program.generate_random_aligned_address
           |vpiFullName:work@test_program.generate_random_aligned_address
@@ -19658,26 +19298,20 @@ design: (work@top)
         \_io_decl: (cmd)
           |vpiName:cmd
           |vpiDirection:1
-          |vpiExpr:
-          \_struct_var: (cmd.Command), line:621, col:6, parent:cmd
-            |vpiName:Command
-            |vpiFullName:cmd.Command
-            |vpiTypespec:
-            \_struct_typespec: (Command), line:45, col:11
+          |vpiTypedef:
+          \_struct_typespec: (Command), line:45, col:11
         |vpiIODecl:
         \_io_decl: (master_id)
           |vpiName:master_id
           |vpiDirection:1
-          |vpiExpr:
-          \_int_var: (master_id), line:622, col:6, parent:master_id
-            |vpiFullName:master_id
+          |vpiTypedef:
+          \_int_typespec: , line:622, col:6
         |vpiIODecl:
         \_io_decl: (slave_id)
           |vpiName:slave_id
           |vpiDirection:1
-          |vpiExpr:
-          \_int_var: (slave_id), line:623, col:6, parent:slave_id
-            |vpiFullName:slave_id
+          |vpiTypedef:
+          \_int_typespec: , line:623, col:6
         |vpiStmt:
         \_begin: (work@test_program.queue_command), parent:work@test_program.queue_command
           |vpiFullName:work@test_program.queue_command
@@ -19732,19 +19366,14 @@ design: (work@top)
         \_io_decl: (cmd)
           |vpiName:cmd
           |vpiDirection:1
-          |vpiExpr:
-          \_struct_var: (cmd.Command), line:632, col:6, parent:cmd
-            |vpiName:Command
-            |vpiFullName:cmd.Command
-            |vpiTypespec:
-            \_struct_typespec: (Command), line:45, col:11
+          |vpiTypedef:
+          \_struct_typespec: (Command), line:45, col:11
         |vpiIODecl:
         \_io_decl: (master_id)
           |vpiName:master_id
           |vpiDirection:1
-          |vpiExpr:
-          \_int_var: (master_id), line:633, col:6, parent:master_id
-            |vpiFullName:master_id
+          |vpiTypedef:
+          \_int_typespec: , line:633, col:6
         |vpiStmt:
         \_if_else: , line:636, col:9, parent:work@test_program.save_command_master
           |vpiCondition:
@@ -19803,19 +19432,14 @@ design: (work@top)
         \_io_decl: (cmd)
           |vpiName:cmd
           |vpiDirection:1
-          |vpiExpr:
-          \_struct_var: (cmd.Command), line:645, col:6, parent:cmd
-            |vpiName:Command
-            |vpiFullName:cmd.Command
-            |vpiTypespec:
-            \_struct_typespec: (Command), line:45, col:11
+          |vpiTypedef:
+          \_struct_typespec: (Command), line:45, col:11
         |vpiIODecl:
         \_io_decl: (slave_id)
           |vpiName:slave_id
           |vpiDirection:1
-          |vpiExpr:
-          \_int_var: (slave_id), line:646, col:6, parent:slave_id
-            |vpiFullName:slave_id
+          |vpiTypedef:
+          \_int_typespec: , line:646, col:6
         |vpiStmt:
         \_begin: (work@test_program.save_command_slave), parent:work@test_program.save_command_slave
           |vpiFullName:work@test_program.save_command_slave
@@ -19915,17 +19539,22 @@ design: (work@top)
         \_io_decl: (addr)
           |vpiName:addr
           |vpiDirection:1
-          |vpiExpr:
-          \_logic_var: (addr), line:659, col:6, parent:addr
-            |vpiFullName:addr
+          |vpiTypedef:
+          \_logic_typespec: , line:659, col:6
             |vpiRange:
             \_range: , line:659, col:13
               |vpiLeftRange:
-              \_constant: , line:659, col:13
-                |vpiConstType:7
-                |vpiDecompile:12
-                |vpiSize:64
-                |INT:12
+              \_operation: , line:659, col:13
+                |vpiOpType:11
+                |vpiOperand:
+                \_ref_obj: (ADDR_W), line:659, col:13
+                  |vpiName:ADDR_W
+                |vpiOperand:
+                \_constant: , line:659, col:20
+                  |vpiConstType:9
+                  |vpiDecompile:1
+                  |vpiSize:64
+                  |UINT:1
               |vpiRightRange:
               \_constant: , line:659, col:23
                 |vpiConstType:9
@@ -20083,19 +19712,14 @@ design: (work@top)
         \_io_decl: (cmd)
           |vpiName:cmd
           |vpiDirection:1
-          |vpiExpr:
-          \_struct_var: (cmd.Command), line:671, col:6, parent:cmd
-            |vpiName:Command
-            |vpiFullName:cmd.Command
-            |vpiTypespec:
-            \_struct_typespec: (Command), line:45, col:11
+          |vpiTypedef:
+          \_struct_typespec: (Command), line:45, col:11
         |vpiIODecl:
         \_io_decl: (master_id)
           |vpiName:master_id
           |vpiDirection:1
-          |vpiExpr:
-          \_int_var: (master_id), line:672, col:6, parent:master_id
-            |vpiFullName:master_id
+          |vpiTypedef:
+          \_int_typespec: , line:672, col:6
         |vpiStmt:
         \_if_else: , line:674, col:6, parent:work@test_program.configure_and_push_command_to_master
           |vpiCondition:
@@ -20168,19 +19792,14 @@ design: (work@top)
         \_io_decl: (cmd)
           |vpiName:cmd
           |vpiDirection:1
-          |vpiExpr:
-          \_struct_var: (cmd.Command), line:683, col:6, parent:cmd
-            |vpiName:Command
-            |vpiFullName:cmd.Command
-            |vpiTypespec:
-            \_struct_typespec: (Command), line:45, col:11
+          |vpiTypedef:
+          \_struct_typespec: (Command), line:45, col:11
         |vpiIODecl:
         \_io_decl: (slave_id)
           |vpiName:slave_id
           |vpiDirection:1
-          |vpiExpr:
-          \_int_var: (slave_id), line:684, col:6, parent:slave_id
-            |vpiFullName:slave_id
+          |vpiTypedef:
+          \_int_typespec: , line:684, col:6
         |vpiStmt:
         \_begin: (work@test_program.get_expected_command_for_slave), parent:work@test_program.get_expected_command_for_slave
           |vpiFullName:work@test_program.get_expected_command_for_slave
@@ -20496,206 +20115,14 @@ design: (work@top)
         \_io_decl: (actual_cmd)
           |vpiName:actual_cmd
           |vpiDirection:1
-          |vpiExpr:
-          \_struct_var: (actual_cmd.Command), line:720, col:6, parent:actual_cmd
-            |vpiName:Command
-            |vpiFullName:actual_cmd.Command
-            |vpiTypespec:
-            \_struct_typespec: (Command), line:45, col:11
+          |vpiTypedef:
+          \_struct_typespec: (Command), line:45, col:11
         |vpiIODecl:
         \_io_decl: (exp_cmd)
           |vpiName:exp_cmd
           |vpiDirection:1
-          |vpiExpr:
-          \_struct_var: (exp_cmd.Command), line:720, col:6, parent:exp_cmd
-            |vpiName:Command
-            |vpiFullName:exp_cmd.Command
-            |vpiTypespec:
-            \_struct_typespec: (Command), line:45, col:11, parent:exp_cmd.Command
-              |vpiName:Command
-              |vpiTypespecMember:
-              \_typespec_member: (trans), line:47, col:36, parent:Command
-                |vpiName:trans
-                |vpiTypespec:
-                \_enum_typespec: (Transaction), line:37, col:5, parent:trans
-                  |vpiName:Transaction
-                  |vpiBaseTypespec:
-                  \_bit_typespec: , line:33, col:16, parent:Transaction
-                  |vpiEnumConst:
-                  \_enum_const: (READ), line:36, parent:Transaction
-                    |vpiName:READ
-                    |UINT:1
-                  |vpiEnumConst:
-                  \_enum_const: (WRITE), line:35, parent:Transaction
-                    |vpiName:WRITE
-                    |UINT:0
-              |vpiTypespecMember:
-              \_typespec_member: (burstcount), line:48, col:36, parent:Command
-                |vpiName:burstcount
-                |vpiTypespec:
-                \_logic_typespec: (Burstcount), line:31, col:11, parent:burstcount
-                  |vpiName:Burstcount
-                  |vpiRange:
-                  \_range: , line:31, col:18, parent:Burstcount
-                    |vpiLeftRange:
-                    \_operation: , line:31, col:18
-                      |vpiOpType:11
-                      |vpiOperand:
-                      \_ref_obj: (exp_cmd.Command.Command.burstcount.Burstcount.BURST_W), line:31, col:18
-                        |vpiName:BURST_W
-                        |vpiFullName:exp_cmd.Command.Command.burstcount.Burstcount.BURST_W
-                      |vpiOperand:
-                      \_constant: , line:31, col:26
-                        |vpiConstType:9
-                        |vpiDecompile:1
-                        |vpiSize:64
-                        |UINT:1
-                    |vpiRightRange:
-                    \_constant: , line:31, col:28
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-                  |vpiTypedefAlias:
-                  \_logic_typespec: (Burstcount), line:31, col:11, parent:Burstcount
-                    |vpiName:Burstcount
-                    |vpiRange:
-                    \_range: , line:31, col:18, parent:Burstcount
-                      |vpiLeftRange:
-                      \_operation: , line:31, col:18
-                        |vpiOpType:11
-                        |vpiOperand:
-                        \_ref_obj: (exp_cmd.Command.Command.burstcount.Burstcount.Burstcount.BURST_W), line:31, col:18
-                          |vpiName:BURST_W
-                          |vpiFullName:exp_cmd.Command.Command.burstcount.Burstcount.Burstcount.BURST_W
-                        |vpiOperand:
-                        \_constant: , line:31, col:26
-                          |vpiConstType:9
-                          |vpiDecompile:1
-                          |vpiSize:64
-                          |UINT:1
-                      |vpiRightRange:
-                      \_constant: , line:31, col:28
-                        |vpiConstType:9
-                        |vpiDecompile:0
-                        |vpiSize:64
-                        |UINT:0
-              |vpiTypespecMember:
-              \_typespec_member: (addr), line:49, col:36, parent:Command
-                |vpiName:addr
-                |vpiTypespec:
-                \_logic_typespec: , line:49, col:7, parent:addr
-                  |vpiRange:
-                  \_range: , line:49, col:14
-                    |vpiLeftRange:
-                    \_operation: , line:49, col:14
-                      |vpiOpType:11
-                      |vpiOperand:
-                      \_ref_obj: (exp_cmd.Command.Command.addr.ADDR_W), line:49, col:14
-                        |vpiName:ADDR_W
-                        |vpiFullName:exp_cmd.Command.Command.addr.ADDR_W
-                      |vpiOperand:
-                      \_constant: , line:49, col:21
-                        |vpiConstType:9
-                        |vpiDecompile:1
-                        |vpiSize:64
-                        |UINT:1
-                    |vpiRightRange:
-                    \_constant: , line:49, col:24
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-              |vpiTypespecMember:
-              \_typespec_member: (data), line:50, col:36, parent:Command
-                |vpiName:data
-                |vpiTypespec:
-                \_logic_typespec: , line:50, col:7, parent:data
-                  |vpiRange:
-                  \_range: , line:50, col:14
-                    |vpiLeftRange:
-                    \_operation: , line:50, col:14
-                      |vpiOpType:11
-                      |vpiOperand:
-                      \_ref_obj: (exp_cmd.Command.Command.data.DATA_W), line:50, col:14
-                        |vpiName:DATA_W
-                        |vpiFullName:exp_cmd.Command.Command.data.DATA_W
-                      |vpiOperand:
-                      \_constant: , line:50, col:21
-                        |vpiConstType:9
-                        |vpiDecompile:1
-                        |vpiSize:64
-                        |UINT:1
-                    |vpiRightRange:
-                    \_constant: , line:50, col:23
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-              |vpiTypespecMember:
-              \_typespec_member: (byteenable), line:51, col:36, parent:Command
-                |vpiName:byteenable
-                |vpiTypespec:
-                \_logic_typespec: , line:51, col:7, parent:byteenable
-                  |vpiRange:
-                  \_range: , line:51, col:14
-                    |vpiLeftRange:
-                    \_operation: , line:51, col:14
-                      |vpiOpType:11
-                      |vpiOperand:
-                      \_ref_obj: (exp_cmd.Command.Command.byteenable.NUM_SYMBOLS), line:51, col:14
-                        |vpiName:NUM_SYMBOLS
-                        |vpiFullName:exp_cmd.Command.Command.byteenable.NUM_SYMBOLS
-                      |vpiOperand:
-                      \_constant: , line:51, col:26
-                        |vpiConstType:9
-                        |vpiDecompile:1
-                        |vpiSize:64
-                        |UINT:1
-                    |vpiRightRange:
-                    \_constant: , line:51, col:28
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-              |vpiTypespecMember:
-              \_typespec_member: (cmd_delay), line:52, col:36, parent:Command
-                |vpiName:cmd_delay
-                |vpiTypespec:
-                \_bit_typespec: , line:52, col:7, parent:cmd_delay
-                  |vpiRange:
-                  \_range: , line:52, col:12
-                    |vpiLeftRange:
-                    \_constant: , line:52, col:12
-                      |vpiConstType:9
-                      |vpiDecompile:31
-                      |vpiSize:64
-                      |UINT:31
-                    |vpiRightRange:
-                    \_constant: , line:52, col:15
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-              |vpiTypespecMember:
-              \_typespec_member: (data_idles), line:53, col:36, parent:Command
-                |vpiName:data_idles
-                |vpiTypespec:
-                \_bit_typespec: , line:53, col:7, parent:data_idles
-                  |vpiRange:
-                  \_range: , line:53, col:12
-                    |vpiLeftRange:
-                    \_constant: , line:53, col:12
-                      |vpiConstType:9
-                      |vpiDecompile:31
-                      |vpiSize:64
-                      |UINT:31
-                    |vpiRightRange:
-                    \_constant: , line:53, col:15
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
+          |vpiTypedef:
+          \_struct_typespec: (Command), line:45, col:11
         |vpiStmt:
         \_begin: (work@test_program.verify_command), parent:work@test_program.verify_command
           |vpiFullName:work@test_program.verify_command
@@ -20906,16 +20333,14 @@ design: (work@top)
         \_io_decl: (message)
           |vpiName:message
           |vpiDirection:1
-          |vpiExpr:
-          \_string_var: (message), line:736, col:6, parent:message
-            |vpiFullName:message
+          |vpiTypedef:
+          \_string_typespec: , line:736, col:6
         |vpiIODecl:
         \_io_decl: (expected_obj)
           |vpiName:expected_obj
           |vpiDirection:1
-          |vpiExpr:
-          \_logic_var: (expected_obj), line:737, col:6, parent:expected_obj
-            |vpiFullName:expected_obj
+          |vpiTypedef:
+          \_logic_typespec: , line:737, col:6
             |vpiRange:
             \_range: , line:737, col:13
               |vpiLeftRange:
@@ -20934,9 +20359,8 @@ design: (work@top)
         \_io_decl: (actual_obj)
           |vpiName:actual_obj
           |vpiDirection:1
-          |vpiExpr:
-          \_logic_var: (actual_obj), line:738, col:6, parent:actual_obj
-            |vpiFullName:actual_obj
+          |vpiTypedef:
+          \_logic_typespec: , line:738, col:6
             |vpiRange:
             \_range: , line:738, col:13
               |vpiLeftRange:
@@ -21066,13 +20490,31 @@ design: (work@top)
         \_io_decl: (burstcount)
           |vpiName:burstcount
           |vpiDirection:1
-          |vpiExpr:
-          \_logic_var: (burstcount.Burstcount), line:760, col:6, parent:burstcount
+          |vpiTypedef:
+          \_logic_typespec: (Burstcount), line:31, col:11
             |vpiName:Burstcount
-            |vpiFullName:burstcount.Burstcount
             |vpiRange:
-            \_range: , line:31, col:18
-            |vpiTypespec:
+            \_range: , line:31, col:18, parent:Burstcount
+              |vpiLeftRange:
+              \_operation: , line:31, col:18
+                |vpiOpType:11
+                |vpiOperand:
+                \_ref_obj: (Burstcount.BURST_W), line:31, col:18
+                  |vpiName:BURST_W
+                  |vpiFullName:Burstcount.BURST_W
+                |vpiOperand:
+                \_constant: , line:31, col:26
+                  |vpiConstType:9
+                  |vpiDecompile:1
+                  |vpiSize:64
+                  |UINT:1
+              |vpiRightRange:
+              \_constant: , line:31, col:28
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+            |vpiTypedefAlias:
             \_logic_typespec: (Burstcount), line:31, col:11
         |vpiStmt:
         \_begin: (work@test_program.create_response), parent:work@test_program.create_response
@@ -21196,12 +20638,8 @@ design: (work@top)
         \_io_decl: (cmd)
           |vpiName:cmd
           |vpiDirection:1
-          |vpiExpr:
-          \_struct_var: (cmd.Command), line:775, col:6, parent:cmd
-            |vpiName:Command
-            |vpiFullName:cmd.Command
-            |vpiTypespec:
-            \_struct_typespec: (Command), line:45, col:11
+          |vpiTypedef:
+          \_struct_typespec: (Command), line:45, col:11
         |vpiStmt:
         \_begin: (work@test_program.get_expected_read_response), parent:work@test_program.get_expected_read_response
           |vpiFullName:work@test_program.get_expected_read_response
@@ -21276,119 +20714,14 @@ design: (work@top)
         \_io_decl: (actual_rsp)
           |vpiName:actual_rsp
           |vpiDirection:1
-          |vpiExpr:
-          \_struct_var: (actual_rsp.Response), line:787, col:6, parent:actual_rsp
-            |vpiName:Response
-            |vpiFullName:actual_rsp.Response
-            |vpiTypespec:
-            \_struct_typespec: (Response), line:56, col:11
+          |vpiTypedef:
+          \_struct_typespec: (Response), line:56, col:11
         |vpiIODecl:
         \_io_decl: (exp_rsp)
           |vpiName:exp_rsp
           |vpiDirection:1
-          |vpiExpr:
-          \_struct_var: (exp_rsp.Response), line:787, col:6, parent:exp_rsp
-            |vpiName:Response
-            |vpiFullName:exp_rsp.Response
-            |vpiTypespec:
-            \_struct_typespec: (Response), line:56, col:11, parent:exp_rsp.Response
-              |vpiName:Response
-              |vpiTypespecMember:
-              \_typespec_member: (burstcount), line:58, col:36, parent:Response
-                |vpiName:burstcount
-                |vpiTypespec:
-                \_logic_typespec: (Burstcount), line:31, col:11, parent:burstcount
-                  |vpiName:Burstcount
-                  |vpiRange:
-                  \_range: , line:31, col:18, parent:Burstcount
-                    |vpiLeftRange:
-                    \_operation: , line:31, col:18
-                      |vpiOpType:11
-                      |vpiOperand:
-                      \_ref_obj: (exp_rsp.Response.Response.burstcount.Burstcount.BURST_W), line:31, col:18
-                        |vpiName:BURST_W
-                        |vpiFullName:exp_rsp.Response.Response.burstcount.Burstcount.BURST_W
-                      |vpiOperand:
-                      \_constant: , line:31, col:26
-                        |vpiConstType:9
-                        |vpiDecompile:1
-                        |vpiSize:64
-                        |UINT:1
-                    |vpiRightRange:
-                    \_constant: , line:31, col:28
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-                  |vpiTypedefAlias:
-                  \_logic_typespec: (Burstcount), line:31, col:11, parent:Burstcount
-                    |vpiName:Burstcount
-                    |vpiRange:
-                    \_range: , line:31, col:18, parent:Burstcount
-                      |vpiLeftRange:
-                      \_operation: , line:31, col:18
-                        |vpiOpType:11
-                        |vpiOperand:
-                        \_ref_obj: (exp_rsp.Response.Response.burstcount.Burstcount.Burstcount.BURST_W), line:31, col:18
-                          |vpiName:BURST_W
-                          |vpiFullName:exp_rsp.Response.Response.burstcount.Burstcount.Burstcount.BURST_W
-                        |vpiOperand:
-                        \_constant: , line:31, col:26
-                          |vpiConstType:9
-                          |vpiDecompile:1
-                          |vpiSize:64
-                          |UINT:1
-                      |vpiRightRange:
-                      \_constant: , line:31, col:28
-                        |vpiConstType:9
-                        |vpiDecompile:0
-                        |vpiSize:64
-                        |UINT:0
-              |vpiTypespecMember:
-              \_typespec_member: (data), line:59, col:36, parent:Response
-                |vpiName:data
-                |vpiTypespec:
-                \_logic_typespec: , line:59, col:6, parent:data
-                  |vpiRange:
-                  \_range: , line:59, col:13
-                    |vpiLeftRange:
-                    \_operation: , line:59, col:13
-                      |vpiOpType:11
-                      |vpiOperand:
-                      \_ref_obj: (exp_rsp.Response.Response.data.DATA_W), line:59, col:13
-                        |vpiName:DATA_W
-                        |vpiFullName:exp_rsp.Response.Response.data.DATA_W
-                      |vpiOperand:
-                      \_constant: , line:59, col:20
-                        |vpiConstType:9
-                        |vpiDecompile:1
-                        |vpiSize:64
-                        |UINT:1
-                    |vpiRightRange:
-                    \_constant: , line:59, col:22
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-              |vpiTypespecMember:
-              \_typespec_member: (latency), line:60, col:36, parent:Response
-                |vpiName:latency
-                |vpiTypespec:
-                \_bit_typespec: , line:60, col:6, parent:latency
-                  |vpiRange:
-                  \_range: , line:60, col:11
-                    |vpiLeftRange:
-                    \_constant: , line:60, col:11
-                      |vpiConstType:9
-                      |vpiDecompile:31
-                      |vpiSize:64
-                      |UINT:31
-                    |vpiRightRange:
-                    \_constant: , line:60, col:14
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
+          |vpiTypedef:
+          \_struct_typespec: (Response), line:56, col:11
         |vpiStmt:
         \_begin: (work@test_program.verify_response), parent:work@test_program.verify_response
           |vpiFullName:work@test_program.verify_response
@@ -21711,34 +21044,56 @@ design: (work@top)
     \_io_decl: (cmd), parent:work@test_program.configure_and_push_command_to_master_0
       |vpiName:cmd
       |vpiDirection:1
-      |vpiExpr:
-      \_struct_var: (work@test_program.configure_and_push_command_to_master_0.cmd.Command), line:225, col:6, parent:cmd
+      |vpiTypedef:
+      \_struct_typespec: (Command), line:45, col:11, parent:cmd
         |vpiName:Command
-        |vpiFullName:work@test_program.configure_and_push_command_to_master_0.cmd.Command
-        |vpiTypespec:
-        \_struct_typespec: (Command), line:45, col:11, parent:work@test_program.configure_and_push_command_to_master_0.cmd.Command
-          |vpiName:Command
-          |vpiTypespecMember:
-          \_typespec_member: (trans), line:47, col:36, parent:Command
-            |vpiName:trans
-            |vpiTypespec:
-            \_enum_typespec: (Transaction), line:37, col:5, parent:trans
-              |vpiName:Transaction
-              |vpiBaseTypespec:
-              \_bit_typespec: , line:33, col:16, parent:Transaction
-              |vpiEnumConst:
-              \_enum_const: (READ), line:36, parent:Transaction
-                |vpiName:READ
-                |UINT:1
-              |vpiEnumConst:
-              \_enum_const: (WRITE), line:35, parent:Transaction
-                |vpiName:WRITE
+        |vpiTypespecMember:
+        \_typespec_member: (trans), line:47, col:36, parent:Command
+          |vpiName:trans
+          |vpiTypespec:
+          \_enum_typespec: (Transaction), line:37, col:5, parent:trans
+            |vpiName:Transaction
+            |vpiBaseTypespec:
+            \_bit_typespec: , line:33, col:16, parent:Transaction
+            |vpiEnumConst:
+            \_enum_const: (READ), line:36, parent:Transaction
+              |vpiName:READ
+              |UINT:1
+            |vpiEnumConst:
+            \_enum_const: (WRITE), line:35, parent:Transaction
+              |vpiName:WRITE
+              |UINT:0
+        |vpiTypespecMember:
+        \_typespec_member: (burstcount), line:48, col:36, parent:Command
+          |vpiName:burstcount
+          |vpiTypespec:
+          \_logic_typespec: (Burstcount), line:31, col:11, parent:burstcount
+            |vpiName:Burstcount
+            |vpiRange:
+            \_range: , line:31, col:18, parent:Burstcount
+              |vpiLeftRange:
+              \_operation: , line:31, col:18
+                |vpiOpType:11
+                |vpiOperand:
+                \_ref_obj: (work@test_program.configure_and_push_command_to_master_0.cmd.Command.burstcount.Burstcount.BURST_W), line:31, col:18
+                  |vpiName:BURST_W
+                  |vpiFullName:work@test_program.configure_and_push_command_to_master_0.cmd.Command.burstcount.Burstcount.BURST_W
+                  |vpiActual:
+                  \_parameter: (work@test_program.BURST_W), line:19, col:14, parent:work@test_program
+                |vpiOperand:
+                \_constant: , line:31, col:26
+                  |vpiConstType:9
+                  |vpiDecompile:1
+                  |vpiSize:64
+                  |UINT:1
+              |vpiRightRange:
+              \_constant: , line:31, col:28
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
                 |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (burstcount), line:48, col:36, parent:Command
-            |vpiName:burstcount
-            |vpiTypespec:
-            \_logic_typespec: (Burstcount), line:31, col:11, parent:burstcount
+            |vpiTypedefAlias:
+            \_logic_typespec: (Burstcount), line:31, col:11, parent:Burstcount
               |vpiName:Burstcount
               |vpiRange:
               \_range: , line:31, col:18, parent:Burstcount
@@ -21746,9 +21101,9 @@ design: (work@top)
                 \_operation: , line:31, col:18
                   |vpiOpType:11
                   |vpiOperand:
-                  \_ref_obj: (work@test_program.configure_and_push_command_to_master_0.cmd.Command.Command.burstcount.Burstcount.BURST_W), line:31, col:18
+                  \_ref_obj: (work@test_program.configure_and_push_command_to_master_0.cmd.Command.burstcount.Burstcount.Burstcount.BURST_W), line:31, col:18
                     |vpiName:BURST_W
-                    |vpiFullName:work@test_program.configure_and_push_command_to_master_0.cmd.Command.Command.burstcount.Burstcount.BURST_W
+                    |vpiFullName:work@test_program.configure_and_push_command_to_master_0.cmd.Command.burstcount.Burstcount.Burstcount.BURST_W
                     |vpiActual:
                     \_parameter: (work@test_program.BURST_W), line:19, col:14, parent:work@test_program
                   |vpiOperand:
@@ -21763,154 +21118,128 @@ design: (work@top)
                   |vpiDecompile:0
                   |vpiSize:64
                   |UINT:0
-              |vpiTypedefAlias:
-              \_logic_typespec: (Burstcount), line:31, col:11, parent:Burstcount
-                |vpiName:Burstcount
-                |vpiRange:
-                \_range: , line:31, col:18, parent:Burstcount
-                  |vpiLeftRange:
-                  \_operation: , line:31, col:18
-                    |vpiOpType:11
-                    |vpiOperand:
-                    \_ref_obj: (work@test_program.configure_and_push_command_to_master_0.cmd.Command.Command.burstcount.Burstcount.Burstcount.BURST_W), line:31, col:18
-                      |vpiName:BURST_W
-                      |vpiFullName:work@test_program.configure_and_push_command_to_master_0.cmd.Command.Command.burstcount.Burstcount.Burstcount.BURST_W
-                      |vpiActual:
-                      \_parameter: (work@test_program.BURST_W), line:19, col:14, parent:work@test_program
-                    |vpiOperand:
-                    \_constant: , line:31, col:26
-                      |vpiConstType:9
-                      |vpiDecompile:1
-                      |vpiSize:64
-                      |UINT:1
-                  |vpiRightRange:
-                  \_constant: , line:31, col:28
-                    |vpiConstType:9
-                    |vpiDecompile:0
-                    |vpiSize:64
-                    |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (addr), line:49, col:36, parent:Command
-            |vpiName:addr
-            |vpiTypespec:
-            \_logic_typespec: , line:49, col:7, parent:addr
-              |vpiRange:
-              \_range: , line:49, col:14
-                |vpiLeftRange:
-                \_operation: , line:49, col:14
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (work@test_program.configure_and_push_command_to_master_0.cmd.Command.Command.addr.ADDR_W), line:49, col:14
-                    |vpiName:ADDR_W
-                    |vpiFullName:work@test_program.configure_and_push_command_to_master_0.cmd.Command.Command.addr.ADDR_W
-                    |vpiActual:
-                    \_parameter: (work@test_program.ADDR_W), line:13, col:14, parent:work@test_program
-                  |vpiOperand:
-                  \_constant: , line:49, col:21
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:49, col:24
+        |vpiTypespecMember:
+        \_typespec_member: (addr), line:49, col:36, parent:Command
+          |vpiName:addr
+          |vpiTypespec:
+          \_logic_typespec: , line:49, col:7, parent:addr
+            |vpiRange:
+            \_range: , line:49, col:14
+              |vpiLeftRange:
+              \_operation: , line:49, col:14
+                |vpiOpType:11
+                |vpiOperand:
+                \_ref_obj: (work@test_program.configure_and_push_command_to_master_0.cmd.Command.addr.ADDR_W), line:49, col:14
+                  |vpiName:ADDR_W
+                  |vpiFullName:work@test_program.configure_and_push_command_to_master_0.cmd.Command.addr.ADDR_W
+                  |vpiActual:
+                  \_parameter: (work@test_program.ADDR_W), line:13, col:14, parent:work@test_program
+                |vpiOperand:
+                \_constant: , line:49, col:21
                   |vpiConstType:9
-                  |vpiDecompile:0
+                  |vpiDecompile:1
                   |vpiSize:64
-                  |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (data), line:50, col:36, parent:Command
-            |vpiName:data
-            |vpiTypespec:
-            \_logic_typespec: , line:50, col:7, parent:data
-              |vpiRange:
-              \_range: , line:50, col:14
-                |vpiLeftRange:
-                \_operation: , line:50, col:14
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (work@test_program.configure_and_push_command_to_master_0.cmd.Command.Command.data.DATA_W), line:50, col:14
-                    |vpiName:DATA_W
-                    |vpiFullName:work@test_program.configure_and_push_command_to_master_0.cmd.Command.Command.data.DATA_W
-                    |vpiActual:
-                    \_parameter: (work@test_program.DATA_W), line:17, col:14, parent:work@test_program
-                  |vpiOperand:
-                  \_constant: , line:50, col:21
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:50, col:23
+                  |UINT:1
+              |vpiRightRange:
+              \_constant: , line:49, col:24
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+        |vpiTypespecMember:
+        \_typespec_member: (data), line:50, col:36, parent:Command
+          |vpiName:data
+          |vpiTypespec:
+          \_logic_typespec: , line:50, col:7, parent:data
+            |vpiRange:
+            \_range: , line:50, col:14
+              |vpiLeftRange:
+              \_operation: , line:50, col:14
+                |vpiOpType:11
+                |vpiOperand:
+                \_ref_obj: (work@test_program.configure_and_push_command_to_master_0.cmd.Command.data.DATA_W), line:50, col:14
+                  |vpiName:DATA_W
+                  |vpiFullName:work@test_program.configure_and_push_command_to_master_0.cmd.Command.data.DATA_W
+                  |vpiActual:
+                  \_parameter: (work@test_program.DATA_W), line:17, col:14, parent:work@test_program
+                |vpiOperand:
+                \_constant: , line:50, col:21
                   |vpiConstType:9
-                  |vpiDecompile:0
+                  |vpiDecompile:1
                   |vpiSize:64
-                  |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (byteenable), line:51, col:36, parent:Command
-            |vpiName:byteenable
-            |vpiTypespec:
-            \_logic_typespec: , line:51, col:7, parent:byteenable
-              |vpiRange:
-              \_range: , line:51, col:14
-                |vpiLeftRange:
-                \_operation: , line:51, col:14
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (work@test_program.configure_and_push_command_to_master_0.cmd.Command.Command.byteenable.NUM_SYMBOLS), line:51, col:14
-                    |vpiName:NUM_SYMBOLS
-                    |vpiFullName:work@test_program.configure_and_push_command_to_master_0.cmd.Command.Command.byteenable.NUM_SYMBOLS
-                    |vpiActual:
-                    \_parameter: (work@test_program.NUM_SYMBOLS), line:16, col:14, parent:work@test_program
-                  |vpiOperand:
-                  \_constant: , line:51, col:26
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:51, col:28
+                  |UINT:1
+              |vpiRightRange:
+              \_constant: , line:50, col:23
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+        |vpiTypespecMember:
+        \_typespec_member: (byteenable), line:51, col:36, parent:Command
+          |vpiName:byteenable
+          |vpiTypespec:
+          \_logic_typespec: , line:51, col:7, parent:byteenable
+            |vpiRange:
+            \_range: , line:51, col:14
+              |vpiLeftRange:
+              \_operation: , line:51, col:14
+                |vpiOpType:11
+                |vpiOperand:
+                \_ref_obj: (work@test_program.configure_and_push_command_to_master_0.cmd.Command.byteenable.NUM_SYMBOLS), line:51, col:14
+                  |vpiName:NUM_SYMBOLS
+                  |vpiFullName:work@test_program.configure_and_push_command_to_master_0.cmd.Command.byteenable.NUM_SYMBOLS
+                  |vpiActual:
+                  \_parameter: (work@test_program.NUM_SYMBOLS), line:16, col:14, parent:work@test_program
+                |vpiOperand:
+                \_constant: , line:51, col:26
                   |vpiConstType:9
-                  |vpiDecompile:0
+                  |vpiDecompile:1
                   |vpiSize:64
-                  |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (cmd_delay), line:52, col:36, parent:Command
-            |vpiName:cmd_delay
-            |vpiTypespec:
-            \_bit_typespec: , line:52, col:7, parent:cmd_delay
-              |vpiRange:
-              \_range: , line:52, col:12
-                |vpiLeftRange:
-                \_constant: , line:52, col:12
-                  |vpiConstType:9
-                  |vpiDecompile:31
-                  |vpiSize:64
-                  |UINT:31
-                |vpiRightRange:
-                \_constant: , line:52, col:15
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (data_idles), line:53, col:36, parent:Command
-            |vpiName:data_idles
-            |vpiTypespec:
-            \_bit_typespec: , line:53, col:7, parent:data_idles
-              |vpiRange:
-              \_range: , line:53, col:12
-                |vpiLeftRange:
-                \_constant: , line:53, col:12
-                  |vpiConstType:9
-                  |vpiDecompile:31
-                  |vpiSize:64
-                  |UINT:31
-                |vpiRightRange:
-                \_constant: , line:53, col:15
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
+                  |UINT:1
+              |vpiRightRange:
+              \_constant: , line:51, col:28
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+        |vpiTypespecMember:
+        \_typespec_member: (cmd_delay), line:52, col:36, parent:Command
+          |vpiName:cmd_delay
+          |vpiTypespec:
+          \_bit_typespec: , line:52, col:7, parent:cmd_delay
+            |vpiRange:
+            \_range: , line:52, col:12
+              |vpiLeftRange:
+              \_constant: , line:52, col:12
+                |vpiConstType:9
+                |vpiDecompile:31
+                |vpiSize:64
+                |UINT:31
+              |vpiRightRange:
+              \_constant: , line:52, col:15
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+        |vpiTypespecMember:
+        \_typespec_member: (data_idles), line:53, col:36, parent:Command
+          |vpiName:data_idles
+          |vpiTypespec:
+          \_bit_typespec: , line:53, col:7, parent:data_idles
+            |vpiRange:
+            \_range: , line:53, col:12
+              |vpiLeftRange:
+              \_constant: , line:53, col:12
+                |vpiConstType:9
+                |vpiDecompile:31
+                |vpiSize:64
+                |UINT:31
+              |vpiRightRange:
+              \_constant: , line:53, col:15
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
     |vpiStmt:
     \_begin: (work@test_program.configure_and_push_command_to_master_0), parent:work@test_program.configure_and_push_command_to_master_0
       |vpiFullName:work@test_program.configure_and_push_command_to_master_0
@@ -21923,8 +21252,6 @@ design: (work@top)
           |vpiActual:
           \_ref_obj: (cmd), parent:cmd.addr
             |vpiName:cmd
-            |vpiActual:
-            \_struct_var: (cmd.Command), line:225, col:6, parent:cmd
           |vpiActual:
           \_ref_obj: (addr), parent:cmd.addr
             |vpiName:addr
@@ -21937,8 +21264,6 @@ design: (work@top)
           |vpiActual:
           \_ref_obj: (cmd), parent:cmd.burstcount
             |vpiName:cmd
-            |vpiActual:
-            \_struct_var: (cmd.Command), line:225, col:6, parent:cmd
           |vpiActual:
           \_ref_obj: (burstcount), parent:cmd.burstcount
             |vpiName:burstcount
@@ -21951,8 +21276,6 @@ design: (work@top)
           |vpiActual:
           \_ref_obj: (cmd), parent:cmd.burstcount
             |vpiName:cmd
-            |vpiActual:
-            \_struct_var: (cmd.Command), line:225, col:6, parent:cmd
           |vpiActual:
           \_ref_obj: (burstcount), parent:cmd.burstcount
             |vpiName:burstcount
@@ -21965,8 +21288,6 @@ design: (work@top)
           |vpiActual:
           \_ref_obj: (cmd), parent:cmd.cmd_delay
             |vpiName:cmd
-            |vpiActual:
-            \_struct_var: (cmd.Command), line:225, col:6, parent:cmd
           |vpiActual:
           \_ref_obj: (cmd_delay), parent:cmd.cmd_delay
             |vpiName:cmd_delay
@@ -21981,8 +21302,6 @@ design: (work@top)
             |vpiActual:
             \_ref_obj: (cmd), parent:cmd.trans
               |vpiName:cmd
-              |vpiActual:
-              \_struct_var: (cmd.Command), line:225, col:6, parent:cmd
             |vpiActual:
             \_ref_obj: (trans), parent:cmd.trans
               |vpiName:trans
@@ -22018,8 +21337,6 @@ design: (work@top)
                 |vpiActual:
                 \_ref_obj: (cmd), parent:cmd.burstcount
                   |vpiName:cmd
-                  |vpiActual:
-                  \_struct_var: (cmd.Command), line:225, col:6, parent:cmd
                 |vpiActual:
                 \_ref_obj: (burstcount), parent:cmd.burstcount
                   |vpiName:burstcount
@@ -22054,8 +21371,6 @@ design: (work@top)
                   |vpiActual:
                   \_ref_obj: (cmd), parent:cmd.data[i]
                     |vpiName:cmd
-                    |vpiActual:
-                    \_struct_var: (cmd.Command), line:225, col:6, parent:cmd
                   |vpiActual:
                   \_bit_select: (data), parent:cmd.data[i]
                     |vpiName:data
@@ -22076,8 +21391,6 @@ design: (work@top)
                   |vpiActual:
                   \_ref_obj: (cmd), parent:cmd.byteenable[i]
                     |vpiName:cmd
-                    |vpiActual:
-                    \_struct_var: (cmd.Command), line:225, col:6, parent:cmd
                   |vpiActual:
                   \_bit_select: (byteenable), parent:cmd.byteenable[i]
                     |vpiName:byteenable
@@ -22098,8 +21411,6 @@ design: (work@top)
                   |vpiActual:
                   \_ref_obj: (cmd), parent:cmd.data_idles[i]
                     |vpiName:cmd
-                    |vpiActual:
-                    \_struct_var: (cmd.Command), line:225, col:6, parent:cmd
                   |vpiActual:
                   \_bit_select: (data_idles), parent:cmd.data_idles[i]
                     |vpiName:data_idles
@@ -22130,8 +21441,6 @@ design: (work@top)
               |vpiActual:
               \_ref_obj: (cmd), parent:cmd.data_idles[0]
                 |vpiName:cmd
-                |vpiActual:
-                \_struct_var: (cmd.Command), line:225, col:6, parent:cmd
               |vpiActual:
               \_bit_select: (data_idles), parent:cmd.data_idles[0]
                 |vpiName:data_idles
@@ -22841,18 +22150,40 @@ design: (work@top)
     \_io_decl: (rsp), parent:work@test_program.configure_and_push_response_to_slave_0
       |vpiName:rsp
       |vpiDirection:1
-      |vpiExpr:
-      \_struct_var: (work@test_program.configure_and_push_response_to_slave_0.rsp.Response), line:341, col:6, parent:rsp
+      |vpiTypedef:
+      \_struct_typespec: (Response), line:56, col:11, parent:rsp
         |vpiName:Response
-        |vpiFullName:work@test_program.configure_and_push_response_to_slave_0.rsp.Response
-        |vpiTypespec:
-        \_struct_typespec: (Response), line:56, col:11, parent:work@test_program.configure_and_push_response_to_slave_0.rsp.Response
-          |vpiName:Response
-          |vpiTypespecMember:
-          \_typespec_member: (burstcount), line:58, col:36, parent:Response
-            |vpiName:burstcount
-            |vpiTypespec:
-            \_logic_typespec: (Burstcount), line:31, col:11, parent:burstcount
+        |vpiTypespecMember:
+        \_typespec_member: (burstcount), line:58, col:36, parent:Response
+          |vpiName:burstcount
+          |vpiTypespec:
+          \_logic_typespec: (Burstcount), line:31, col:11, parent:burstcount
+            |vpiName:Burstcount
+            |vpiRange:
+            \_range: , line:31, col:18, parent:Burstcount
+              |vpiLeftRange:
+              \_operation: , line:31, col:18
+                |vpiOpType:11
+                |vpiOperand:
+                \_ref_obj: (work@test_program.configure_and_push_response_to_slave_0.rsp.Response.burstcount.Burstcount.BURST_W), line:31, col:18
+                  |vpiName:BURST_W
+                  |vpiFullName:work@test_program.configure_and_push_response_to_slave_0.rsp.Response.burstcount.Burstcount.BURST_W
+                  |vpiActual:
+                  \_parameter: (work@test_program.BURST_W), line:19, col:14, parent:work@test_program
+                |vpiOperand:
+                \_constant: , line:31, col:26
+                  |vpiConstType:9
+                  |vpiDecompile:1
+                  |vpiSize:64
+                  |UINT:1
+              |vpiRightRange:
+              \_constant: , line:31, col:28
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+            |vpiTypedefAlias:
+            \_logic_typespec: (Burstcount), line:31, col:11, parent:Burstcount
               |vpiName:Burstcount
               |vpiRange:
               \_range: , line:31, col:18, parent:Burstcount
@@ -22860,9 +22191,9 @@ design: (work@top)
                 \_operation: , line:31, col:18
                   |vpiOpType:11
                   |vpiOperand:
-                  \_ref_obj: (work@test_program.configure_and_push_response_to_slave_0.rsp.Response.Response.burstcount.Burstcount.BURST_W), line:31, col:18
+                  \_ref_obj: (work@test_program.configure_and_push_response_to_slave_0.rsp.Response.burstcount.Burstcount.Burstcount.BURST_W), line:31, col:18
                     |vpiName:BURST_W
-                    |vpiFullName:work@test_program.configure_and_push_response_to_slave_0.rsp.Response.Response.burstcount.Burstcount.BURST_W
+                    |vpiFullName:work@test_program.configure_and_push_response_to_slave_0.rsp.Response.burstcount.Burstcount.Burstcount.BURST_W
                     |vpiActual:
                     \_parameter: (work@test_program.BURST_W), line:19, col:14, parent:work@test_program
                   |vpiOperand:
@@ -22877,79 +22208,53 @@ design: (work@top)
                   |vpiDecompile:0
                   |vpiSize:64
                   |UINT:0
-              |vpiTypedefAlias:
-              \_logic_typespec: (Burstcount), line:31, col:11, parent:Burstcount
-                |vpiName:Burstcount
-                |vpiRange:
-                \_range: , line:31, col:18, parent:Burstcount
-                  |vpiLeftRange:
-                  \_operation: , line:31, col:18
-                    |vpiOpType:11
-                    |vpiOperand:
-                    \_ref_obj: (work@test_program.configure_and_push_response_to_slave_0.rsp.Response.Response.burstcount.Burstcount.Burstcount.BURST_W), line:31, col:18
-                      |vpiName:BURST_W
-                      |vpiFullName:work@test_program.configure_and_push_response_to_slave_0.rsp.Response.Response.burstcount.Burstcount.Burstcount.BURST_W
-                      |vpiActual:
-                      \_parameter: (work@test_program.BURST_W), line:19, col:14, parent:work@test_program
-                    |vpiOperand:
-                    \_constant: , line:31, col:26
-                      |vpiConstType:9
-                      |vpiDecompile:1
-                      |vpiSize:64
-                      |UINT:1
-                  |vpiRightRange:
-                  \_constant: , line:31, col:28
-                    |vpiConstType:9
-                    |vpiDecompile:0
-                    |vpiSize:64
-                    |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (data), line:59, col:36, parent:Response
-            |vpiName:data
-            |vpiTypespec:
-            \_logic_typespec: , line:59, col:6, parent:data
-              |vpiRange:
-              \_range: , line:59, col:13
-                |vpiLeftRange:
-                \_operation: , line:59, col:13
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (work@test_program.configure_and_push_response_to_slave_0.rsp.Response.Response.data.DATA_W), line:59, col:13
-                    |vpiName:DATA_W
-                    |vpiFullName:work@test_program.configure_and_push_response_to_slave_0.rsp.Response.Response.data.DATA_W
-                    |vpiActual:
-                    \_parameter: (work@test_program.DATA_W), line:17, col:14, parent:work@test_program
-                  |vpiOperand:
-                  \_constant: , line:59, col:20
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:59, col:22
+        |vpiTypespecMember:
+        \_typespec_member: (data), line:59, col:36, parent:Response
+          |vpiName:data
+          |vpiTypespec:
+          \_logic_typespec: , line:59, col:6, parent:data
+            |vpiRange:
+            \_range: , line:59, col:13
+              |vpiLeftRange:
+              \_operation: , line:59, col:13
+                |vpiOpType:11
+                |vpiOperand:
+                \_ref_obj: (work@test_program.configure_and_push_response_to_slave_0.rsp.Response.data.DATA_W), line:59, col:13
+                  |vpiName:DATA_W
+                  |vpiFullName:work@test_program.configure_and_push_response_to_slave_0.rsp.Response.data.DATA_W
+                  |vpiActual:
+                  \_parameter: (work@test_program.DATA_W), line:17, col:14, parent:work@test_program
+                |vpiOperand:
+                \_constant: , line:59, col:20
                   |vpiConstType:9
-                  |vpiDecompile:0
+                  |vpiDecompile:1
                   |vpiSize:64
-                  |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (latency), line:60, col:36, parent:Response
-            |vpiName:latency
-            |vpiTypespec:
-            \_bit_typespec: , line:60, col:6, parent:latency
-              |vpiRange:
-              \_range: , line:60, col:11
-                |vpiLeftRange:
-                \_constant: , line:60, col:11
-                  |vpiConstType:9
-                  |vpiDecompile:31
-                  |vpiSize:64
-                  |UINT:31
-                |vpiRightRange:
-                \_constant: , line:60, col:14
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
+                  |UINT:1
+              |vpiRightRange:
+              \_constant: , line:59, col:22
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+        |vpiTypespecMember:
+        \_typespec_member: (latency), line:60, col:36, parent:Response
+          |vpiName:latency
+          |vpiTypespec:
+          \_bit_typespec: , line:60, col:6, parent:latency
+            |vpiRange:
+            \_range: , line:60, col:11
+              |vpiLeftRange:
+              \_constant: , line:60, col:11
+                |vpiConstType:9
+                |vpiDecompile:31
+                |vpiSize:64
+                |UINT:31
+              |vpiRightRange:
+              \_constant: , line:60, col:14
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
     |vpiStmt:
     \_begin: (work@test_program.configure_and_push_response_to_slave_0), parent:work@test_program.configure_and_push_response_to_slave_0
       |vpiFullName:work@test_program.configure_and_push_response_to_slave_0
@@ -22969,8 +22274,6 @@ design: (work@top)
           |vpiActual:
           \_ref_obj: (rsp), parent:rsp.burstcount
             |vpiName:rsp
-            |vpiActual:
-            \_struct_var: (rsp.Response), line:341, col:6, parent:rsp
           |vpiActual:
           \_ref_obj: (burstcount), parent:rsp.burstcount
             |vpiName:burstcount
@@ -22990,8 +22293,6 @@ design: (work@top)
             |vpiActual:
             \_ref_obj: (rsp), parent:rsp.burstcount
               |vpiName:rsp
-              |vpiActual:
-              \_struct_var: (rsp.Response), line:341, col:6, parent:rsp
             |vpiActual:
             \_ref_obj: (burstcount), parent:rsp.burstcount
               |vpiName:burstcount
@@ -23026,8 +22327,6 @@ design: (work@top)
               |vpiActual:
               \_ref_obj: (rsp), parent:rsp.data[i]
                 |vpiName:rsp
-                |vpiActual:
-                \_struct_var: (rsp.Response), line:341, col:6, parent:rsp
               |vpiActual:
               \_bit_select: (data), parent:rsp.data[i]
                 |vpiName:data
@@ -23069,8 +22368,6 @@ design: (work@top)
                     |vpiActual:
                     \_ref_obj: (rsp), parent:rsp.latency[i]
                       |vpiName:rsp
-                      |vpiActual:
-                      \_struct_var: (rsp.Response), line:341, col:6, parent:rsp
                     |vpiActual:
                     \_bit_select: (latency), parent:rsp.latency[i]
                       |vpiName:latency
@@ -23104,8 +22401,6 @@ design: (work@top)
                   |vpiActual:
                   \_ref_obj: (rsp), parent:rsp.latency[i]
                     |vpiName:rsp
-                    |vpiActual:
-                    \_struct_var: (rsp.Response), line:341, col:6, parent:rsp
                   |vpiActual:
                   \_bit_select: (latency), parent:rsp.latency[i]
                     |vpiName:latency
@@ -23125,8 +22420,6 @@ design: (work@top)
                   |vpiActual:
                   \_ref_obj: (rsp), parent:rsp.latency[i]
                     |vpiName:rsp
-                    |vpiActual:
-                    \_struct_var: (rsp.Response), line:341, col:6, parent:rsp
                   |vpiActual:
                   \_bit_select: (latency), parent:rsp.latency[i]
                     |vpiName:latency
@@ -23157,8 +22450,6 @@ design: (work@top)
                     |vpiActual:
                     \_ref_obj: (rsp), parent:rsp.latency[i]
                       |vpiName:rsp
-                      |vpiActual:
-                      \_struct_var: (rsp.Response), line:341, col:6, parent:rsp
                     |vpiActual:
                     \_bit_select: (latency), parent:rsp.latency[i]
                       |vpiName:latency
@@ -23212,8 +22503,6 @@ design: (work@top)
               |vpiActual:
               \_ref_obj: (rsp), parent:rsp.burstcount
                 |vpiName:rsp
-                |vpiActual:
-                \_struct_var: (rsp.Response), line:341, col:6, parent:rsp
               |vpiActual:
               \_ref_obj: (burstcount), parent:rsp.burstcount
                 |vpiName:burstcount
@@ -23239,34 +22528,56 @@ design: (work@top)
     \_io_decl: (cmd), parent:work@test_program.configure_and_push_command_to_master_1
       |vpiName:cmd
       |vpiDirection:1
-      |vpiExpr:
-      \_struct_var: (work@test_program.configure_and_push_command_to_master_1.cmd.Command), line:368, col:6, parent:cmd
+      |vpiTypedef:
+      \_struct_typespec: (Command), line:45, col:11, parent:cmd
         |vpiName:Command
-        |vpiFullName:work@test_program.configure_and_push_command_to_master_1.cmd.Command
-        |vpiTypespec:
-        \_struct_typespec: (Command), line:45, col:11, parent:work@test_program.configure_and_push_command_to_master_1.cmd.Command
-          |vpiName:Command
-          |vpiTypespecMember:
-          \_typespec_member: (trans), line:47, col:36, parent:Command
-            |vpiName:trans
-            |vpiTypespec:
-            \_enum_typespec: (Transaction), line:37, col:5, parent:trans
-              |vpiName:Transaction
-              |vpiBaseTypespec:
-              \_bit_typespec: , line:33, col:16, parent:Transaction
-              |vpiEnumConst:
-              \_enum_const: (READ), line:36, parent:Transaction
-                |vpiName:READ
-                |UINT:1
-              |vpiEnumConst:
-              \_enum_const: (WRITE), line:35, parent:Transaction
-                |vpiName:WRITE
+        |vpiTypespecMember:
+        \_typespec_member: (trans), line:47, col:36, parent:Command
+          |vpiName:trans
+          |vpiTypespec:
+          \_enum_typespec: (Transaction), line:37, col:5, parent:trans
+            |vpiName:Transaction
+            |vpiBaseTypespec:
+            \_bit_typespec: , line:33, col:16, parent:Transaction
+            |vpiEnumConst:
+            \_enum_const: (READ), line:36, parent:Transaction
+              |vpiName:READ
+              |UINT:1
+            |vpiEnumConst:
+            \_enum_const: (WRITE), line:35, parent:Transaction
+              |vpiName:WRITE
+              |UINT:0
+        |vpiTypespecMember:
+        \_typespec_member: (burstcount), line:48, col:36, parent:Command
+          |vpiName:burstcount
+          |vpiTypespec:
+          \_logic_typespec: (Burstcount), line:31, col:11, parent:burstcount
+            |vpiName:Burstcount
+            |vpiRange:
+            \_range: , line:31, col:18, parent:Burstcount
+              |vpiLeftRange:
+              \_operation: , line:31, col:18
+                |vpiOpType:11
+                |vpiOperand:
+                \_ref_obj: (work@test_program.configure_and_push_command_to_master_1.cmd.Command.burstcount.Burstcount.BURST_W), line:31, col:18
+                  |vpiName:BURST_W
+                  |vpiFullName:work@test_program.configure_and_push_command_to_master_1.cmd.Command.burstcount.Burstcount.BURST_W
+                  |vpiActual:
+                  \_parameter: (work@test_program.BURST_W), line:19, col:14, parent:work@test_program
+                |vpiOperand:
+                \_constant: , line:31, col:26
+                  |vpiConstType:9
+                  |vpiDecompile:1
+                  |vpiSize:64
+                  |UINT:1
+              |vpiRightRange:
+              \_constant: , line:31, col:28
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
                 |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (burstcount), line:48, col:36, parent:Command
-            |vpiName:burstcount
-            |vpiTypespec:
-            \_logic_typespec: (Burstcount), line:31, col:11, parent:burstcount
+            |vpiTypedefAlias:
+            \_logic_typespec: (Burstcount), line:31, col:11, parent:Burstcount
               |vpiName:Burstcount
               |vpiRange:
               \_range: , line:31, col:18, parent:Burstcount
@@ -23274,9 +22585,9 @@ design: (work@top)
                 \_operation: , line:31, col:18
                   |vpiOpType:11
                   |vpiOperand:
-                  \_ref_obj: (work@test_program.configure_and_push_command_to_master_1.cmd.Command.Command.burstcount.Burstcount.BURST_W), line:31, col:18
+                  \_ref_obj: (work@test_program.configure_and_push_command_to_master_1.cmd.Command.burstcount.Burstcount.Burstcount.BURST_W), line:31, col:18
                     |vpiName:BURST_W
-                    |vpiFullName:work@test_program.configure_and_push_command_to_master_1.cmd.Command.Command.burstcount.Burstcount.BURST_W
+                    |vpiFullName:work@test_program.configure_and_push_command_to_master_1.cmd.Command.burstcount.Burstcount.Burstcount.BURST_W
                     |vpiActual:
                     \_parameter: (work@test_program.BURST_W), line:19, col:14, parent:work@test_program
                   |vpiOperand:
@@ -23291,154 +22602,128 @@ design: (work@top)
                   |vpiDecompile:0
                   |vpiSize:64
                   |UINT:0
-              |vpiTypedefAlias:
-              \_logic_typespec: (Burstcount), line:31, col:11, parent:Burstcount
-                |vpiName:Burstcount
-                |vpiRange:
-                \_range: , line:31, col:18, parent:Burstcount
-                  |vpiLeftRange:
-                  \_operation: , line:31, col:18
-                    |vpiOpType:11
-                    |vpiOperand:
-                    \_ref_obj: (work@test_program.configure_and_push_command_to_master_1.cmd.Command.Command.burstcount.Burstcount.Burstcount.BURST_W), line:31, col:18
-                      |vpiName:BURST_W
-                      |vpiFullName:work@test_program.configure_and_push_command_to_master_1.cmd.Command.Command.burstcount.Burstcount.Burstcount.BURST_W
-                      |vpiActual:
-                      \_parameter: (work@test_program.BURST_W), line:19, col:14, parent:work@test_program
-                    |vpiOperand:
-                    \_constant: , line:31, col:26
-                      |vpiConstType:9
-                      |vpiDecompile:1
-                      |vpiSize:64
-                      |UINT:1
-                  |vpiRightRange:
-                  \_constant: , line:31, col:28
-                    |vpiConstType:9
-                    |vpiDecompile:0
-                    |vpiSize:64
-                    |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (addr), line:49, col:36, parent:Command
-            |vpiName:addr
-            |vpiTypespec:
-            \_logic_typespec: , line:49, col:7, parent:addr
-              |vpiRange:
-              \_range: , line:49, col:14
-                |vpiLeftRange:
-                \_operation: , line:49, col:14
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (work@test_program.configure_and_push_command_to_master_1.cmd.Command.Command.addr.ADDR_W), line:49, col:14
-                    |vpiName:ADDR_W
-                    |vpiFullName:work@test_program.configure_and_push_command_to_master_1.cmd.Command.Command.addr.ADDR_W
-                    |vpiActual:
-                    \_parameter: (work@test_program.ADDR_W), line:13, col:14, parent:work@test_program
-                  |vpiOperand:
-                  \_constant: , line:49, col:21
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:49, col:24
+        |vpiTypespecMember:
+        \_typespec_member: (addr), line:49, col:36, parent:Command
+          |vpiName:addr
+          |vpiTypespec:
+          \_logic_typespec: , line:49, col:7, parent:addr
+            |vpiRange:
+            \_range: , line:49, col:14
+              |vpiLeftRange:
+              \_operation: , line:49, col:14
+                |vpiOpType:11
+                |vpiOperand:
+                \_ref_obj: (work@test_program.configure_and_push_command_to_master_1.cmd.Command.addr.ADDR_W), line:49, col:14
+                  |vpiName:ADDR_W
+                  |vpiFullName:work@test_program.configure_and_push_command_to_master_1.cmd.Command.addr.ADDR_W
+                  |vpiActual:
+                  \_parameter: (work@test_program.ADDR_W), line:13, col:14, parent:work@test_program
+                |vpiOperand:
+                \_constant: , line:49, col:21
                   |vpiConstType:9
-                  |vpiDecompile:0
+                  |vpiDecompile:1
                   |vpiSize:64
-                  |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (data), line:50, col:36, parent:Command
-            |vpiName:data
-            |vpiTypespec:
-            \_logic_typespec: , line:50, col:7, parent:data
-              |vpiRange:
-              \_range: , line:50, col:14
-                |vpiLeftRange:
-                \_operation: , line:50, col:14
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (work@test_program.configure_and_push_command_to_master_1.cmd.Command.Command.data.DATA_W), line:50, col:14
-                    |vpiName:DATA_W
-                    |vpiFullName:work@test_program.configure_and_push_command_to_master_1.cmd.Command.Command.data.DATA_W
-                    |vpiActual:
-                    \_parameter: (work@test_program.DATA_W), line:17, col:14, parent:work@test_program
-                  |vpiOperand:
-                  \_constant: , line:50, col:21
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:50, col:23
+                  |UINT:1
+              |vpiRightRange:
+              \_constant: , line:49, col:24
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+        |vpiTypespecMember:
+        \_typespec_member: (data), line:50, col:36, parent:Command
+          |vpiName:data
+          |vpiTypespec:
+          \_logic_typespec: , line:50, col:7, parent:data
+            |vpiRange:
+            \_range: , line:50, col:14
+              |vpiLeftRange:
+              \_operation: , line:50, col:14
+                |vpiOpType:11
+                |vpiOperand:
+                \_ref_obj: (work@test_program.configure_and_push_command_to_master_1.cmd.Command.data.DATA_W), line:50, col:14
+                  |vpiName:DATA_W
+                  |vpiFullName:work@test_program.configure_and_push_command_to_master_1.cmd.Command.data.DATA_W
+                  |vpiActual:
+                  \_parameter: (work@test_program.DATA_W), line:17, col:14, parent:work@test_program
+                |vpiOperand:
+                \_constant: , line:50, col:21
                   |vpiConstType:9
-                  |vpiDecompile:0
+                  |vpiDecompile:1
                   |vpiSize:64
-                  |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (byteenable), line:51, col:36, parent:Command
-            |vpiName:byteenable
-            |vpiTypespec:
-            \_logic_typespec: , line:51, col:7, parent:byteenable
-              |vpiRange:
-              \_range: , line:51, col:14
-                |vpiLeftRange:
-                \_operation: , line:51, col:14
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (work@test_program.configure_and_push_command_to_master_1.cmd.Command.Command.byteenable.NUM_SYMBOLS), line:51, col:14
-                    |vpiName:NUM_SYMBOLS
-                    |vpiFullName:work@test_program.configure_and_push_command_to_master_1.cmd.Command.Command.byteenable.NUM_SYMBOLS
-                    |vpiActual:
-                    \_parameter: (work@test_program.NUM_SYMBOLS), line:16, col:14, parent:work@test_program
-                  |vpiOperand:
-                  \_constant: , line:51, col:26
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:51, col:28
+                  |UINT:1
+              |vpiRightRange:
+              \_constant: , line:50, col:23
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+        |vpiTypespecMember:
+        \_typespec_member: (byteenable), line:51, col:36, parent:Command
+          |vpiName:byteenable
+          |vpiTypespec:
+          \_logic_typespec: , line:51, col:7, parent:byteenable
+            |vpiRange:
+            \_range: , line:51, col:14
+              |vpiLeftRange:
+              \_operation: , line:51, col:14
+                |vpiOpType:11
+                |vpiOperand:
+                \_ref_obj: (work@test_program.configure_and_push_command_to_master_1.cmd.Command.byteenable.NUM_SYMBOLS), line:51, col:14
+                  |vpiName:NUM_SYMBOLS
+                  |vpiFullName:work@test_program.configure_and_push_command_to_master_1.cmd.Command.byteenable.NUM_SYMBOLS
+                  |vpiActual:
+                  \_parameter: (work@test_program.NUM_SYMBOLS), line:16, col:14, parent:work@test_program
+                |vpiOperand:
+                \_constant: , line:51, col:26
                   |vpiConstType:9
-                  |vpiDecompile:0
+                  |vpiDecompile:1
                   |vpiSize:64
-                  |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (cmd_delay), line:52, col:36, parent:Command
-            |vpiName:cmd_delay
-            |vpiTypespec:
-            \_bit_typespec: , line:52, col:7, parent:cmd_delay
-              |vpiRange:
-              \_range: , line:52, col:12
-                |vpiLeftRange:
-                \_constant: , line:52, col:12
-                  |vpiConstType:9
-                  |vpiDecompile:31
-                  |vpiSize:64
-                  |UINT:31
-                |vpiRightRange:
-                \_constant: , line:52, col:15
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (data_idles), line:53, col:36, parent:Command
-            |vpiName:data_idles
-            |vpiTypespec:
-            \_bit_typespec: , line:53, col:7, parent:data_idles
-              |vpiRange:
-              \_range: , line:53, col:12
-                |vpiLeftRange:
-                \_constant: , line:53, col:12
-                  |vpiConstType:9
-                  |vpiDecompile:31
-                  |vpiSize:64
-                  |UINT:31
-                |vpiRightRange:
-                \_constant: , line:53, col:15
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
+                  |UINT:1
+              |vpiRightRange:
+              \_constant: , line:51, col:28
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+        |vpiTypespecMember:
+        \_typespec_member: (cmd_delay), line:52, col:36, parent:Command
+          |vpiName:cmd_delay
+          |vpiTypespec:
+          \_bit_typespec: , line:52, col:7, parent:cmd_delay
+            |vpiRange:
+            \_range: , line:52, col:12
+              |vpiLeftRange:
+              \_constant: , line:52, col:12
+                |vpiConstType:9
+                |vpiDecompile:31
+                |vpiSize:64
+                |UINT:31
+              |vpiRightRange:
+              \_constant: , line:52, col:15
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+        |vpiTypespecMember:
+        \_typespec_member: (data_idles), line:53, col:36, parent:Command
+          |vpiName:data_idles
+          |vpiTypespec:
+          \_bit_typespec: , line:53, col:7, parent:data_idles
+            |vpiRange:
+            \_range: , line:53, col:12
+              |vpiLeftRange:
+              \_constant: , line:53, col:12
+                |vpiConstType:9
+                |vpiDecompile:31
+                |vpiSize:64
+                |UINT:31
+              |vpiRightRange:
+              \_constant: , line:53, col:15
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
     |vpiStmt:
     \_begin: (work@test_program.configure_and_push_command_to_master_1), parent:work@test_program.configure_and_push_command_to_master_1
       |vpiFullName:work@test_program.configure_and_push_command_to_master_1
@@ -23451,8 +22736,6 @@ design: (work@top)
           |vpiActual:
           \_ref_obj: (cmd), parent:cmd.addr
             |vpiName:cmd
-            |vpiActual:
-            \_struct_var: (cmd.Command), line:368, col:6, parent:cmd
           |vpiActual:
           \_ref_obj: (addr), parent:cmd.addr
             |vpiName:addr
@@ -23465,8 +22748,6 @@ design: (work@top)
           |vpiActual:
           \_ref_obj: (cmd), parent:cmd.burstcount
             |vpiName:cmd
-            |vpiActual:
-            \_struct_var: (cmd.Command), line:368, col:6, parent:cmd
           |vpiActual:
           \_ref_obj: (burstcount), parent:cmd.burstcount
             |vpiName:burstcount
@@ -23479,8 +22760,6 @@ design: (work@top)
           |vpiActual:
           \_ref_obj: (cmd), parent:cmd.burstcount
             |vpiName:cmd
-            |vpiActual:
-            \_struct_var: (cmd.Command), line:368, col:6, parent:cmd
           |vpiActual:
           \_ref_obj: (burstcount), parent:cmd.burstcount
             |vpiName:burstcount
@@ -23493,8 +22772,6 @@ design: (work@top)
           |vpiActual:
           \_ref_obj: (cmd), parent:cmd.cmd_delay
             |vpiName:cmd
-            |vpiActual:
-            \_struct_var: (cmd.Command), line:368, col:6, parent:cmd
           |vpiActual:
           \_ref_obj: (cmd_delay), parent:cmd.cmd_delay
             |vpiName:cmd_delay
@@ -23509,8 +22786,6 @@ design: (work@top)
             |vpiActual:
             \_ref_obj: (cmd), parent:cmd.trans
               |vpiName:cmd
-              |vpiActual:
-              \_struct_var: (cmd.Command), line:368, col:6, parent:cmd
             |vpiActual:
             \_ref_obj: (trans), parent:cmd.trans
               |vpiName:trans
@@ -23546,8 +22821,6 @@ design: (work@top)
                 |vpiActual:
                 \_ref_obj: (cmd), parent:cmd.burstcount
                   |vpiName:cmd
-                  |vpiActual:
-                  \_struct_var: (cmd.Command), line:368, col:6, parent:cmd
                 |vpiActual:
                 \_ref_obj: (burstcount), parent:cmd.burstcount
                   |vpiName:burstcount
@@ -23582,8 +22855,6 @@ design: (work@top)
                   |vpiActual:
                   \_ref_obj: (cmd), parent:cmd.data[i]
                     |vpiName:cmd
-                    |vpiActual:
-                    \_struct_var: (cmd.Command), line:368, col:6, parent:cmd
                   |vpiActual:
                   \_bit_select: (data), parent:cmd.data[i]
                     |vpiName:data
@@ -23604,8 +22875,6 @@ design: (work@top)
                   |vpiActual:
                   \_ref_obj: (cmd), parent:cmd.byteenable[i]
                     |vpiName:cmd
-                    |vpiActual:
-                    \_struct_var: (cmd.Command), line:368, col:6, parent:cmd
                   |vpiActual:
                   \_bit_select: (byteenable), parent:cmd.byteenable[i]
                     |vpiName:byteenable
@@ -23626,8 +22895,6 @@ design: (work@top)
                   |vpiActual:
                   \_ref_obj: (cmd), parent:cmd.data_idles[i]
                     |vpiName:cmd
-                    |vpiActual:
-                    \_struct_var: (cmd.Command), line:368, col:6, parent:cmd
                   |vpiActual:
                   \_bit_select: (data_idles), parent:cmd.data_idles[i]
                     |vpiName:data_idles
@@ -23658,8 +22925,6 @@ design: (work@top)
               |vpiActual:
               \_ref_obj: (cmd), parent:cmd.data_idles[0]
                 |vpiName:cmd
-                |vpiActual:
-                \_struct_var: (cmd.Command), line:368, col:6, parent:cmd
               |vpiActual:
               \_bit_select: (data_idles), parent:cmd.data_idles[0]
                 |vpiName:data_idles
@@ -24369,18 +23634,40 @@ design: (work@top)
     \_io_decl: (rsp), parent:work@test_program.configure_and_push_response_to_slave_1
       |vpiName:rsp
       |vpiDirection:1
-      |vpiExpr:
-      \_struct_var: (work@test_program.configure_and_push_response_to_slave_1.rsp.Response), line:484, col:6, parent:rsp
+      |vpiTypedef:
+      \_struct_typespec: (Response), line:56, col:11, parent:rsp
         |vpiName:Response
-        |vpiFullName:work@test_program.configure_and_push_response_to_slave_1.rsp.Response
-        |vpiTypespec:
-        \_struct_typespec: (Response), line:56, col:11, parent:work@test_program.configure_and_push_response_to_slave_1.rsp.Response
-          |vpiName:Response
-          |vpiTypespecMember:
-          \_typespec_member: (burstcount), line:58, col:36, parent:Response
-            |vpiName:burstcount
-            |vpiTypespec:
-            \_logic_typespec: (Burstcount), line:31, col:11, parent:burstcount
+        |vpiTypespecMember:
+        \_typespec_member: (burstcount), line:58, col:36, parent:Response
+          |vpiName:burstcount
+          |vpiTypespec:
+          \_logic_typespec: (Burstcount), line:31, col:11, parent:burstcount
+            |vpiName:Burstcount
+            |vpiRange:
+            \_range: , line:31, col:18, parent:Burstcount
+              |vpiLeftRange:
+              \_operation: , line:31, col:18
+                |vpiOpType:11
+                |vpiOperand:
+                \_ref_obj: (work@test_program.configure_and_push_response_to_slave_1.rsp.Response.burstcount.Burstcount.BURST_W), line:31, col:18
+                  |vpiName:BURST_W
+                  |vpiFullName:work@test_program.configure_and_push_response_to_slave_1.rsp.Response.burstcount.Burstcount.BURST_W
+                  |vpiActual:
+                  \_parameter: (work@test_program.BURST_W), line:19, col:14, parent:work@test_program
+                |vpiOperand:
+                \_constant: , line:31, col:26
+                  |vpiConstType:9
+                  |vpiDecompile:1
+                  |vpiSize:64
+                  |UINT:1
+              |vpiRightRange:
+              \_constant: , line:31, col:28
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+            |vpiTypedefAlias:
+            \_logic_typespec: (Burstcount), line:31, col:11, parent:Burstcount
               |vpiName:Burstcount
               |vpiRange:
               \_range: , line:31, col:18, parent:Burstcount
@@ -24388,9 +23675,9 @@ design: (work@top)
                 \_operation: , line:31, col:18
                   |vpiOpType:11
                   |vpiOperand:
-                  \_ref_obj: (work@test_program.configure_and_push_response_to_slave_1.rsp.Response.Response.burstcount.Burstcount.BURST_W), line:31, col:18
+                  \_ref_obj: (work@test_program.configure_and_push_response_to_slave_1.rsp.Response.burstcount.Burstcount.Burstcount.BURST_W), line:31, col:18
                     |vpiName:BURST_W
-                    |vpiFullName:work@test_program.configure_and_push_response_to_slave_1.rsp.Response.Response.burstcount.Burstcount.BURST_W
+                    |vpiFullName:work@test_program.configure_and_push_response_to_slave_1.rsp.Response.burstcount.Burstcount.Burstcount.BURST_W
                     |vpiActual:
                     \_parameter: (work@test_program.BURST_W), line:19, col:14, parent:work@test_program
                   |vpiOperand:
@@ -24405,79 +23692,53 @@ design: (work@top)
                   |vpiDecompile:0
                   |vpiSize:64
                   |UINT:0
-              |vpiTypedefAlias:
-              \_logic_typespec: (Burstcount), line:31, col:11, parent:Burstcount
-                |vpiName:Burstcount
-                |vpiRange:
-                \_range: , line:31, col:18, parent:Burstcount
-                  |vpiLeftRange:
-                  \_operation: , line:31, col:18
-                    |vpiOpType:11
-                    |vpiOperand:
-                    \_ref_obj: (work@test_program.configure_and_push_response_to_slave_1.rsp.Response.Response.burstcount.Burstcount.Burstcount.BURST_W), line:31, col:18
-                      |vpiName:BURST_W
-                      |vpiFullName:work@test_program.configure_and_push_response_to_slave_1.rsp.Response.Response.burstcount.Burstcount.Burstcount.BURST_W
-                      |vpiActual:
-                      \_parameter: (work@test_program.BURST_W), line:19, col:14, parent:work@test_program
-                    |vpiOperand:
-                    \_constant: , line:31, col:26
-                      |vpiConstType:9
-                      |vpiDecompile:1
-                      |vpiSize:64
-                      |UINT:1
-                  |vpiRightRange:
-                  \_constant: , line:31, col:28
-                    |vpiConstType:9
-                    |vpiDecompile:0
-                    |vpiSize:64
-                    |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (data), line:59, col:36, parent:Response
-            |vpiName:data
-            |vpiTypespec:
-            \_logic_typespec: , line:59, col:6, parent:data
-              |vpiRange:
-              \_range: , line:59, col:13
-                |vpiLeftRange:
-                \_operation: , line:59, col:13
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (work@test_program.configure_and_push_response_to_slave_1.rsp.Response.Response.data.DATA_W), line:59, col:13
-                    |vpiName:DATA_W
-                    |vpiFullName:work@test_program.configure_and_push_response_to_slave_1.rsp.Response.Response.data.DATA_W
-                    |vpiActual:
-                    \_parameter: (work@test_program.DATA_W), line:17, col:14, parent:work@test_program
-                  |vpiOperand:
-                  \_constant: , line:59, col:20
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:59, col:22
+        |vpiTypespecMember:
+        \_typespec_member: (data), line:59, col:36, parent:Response
+          |vpiName:data
+          |vpiTypespec:
+          \_logic_typespec: , line:59, col:6, parent:data
+            |vpiRange:
+            \_range: , line:59, col:13
+              |vpiLeftRange:
+              \_operation: , line:59, col:13
+                |vpiOpType:11
+                |vpiOperand:
+                \_ref_obj: (work@test_program.configure_and_push_response_to_slave_1.rsp.Response.data.DATA_W), line:59, col:13
+                  |vpiName:DATA_W
+                  |vpiFullName:work@test_program.configure_and_push_response_to_slave_1.rsp.Response.data.DATA_W
+                  |vpiActual:
+                  \_parameter: (work@test_program.DATA_W), line:17, col:14, parent:work@test_program
+                |vpiOperand:
+                \_constant: , line:59, col:20
                   |vpiConstType:9
-                  |vpiDecompile:0
+                  |vpiDecompile:1
                   |vpiSize:64
-                  |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (latency), line:60, col:36, parent:Response
-            |vpiName:latency
-            |vpiTypespec:
-            \_bit_typespec: , line:60, col:6, parent:latency
-              |vpiRange:
-              \_range: , line:60, col:11
-                |vpiLeftRange:
-                \_constant: , line:60, col:11
-                  |vpiConstType:9
-                  |vpiDecompile:31
-                  |vpiSize:64
-                  |UINT:31
-                |vpiRightRange:
-                \_constant: , line:60, col:14
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
+                  |UINT:1
+              |vpiRightRange:
+              \_constant: , line:59, col:22
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+        |vpiTypespecMember:
+        \_typespec_member: (latency), line:60, col:36, parent:Response
+          |vpiName:latency
+          |vpiTypespec:
+          \_bit_typespec: , line:60, col:6, parent:latency
+            |vpiRange:
+            \_range: , line:60, col:11
+              |vpiLeftRange:
+              \_constant: , line:60, col:11
+                |vpiConstType:9
+                |vpiDecompile:31
+                |vpiSize:64
+                |UINT:31
+              |vpiRightRange:
+              \_constant: , line:60, col:14
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
     |vpiStmt:
     \_begin: (work@test_program.configure_and_push_response_to_slave_1), parent:work@test_program.configure_and_push_response_to_slave_1
       |vpiFullName:work@test_program.configure_and_push_response_to_slave_1
@@ -24497,8 +23758,6 @@ design: (work@top)
           |vpiActual:
           \_ref_obj: (rsp), parent:rsp.burstcount
             |vpiName:rsp
-            |vpiActual:
-            \_struct_var: (rsp.Response), line:484, col:6, parent:rsp
           |vpiActual:
           \_ref_obj: (burstcount), parent:rsp.burstcount
             |vpiName:burstcount
@@ -24518,8 +23777,6 @@ design: (work@top)
             |vpiActual:
             \_ref_obj: (rsp), parent:rsp.burstcount
               |vpiName:rsp
-              |vpiActual:
-              \_struct_var: (rsp.Response), line:484, col:6, parent:rsp
             |vpiActual:
             \_ref_obj: (burstcount), parent:rsp.burstcount
               |vpiName:burstcount
@@ -24554,8 +23811,6 @@ design: (work@top)
               |vpiActual:
               \_ref_obj: (rsp), parent:rsp.data[i]
                 |vpiName:rsp
-                |vpiActual:
-                \_struct_var: (rsp.Response), line:484, col:6, parent:rsp
               |vpiActual:
               \_bit_select: (data), parent:rsp.data[i]
                 |vpiName:data
@@ -24597,8 +23852,6 @@ design: (work@top)
                     |vpiActual:
                     \_ref_obj: (rsp), parent:rsp.latency[i]
                       |vpiName:rsp
-                      |vpiActual:
-                      \_struct_var: (rsp.Response), line:484, col:6, parent:rsp
                     |vpiActual:
                     \_bit_select: (latency), parent:rsp.latency[i]
                       |vpiName:latency
@@ -24632,8 +23885,6 @@ design: (work@top)
                   |vpiActual:
                   \_ref_obj: (rsp), parent:rsp.latency[i]
                     |vpiName:rsp
-                    |vpiActual:
-                    \_struct_var: (rsp.Response), line:484, col:6, parent:rsp
                   |vpiActual:
                   \_bit_select: (latency), parent:rsp.latency[i]
                     |vpiName:latency
@@ -24653,8 +23904,6 @@ design: (work@top)
                   |vpiActual:
                   \_ref_obj: (rsp), parent:rsp.latency[i]
                     |vpiName:rsp
-                    |vpiActual:
-                    \_struct_var: (rsp.Response), line:484, col:6, parent:rsp
                   |vpiActual:
                   \_bit_select: (latency), parent:rsp.latency[i]
                     |vpiName:latency
@@ -24685,8 +23934,6 @@ design: (work@top)
                     |vpiActual:
                     \_ref_obj: (rsp), parent:rsp.latency[i]
                       |vpiName:rsp
-                      |vpiActual:
-                      \_struct_var: (rsp.Response), line:484, col:6, parent:rsp
                     |vpiActual:
                     \_bit_select: (latency), parent:rsp.latency[i]
                       |vpiName:latency
@@ -24740,8 +23987,6 @@ design: (work@top)
               |vpiActual:
               \_ref_obj: (rsp), parent:rsp.burstcount
                 |vpiName:rsp
-                |vpiActual:
-                \_struct_var: (rsp.Response), line:484, col:6, parent:rsp
               |vpiActual:
               \_ref_obj: (burstcount), parent:rsp.burstcount
                 |vpiName:burstcount
@@ -24767,51 +24012,42 @@ design: (work@top)
     \_io_decl: (num_command), parent:work@test_program.master_send_commands
       |vpiName:num_command
       |vpiDirection:1
-      |vpiExpr:
-      \_int_var: (work@test_program.master_send_commands.num_command), line:545, col:6, parent:num_command
-        |vpiFullName:work@test_program.master_send_commands.num_command
+      |vpiTypedef:
+      \_int_typespec: , line:545, col:6, parent:num_command
     |vpiIODecl:
     \_io_decl: (trans), parent:work@test_program.master_send_commands
       |vpiName:trans
       |vpiDirection:1
-      |vpiExpr:
-      \_bit_var: (work@test_program.master_send_commands.trans.Transaction), line:546, col:6, parent:trans
+      |vpiTypedef:
+      \_enum_typespec: (Transaction), line:37, col:5, parent:trans
         |vpiName:Transaction
-        |vpiFullName:work@test_program.master_send_commands.trans.Transaction
-        |vpiTypespec:
-        \_enum_typespec: (Transaction), line:37, col:5, parent:work@test_program.master_send_commands.trans.Transaction
-          |vpiName:Transaction
-          |vpiBaseTypespec:
-          \_bit_typespec: , line:33, col:16, parent:Transaction
-          |vpiEnumConst:
-          \_enum_const: (READ), line:36, parent:Transaction
-            |vpiName:READ
-            |UINT:1
-          |vpiEnumConst:
-          \_enum_const: (WRITE), line:35, parent:Transaction
-            |vpiName:WRITE
-            |UINT:0
+        |vpiBaseTypespec:
+        \_bit_typespec: , line:33, col:16, parent:Transaction
+        |vpiEnumConst:
+        \_enum_const: (READ), line:36, parent:Transaction
+          |vpiName:READ
+          |UINT:1
+        |vpiEnumConst:
+        \_enum_const: (WRITE), line:35, parent:Transaction
+          |vpiName:WRITE
+          |UINT:0
     |vpiIODecl:
     \_io_decl: (burstmode), parent:work@test_program.master_send_commands
       |vpiName:burstmode
       |vpiDirection:1
-      |vpiExpr:
-      \_bit_var: (work@test_program.master_send_commands.burstmode.Burstmode), line:547, col:6, parent:burstmode
+      |vpiTypedef:
+      \_enum_typespec: (Burstmode), line:43, col:5, parent:burstmode
         |vpiName:Burstmode
-        |vpiFullName:work@test_program.master_send_commands.burstmode.Burstmode
-        |vpiTypespec:
-        \_enum_typespec: (Burstmode), line:43, col:5, parent:work@test_program.master_send_commands.burstmode.Burstmode
-          |vpiName:Burstmode
-          |vpiBaseTypespec:
-          \_bit_typespec: , line:39, col:16, parent:Burstmode
-          |vpiEnumConst:
-          \_enum_const: (BURST), line:42, parent:Burstmode
-            |vpiName:BURST
-            |UINT:1
-          |vpiEnumConst:
-          \_enum_const: (NOBURST), line:41, parent:Burstmode
-            |vpiName:NOBURST
-            |UINT:0
+        |vpiBaseTypespec:
+        \_bit_typespec: , line:39, col:16, parent:Burstmode
+        |vpiEnumConst:
+        \_enum_const: (BURST), line:42, parent:Burstmode
+          |vpiName:BURST
+          |UINT:1
+        |vpiEnumConst:
+        \_enum_const: (NOBURST), line:41, parent:Burstmode
+          |vpiName:NOBURST
+          |UINT:0
     |vpiStmt:
     \_begin: (work@test_program.master_send_commands), parent:work@test_program.master_send_commands
       |vpiFullName:work@test_program.master_send_commands
@@ -24829,8 +24065,6 @@ design: (work@top)
           \_ref_obj: (work@test_program.master_send_commands.num_command), line:554, col:26
             |vpiName:num_command
             |vpiFullName:work@test_program.master_send_commands.num_command
-            |vpiActual:
-            \_int_var: (num_command), line:545, col:6, parent:num_command
         |vpiForInitStmt:
         \_assign_stmt: , parent:work@test_program.master_send_commands
           |vpiRhs:
@@ -24940,14 +24174,10 @@ design: (work@top)
               \_ref_obj: (work@test_program.master_send_commands.trans), line:561, col:19, parent:create_command
                 |vpiName:trans
                 |vpiFullName:work@test_program.master_send_commands.trans
-                |vpiActual:
-                \_bit_var: (trans.Transaction), line:546, col:6, parent:trans
               |vpiArgument:
               \_ref_obj: (work@test_program.master_send_commands.burstmode), line:562, col:23, parent:create_command
                 |vpiName:burstmode
                 |vpiFullName:work@test_program.master_send_commands.burstmode
-                |vpiActual:
-                \_bit_var: (burstmode.Burstmode), line:547, col:6, parent:burstmode
               |vpiArgument:
               \_ref_obj: (work@test_program.master_send_commands.slave_id), line:563, col:22, parent:create_command
                 |vpiName:slave_id
@@ -25417,51 +24647,42 @@ design: (work@top)
     \_io_decl: (trans), parent:work@test_program.create_command
       |vpiName:trans
       |vpiDirection:1
-      |vpiExpr:
-      \_bit_var: (work@test_program.create_command.trans.Transaction), line:571, col:6, parent:trans
+      |vpiTypedef:
+      \_enum_typespec: (Transaction), line:37, col:5, parent:trans
         |vpiName:Transaction
-        |vpiFullName:work@test_program.create_command.trans.Transaction
-        |vpiTypespec:
-        \_enum_typespec: (Transaction), line:37, col:5, parent:work@test_program.create_command.trans.Transaction
-          |vpiName:Transaction
-          |vpiBaseTypespec:
-          \_bit_typespec: , line:33, col:16, parent:Transaction
-          |vpiEnumConst:
-          \_enum_const: (READ), line:36, parent:Transaction
-            |vpiName:READ
-            |UINT:1
-          |vpiEnumConst:
-          \_enum_const: (WRITE), line:35, parent:Transaction
-            |vpiName:WRITE
-            |UINT:0
+        |vpiBaseTypespec:
+        \_bit_typespec: , line:33, col:16, parent:Transaction
+        |vpiEnumConst:
+        \_enum_const: (READ), line:36, parent:Transaction
+          |vpiName:READ
+          |UINT:1
+        |vpiEnumConst:
+        \_enum_const: (WRITE), line:35, parent:Transaction
+          |vpiName:WRITE
+          |UINT:0
     |vpiIODecl:
     \_io_decl: (burstmode), parent:work@test_program.create_command
       |vpiName:burstmode
       |vpiDirection:1
-      |vpiExpr:
-      \_bit_var: (work@test_program.create_command.burstmode.Burstmode), line:572, col:6, parent:burstmode
+      |vpiTypedef:
+      \_enum_typespec: (Burstmode), line:43, col:5, parent:burstmode
         |vpiName:Burstmode
-        |vpiFullName:work@test_program.create_command.burstmode.Burstmode
-        |vpiTypespec:
-        \_enum_typespec: (Burstmode), line:43, col:5, parent:work@test_program.create_command.burstmode.Burstmode
-          |vpiName:Burstmode
-          |vpiBaseTypespec:
-          \_bit_typespec: , line:39, col:16, parent:Burstmode
-          |vpiEnumConst:
-          \_enum_const: (BURST), line:42, parent:Burstmode
-            |vpiName:BURST
-            |UINT:1
-          |vpiEnumConst:
-          \_enum_const: (NOBURST), line:41, parent:Burstmode
-            |vpiName:NOBURST
-            |UINT:0
+        |vpiBaseTypespec:
+        \_bit_typespec: , line:39, col:16, parent:Burstmode
+        |vpiEnumConst:
+        \_enum_const: (BURST), line:42, parent:Burstmode
+          |vpiName:BURST
+          |UINT:1
+        |vpiEnumConst:
+        \_enum_const: (NOBURST), line:41, parent:Burstmode
+          |vpiName:NOBURST
+          |UINT:0
     |vpiIODecl:
     \_io_decl: (slave_id), parent:work@test_program.create_command
       |vpiName:slave_id
       |vpiDirection:1
-      |vpiExpr:
-      \_int_var: (work@test_program.create_command.slave_id), line:573, col:6, parent:slave_id
-        |vpiFullName:work@test_program.create_command.slave_id
+      |vpiTypedef:
+      \_int_typespec: , line:573, col:6, parent:slave_id
     |vpiStmt:
     \_begin: (work@test_program.create_command), parent:work@test_program.create_command
       |vpiFullName:work@test_program.create_command
@@ -25474,8 +24695,6 @@ design: (work@top)
           \_ref_obj: (work@test_program.create_command.burstmode), line:578, col:10
             |vpiName:burstmode
             |vpiFullName:work@test_program.create_command.burstmode
-            |vpiActual:
-            \_bit_var: (burstmode.Burstmode), line:572, col:6, parent:burstmode
           |vpiOperand:
           \_ref_obj: (work@test_program.create_command.BURST), line:578, col:23
             |vpiName:BURST
@@ -25527,8 +24746,6 @@ design: (work@top)
         \_ref_obj: (work@test_program.create_command.trans), line:584, col:35
           |vpiName:trans
           |vpiFullName:work@test_program.create_command.trans
-          |vpiActual:
-          \_bit_var: (trans.Transaction), line:571, col:6, parent:trans
       |vpiStmt:
       \_assignment: , line:585, col:6, parent:work@test_program.create_command
         |vpiOpType:82
@@ -25546,8 +24763,6 @@ design: (work@top)
           \_ref_obj: (work@test_program.create_command.slave_id), line:585, col:67, parent:generate_random_aligned_address
             |vpiName:slave_id
             |vpiFullName:work@test_program.create_command.slave_id
-            |vpiActual:
-            \_int_var: (slave_id), line:573, col:6, parent:slave_id
       |vpiStmt:
       \_assignment: , line:586, col:6, parent:work@test_program.create_command
         |vpiOpType:82
@@ -25580,8 +24795,6 @@ design: (work@top)
           \_ref_obj: (work@test_program.create_command.trans), line:588, col:10
             |vpiName:trans
             |vpiFullName:work@test_program.create_command.trans
-            |vpiActual:
-            \_bit_var: (trans.Transaction), line:571, col:6, parent:trans
           |vpiOperand:
           \_ref_obj: (work@test_program.create_command.WRITE), line:588, col:19
             |vpiName:WRITE
@@ -25996,29 +25209,6 @@ design: (work@top)
     \_logic_var: (work@test_program.randomize_burstcount.burstcount), line:603, col:6, parent:work@test_program.randomize_burstcount
       |vpiName:burstcount
       |vpiFullName:work@test_program.randomize_burstcount.burstcount
-      |vpiRange:
-      \_range: , line:31, col:18, parent:work@test_program.randomize_burstcount.burstcount
-        |vpiLeftRange:
-        \_operation: , line:31, col:18
-          |vpiOpType:11
-          |vpiOperand:
-          \_ref_obj: (work@test_program.randomize_burstcount.burstcount.BURST_W), line:31, col:18
-            |vpiName:BURST_W
-            |vpiFullName:work@test_program.randomize_burstcount.burstcount.BURST_W
-            |vpiActual:
-            \_parameter: (work@test_program.BURST_W), line:19, col:14, parent:work@test_program
-          |vpiOperand:
-          \_constant: , line:31, col:26
-            |vpiConstType:9
-            |vpiDecompile:1
-            |vpiSize:64
-            |UINT:1
-        |vpiRightRange:
-        \_constant: , line:31, col:28
-          |vpiConstType:9
-          |vpiDecompile:0
-          |vpiSize:64
-          |UINT:0
       |vpiTypespec:
       \_logic_typespec: (Burstcount), line:31, col:11, parent:work@test_program.randomize_burstcount.burstcount
         |vpiName:Burstcount
@@ -26059,9 +25249,8 @@ design: (work@top)
     \_io_decl: (slave_id), parent:work@test_program.generate_random_aligned_address
       |vpiName:slave_id
       |vpiDirection:1
-      |vpiExpr:
-      \_int_var: (work@test_program.generate_random_aligned_address.slave_id), line:610, col:6, parent:slave_id
-        |vpiFullName:work@test_program.generate_random_aligned_address.slave_id
+      |vpiTypedef:
+      \_int_typespec: , line:610, col:6, parent:slave_id
     |vpiStmt:
     \_begin: (work@test_program.generate_random_aligned_address), parent:work@test_program.generate_random_aligned_address
       |vpiFullName:work@test_program.generate_random_aligned_address
@@ -26082,8 +25271,6 @@ design: (work@top)
           \_ref_obj: (work@test_program.generate_random_aligned_address.slave_id), line:614, col:18
             |vpiName:slave_id
             |vpiFullName:work@test_program.generate_random_aligned_address.slave_id
-            |vpiActual:
-            \_int_var: (slave_id), line:610, col:6, parent:slave_id
           |vpiOperand:
           \_ref_obj: (work@test_program.generate_random_aligned_address.SLAVE_SPAN), line:614, col:29
             |vpiName:SLAVE_SPAN
@@ -26213,34 +25400,56 @@ design: (work@top)
     \_io_decl: (cmd), parent:work@test_program.queue_command
       |vpiName:cmd
       |vpiDirection:1
-      |vpiExpr:
-      \_struct_var: (work@test_program.queue_command.cmd.Command), line:621, col:6, parent:cmd
+      |vpiTypedef:
+      \_struct_typespec: (Command), line:45, col:11, parent:cmd
         |vpiName:Command
-        |vpiFullName:work@test_program.queue_command.cmd.Command
-        |vpiTypespec:
-        \_struct_typespec: (Command), line:45, col:11, parent:work@test_program.queue_command.cmd.Command
-          |vpiName:Command
-          |vpiTypespecMember:
-          \_typespec_member: (trans), line:47, col:36, parent:Command
-            |vpiName:trans
-            |vpiTypespec:
-            \_enum_typespec: (Transaction), line:37, col:5, parent:trans
-              |vpiName:Transaction
-              |vpiBaseTypespec:
-              \_bit_typespec: , line:33, col:16, parent:Transaction
-              |vpiEnumConst:
-              \_enum_const: (READ), line:36, parent:Transaction
-                |vpiName:READ
-                |UINT:1
-              |vpiEnumConst:
-              \_enum_const: (WRITE), line:35, parent:Transaction
-                |vpiName:WRITE
+        |vpiTypespecMember:
+        \_typespec_member: (trans), line:47, col:36, parent:Command
+          |vpiName:trans
+          |vpiTypespec:
+          \_enum_typespec: (Transaction), line:37, col:5, parent:trans
+            |vpiName:Transaction
+            |vpiBaseTypespec:
+            \_bit_typespec: , line:33, col:16, parent:Transaction
+            |vpiEnumConst:
+            \_enum_const: (READ), line:36, parent:Transaction
+              |vpiName:READ
+              |UINT:1
+            |vpiEnumConst:
+            \_enum_const: (WRITE), line:35, parent:Transaction
+              |vpiName:WRITE
+              |UINT:0
+        |vpiTypespecMember:
+        \_typespec_member: (burstcount), line:48, col:36, parent:Command
+          |vpiName:burstcount
+          |vpiTypespec:
+          \_logic_typespec: (Burstcount), line:31, col:11, parent:burstcount
+            |vpiName:Burstcount
+            |vpiRange:
+            \_range: , line:31, col:18, parent:Burstcount
+              |vpiLeftRange:
+              \_operation: , line:31, col:18
+                |vpiOpType:11
+                |vpiOperand:
+                \_ref_obj: (work@test_program.queue_command.cmd.Command.burstcount.Burstcount.BURST_W), line:31, col:18
+                  |vpiName:BURST_W
+                  |vpiFullName:work@test_program.queue_command.cmd.Command.burstcount.Burstcount.BURST_W
+                  |vpiActual:
+                  \_parameter: (work@test_program.BURST_W), line:19, col:14, parent:work@test_program
+                |vpiOperand:
+                \_constant: , line:31, col:26
+                  |vpiConstType:9
+                  |vpiDecompile:1
+                  |vpiSize:64
+                  |UINT:1
+              |vpiRightRange:
+              \_constant: , line:31, col:28
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
                 |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (burstcount), line:48, col:36, parent:Command
-            |vpiName:burstcount
-            |vpiTypespec:
-            \_logic_typespec: (Burstcount), line:31, col:11, parent:burstcount
+            |vpiTypedefAlias:
+            \_logic_typespec: (Burstcount), line:31, col:11, parent:Burstcount
               |vpiName:Burstcount
               |vpiRange:
               \_range: , line:31, col:18, parent:Burstcount
@@ -26248,9 +25457,9 @@ design: (work@top)
                 \_operation: , line:31, col:18
                   |vpiOpType:11
                   |vpiOperand:
-                  \_ref_obj: (work@test_program.queue_command.cmd.Command.Command.burstcount.Burstcount.BURST_W), line:31, col:18
+                  \_ref_obj: (work@test_program.queue_command.cmd.Command.burstcount.Burstcount.Burstcount.BURST_W), line:31, col:18
                     |vpiName:BURST_W
-                    |vpiFullName:work@test_program.queue_command.cmd.Command.Command.burstcount.Burstcount.BURST_W
+                    |vpiFullName:work@test_program.queue_command.cmd.Command.burstcount.Burstcount.Burstcount.BURST_W
                     |vpiActual:
                     \_parameter: (work@test_program.BURST_W), line:19, col:14, parent:work@test_program
                   |vpiOperand:
@@ -26265,168 +25474,140 @@ design: (work@top)
                   |vpiDecompile:0
                   |vpiSize:64
                   |UINT:0
-              |vpiTypedefAlias:
-              \_logic_typespec: (Burstcount), line:31, col:11, parent:Burstcount
-                |vpiName:Burstcount
-                |vpiRange:
-                \_range: , line:31, col:18, parent:Burstcount
-                  |vpiLeftRange:
-                  \_operation: , line:31, col:18
-                    |vpiOpType:11
-                    |vpiOperand:
-                    \_ref_obj: (work@test_program.queue_command.cmd.Command.Command.burstcount.Burstcount.Burstcount.BURST_W), line:31, col:18
-                      |vpiName:BURST_W
-                      |vpiFullName:work@test_program.queue_command.cmd.Command.Command.burstcount.Burstcount.Burstcount.BURST_W
-                      |vpiActual:
-                      \_parameter: (work@test_program.BURST_W), line:19, col:14, parent:work@test_program
-                    |vpiOperand:
-                    \_constant: , line:31, col:26
-                      |vpiConstType:9
-                      |vpiDecompile:1
-                      |vpiSize:64
-                      |UINT:1
-                  |vpiRightRange:
-                  \_constant: , line:31, col:28
-                    |vpiConstType:9
-                    |vpiDecompile:0
-                    |vpiSize:64
-                    |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (addr), line:49, col:36, parent:Command
-            |vpiName:addr
-            |vpiTypespec:
-            \_logic_typespec: , line:49, col:7, parent:addr
-              |vpiRange:
-              \_range: , line:49, col:14
-                |vpiLeftRange:
-                \_operation: , line:49, col:14
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (work@test_program.queue_command.cmd.Command.Command.addr.ADDR_W), line:49, col:14
-                    |vpiName:ADDR_W
-                    |vpiFullName:work@test_program.queue_command.cmd.Command.Command.addr.ADDR_W
-                    |vpiActual:
-                    \_parameter: (work@test_program.ADDR_W), line:13, col:14, parent:work@test_program
-                  |vpiOperand:
-                  \_constant: , line:49, col:21
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:49, col:24
+        |vpiTypespecMember:
+        \_typespec_member: (addr), line:49, col:36, parent:Command
+          |vpiName:addr
+          |vpiTypespec:
+          \_logic_typespec: , line:49, col:7, parent:addr
+            |vpiRange:
+            \_range: , line:49, col:14
+              |vpiLeftRange:
+              \_operation: , line:49, col:14
+                |vpiOpType:11
+                |vpiOperand:
+                \_ref_obj: (work@test_program.queue_command.cmd.Command.addr.ADDR_W), line:49, col:14
+                  |vpiName:ADDR_W
+                  |vpiFullName:work@test_program.queue_command.cmd.Command.addr.ADDR_W
+                  |vpiActual:
+                  \_parameter: (work@test_program.ADDR_W), line:13, col:14, parent:work@test_program
+                |vpiOperand:
+                \_constant: , line:49, col:21
                   |vpiConstType:9
-                  |vpiDecompile:0
+                  |vpiDecompile:1
                   |vpiSize:64
-                  |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (data), line:50, col:36, parent:Command
-            |vpiName:data
-            |vpiTypespec:
-            \_logic_typespec: , line:50, col:7, parent:data
-              |vpiRange:
-              \_range: , line:50, col:14
-                |vpiLeftRange:
-                \_operation: , line:50, col:14
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (work@test_program.queue_command.cmd.Command.Command.data.DATA_W), line:50, col:14
-                    |vpiName:DATA_W
-                    |vpiFullName:work@test_program.queue_command.cmd.Command.Command.data.DATA_W
-                    |vpiActual:
-                    \_parameter: (work@test_program.DATA_W), line:17, col:14, parent:work@test_program
-                  |vpiOperand:
-                  \_constant: , line:50, col:21
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:50, col:23
+                  |UINT:1
+              |vpiRightRange:
+              \_constant: , line:49, col:24
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+        |vpiTypespecMember:
+        \_typespec_member: (data), line:50, col:36, parent:Command
+          |vpiName:data
+          |vpiTypespec:
+          \_logic_typespec: , line:50, col:7, parent:data
+            |vpiRange:
+            \_range: , line:50, col:14
+              |vpiLeftRange:
+              \_operation: , line:50, col:14
+                |vpiOpType:11
+                |vpiOperand:
+                \_ref_obj: (work@test_program.queue_command.cmd.Command.data.DATA_W), line:50, col:14
+                  |vpiName:DATA_W
+                  |vpiFullName:work@test_program.queue_command.cmd.Command.data.DATA_W
+                  |vpiActual:
+                  \_parameter: (work@test_program.DATA_W), line:17, col:14, parent:work@test_program
+                |vpiOperand:
+                \_constant: , line:50, col:21
                   |vpiConstType:9
-                  |vpiDecompile:0
+                  |vpiDecompile:1
                   |vpiSize:64
-                  |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (byteenable), line:51, col:36, parent:Command
-            |vpiName:byteenable
-            |vpiTypespec:
-            \_logic_typespec: , line:51, col:7, parent:byteenable
-              |vpiRange:
-              \_range: , line:51, col:14
-                |vpiLeftRange:
-                \_operation: , line:51, col:14
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (work@test_program.queue_command.cmd.Command.Command.byteenable.NUM_SYMBOLS), line:51, col:14
-                    |vpiName:NUM_SYMBOLS
-                    |vpiFullName:work@test_program.queue_command.cmd.Command.Command.byteenable.NUM_SYMBOLS
-                    |vpiActual:
-                    \_parameter: (work@test_program.NUM_SYMBOLS), line:16, col:14, parent:work@test_program
-                  |vpiOperand:
-                  \_constant: , line:51, col:26
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:51, col:28
+                  |UINT:1
+              |vpiRightRange:
+              \_constant: , line:50, col:23
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+        |vpiTypespecMember:
+        \_typespec_member: (byteenable), line:51, col:36, parent:Command
+          |vpiName:byteenable
+          |vpiTypespec:
+          \_logic_typespec: , line:51, col:7, parent:byteenable
+            |vpiRange:
+            \_range: , line:51, col:14
+              |vpiLeftRange:
+              \_operation: , line:51, col:14
+                |vpiOpType:11
+                |vpiOperand:
+                \_ref_obj: (work@test_program.queue_command.cmd.Command.byteenable.NUM_SYMBOLS), line:51, col:14
+                  |vpiName:NUM_SYMBOLS
+                  |vpiFullName:work@test_program.queue_command.cmd.Command.byteenable.NUM_SYMBOLS
+                  |vpiActual:
+                  \_parameter: (work@test_program.NUM_SYMBOLS), line:16, col:14, parent:work@test_program
+                |vpiOperand:
+                \_constant: , line:51, col:26
                   |vpiConstType:9
-                  |vpiDecompile:0
+                  |vpiDecompile:1
                   |vpiSize:64
-                  |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (cmd_delay), line:52, col:36, parent:Command
-            |vpiName:cmd_delay
-            |vpiTypespec:
-            \_bit_typespec: , line:52, col:7, parent:cmd_delay
-              |vpiRange:
-              \_range: , line:52, col:12
-                |vpiLeftRange:
-                \_constant: , line:52, col:12
-                  |vpiConstType:9
-                  |vpiDecompile:31
-                  |vpiSize:64
-                  |UINT:31
-                |vpiRightRange:
-                \_constant: , line:52, col:15
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (data_idles), line:53, col:36, parent:Command
-            |vpiName:data_idles
-            |vpiTypespec:
-            \_bit_typespec: , line:53, col:7, parent:data_idles
-              |vpiRange:
-              \_range: , line:53, col:12
-                |vpiLeftRange:
-                \_constant: , line:53, col:12
-                  |vpiConstType:9
-                  |vpiDecompile:31
-                  |vpiSize:64
-                  |UINT:31
-                |vpiRightRange:
-                \_constant: , line:53, col:15
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
+                  |UINT:1
+              |vpiRightRange:
+              \_constant: , line:51, col:28
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+        |vpiTypespecMember:
+        \_typespec_member: (cmd_delay), line:52, col:36, parent:Command
+          |vpiName:cmd_delay
+          |vpiTypespec:
+          \_bit_typespec: , line:52, col:7, parent:cmd_delay
+            |vpiRange:
+            \_range: , line:52, col:12
+              |vpiLeftRange:
+              \_constant: , line:52, col:12
+                |vpiConstType:9
+                |vpiDecompile:31
+                |vpiSize:64
+                |UINT:31
+              |vpiRightRange:
+              \_constant: , line:52, col:15
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+        |vpiTypespecMember:
+        \_typespec_member: (data_idles), line:53, col:36, parent:Command
+          |vpiName:data_idles
+          |vpiTypespec:
+          \_bit_typespec: , line:53, col:7, parent:data_idles
+            |vpiRange:
+            \_range: , line:53, col:12
+              |vpiLeftRange:
+              \_constant: , line:53, col:12
+                |vpiConstType:9
+                |vpiDecompile:31
+                |vpiSize:64
+                |UINT:31
+              |vpiRightRange:
+              \_constant: , line:53, col:15
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
     |vpiIODecl:
     \_io_decl: (master_id), parent:work@test_program.queue_command
       |vpiName:master_id
       |vpiDirection:1
-      |vpiExpr:
-      \_int_var: (work@test_program.queue_command.master_id), line:622, col:6, parent:master_id
-        |vpiFullName:work@test_program.queue_command.master_id
+      |vpiTypedef:
+      \_int_typespec: , line:622, col:6, parent:master_id
     |vpiIODecl:
     \_io_decl: (slave_id), parent:work@test_program.queue_command
       |vpiName:slave_id
       |vpiDirection:1
-      |vpiExpr:
-      \_int_var: (work@test_program.queue_command.slave_id), line:623, col:6, parent:slave_id
-        |vpiFullName:work@test_program.queue_command.slave_id
+      |vpiTypedef:
+      \_int_typespec: , line:623, col:6, parent:slave_id
     |vpiStmt:
     \_begin: (work@test_program.queue_command), parent:work@test_program.queue_command
       |vpiFullName:work@test_program.queue_command
@@ -26439,14 +25620,10 @@ design: (work@top)
         \_ref_obj: (work@test_program.queue_command.cmd), line:626, col:26, parent:save_command_master
           |vpiName:cmd
           |vpiFullName:work@test_program.queue_command.cmd
-          |vpiActual:
-          \_struct_var: (cmd.Command), line:621, col:6, parent:cmd
         |vpiArgument:
         \_ref_obj: (work@test_program.queue_command.master_id), line:626, col:31, parent:save_command_master
           |vpiName:master_id
           |vpiFullName:work@test_program.queue_command.master_id
-          |vpiActual:
-          \_int_var: (master_id), line:622, col:6, parent:master_id
       |vpiStmt:
       \_task_call: (save_command_slave), line:627, col:6, parent:work@test_program.queue_command
         |vpiName:save_command_slave
@@ -26456,14 +25633,10 @@ design: (work@top)
         \_ref_obj: (work@test_program.queue_command.cmd), line:627, col:25, parent:save_command_slave
           |vpiName:cmd
           |vpiFullName:work@test_program.queue_command.cmd
-          |vpiActual:
-          \_struct_var: (cmd.Command), line:621, col:6, parent:cmd
         |vpiArgument:
         \_ref_obj: (work@test_program.queue_command.slave_id), line:627, col:30, parent:save_command_slave
           |vpiName:slave_id
           |vpiFullName:work@test_program.queue_command.slave_id
-          |vpiActual:
-          \_int_var: (slave_id), line:623, col:6, parent:slave_id
       |vpiStmt:
       \_task_call: (configure_and_push_command_to_master), line:628, col:6, parent:work@test_program.queue_command
         |vpiName:configure_and_push_command_to_master
@@ -26473,14 +25646,10 @@ design: (work@top)
         \_ref_obj: (work@test_program.queue_command.cmd), line:628, col:43, parent:configure_and_push_command_to_master
           |vpiName:cmd
           |vpiFullName:work@test_program.queue_command.cmd
-          |vpiActual:
-          \_struct_var: (cmd.Command), line:621, col:6, parent:cmd
         |vpiArgument:
         \_ref_obj: (work@test_program.queue_command.master_id), line:628, col:48, parent:configure_and_push_command_to_master
           |vpiName:master_id
           |vpiFullName:work@test_program.queue_command.master_id
-          |vpiActual:
-          \_int_var: (master_id), line:622, col:6, parent:master_id
   |vpiTaskFunc:
   \_task: (work@test_program.save_command_master), line:631, col:3, parent:work@test_program
     |vpiVisibility:1
@@ -26493,34 +25662,56 @@ design: (work@top)
     \_io_decl: (cmd), parent:work@test_program.save_command_master
       |vpiName:cmd
       |vpiDirection:1
-      |vpiExpr:
-      \_struct_var: (work@test_program.save_command_master.cmd.Command), line:632, col:6, parent:cmd
+      |vpiTypedef:
+      \_struct_typespec: (Command), line:45, col:11, parent:cmd
         |vpiName:Command
-        |vpiFullName:work@test_program.save_command_master.cmd.Command
-        |vpiTypespec:
-        \_struct_typespec: (Command), line:45, col:11, parent:work@test_program.save_command_master.cmd.Command
-          |vpiName:Command
-          |vpiTypespecMember:
-          \_typespec_member: (trans), line:47, col:36, parent:Command
-            |vpiName:trans
-            |vpiTypespec:
-            \_enum_typespec: (Transaction), line:37, col:5, parent:trans
-              |vpiName:Transaction
-              |vpiBaseTypespec:
-              \_bit_typespec: , line:33, col:16, parent:Transaction
-              |vpiEnumConst:
-              \_enum_const: (READ), line:36, parent:Transaction
-                |vpiName:READ
-                |UINT:1
-              |vpiEnumConst:
-              \_enum_const: (WRITE), line:35, parent:Transaction
-                |vpiName:WRITE
+        |vpiTypespecMember:
+        \_typespec_member: (trans), line:47, col:36, parent:Command
+          |vpiName:trans
+          |vpiTypespec:
+          \_enum_typespec: (Transaction), line:37, col:5, parent:trans
+            |vpiName:Transaction
+            |vpiBaseTypespec:
+            \_bit_typespec: , line:33, col:16, parent:Transaction
+            |vpiEnumConst:
+            \_enum_const: (READ), line:36, parent:Transaction
+              |vpiName:READ
+              |UINT:1
+            |vpiEnumConst:
+            \_enum_const: (WRITE), line:35, parent:Transaction
+              |vpiName:WRITE
+              |UINT:0
+        |vpiTypespecMember:
+        \_typespec_member: (burstcount), line:48, col:36, parent:Command
+          |vpiName:burstcount
+          |vpiTypespec:
+          \_logic_typespec: (Burstcount), line:31, col:11, parent:burstcount
+            |vpiName:Burstcount
+            |vpiRange:
+            \_range: , line:31, col:18, parent:Burstcount
+              |vpiLeftRange:
+              \_operation: , line:31, col:18
+                |vpiOpType:11
+                |vpiOperand:
+                \_ref_obj: (work@test_program.save_command_master.cmd.Command.burstcount.Burstcount.BURST_W), line:31, col:18
+                  |vpiName:BURST_W
+                  |vpiFullName:work@test_program.save_command_master.cmd.Command.burstcount.Burstcount.BURST_W
+                  |vpiActual:
+                  \_parameter: (work@test_program.BURST_W), line:19, col:14, parent:work@test_program
+                |vpiOperand:
+                \_constant: , line:31, col:26
+                  |vpiConstType:9
+                  |vpiDecompile:1
+                  |vpiSize:64
+                  |UINT:1
+              |vpiRightRange:
+              \_constant: , line:31, col:28
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
                 |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (burstcount), line:48, col:36, parent:Command
-            |vpiName:burstcount
-            |vpiTypespec:
-            \_logic_typespec: (Burstcount), line:31, col:11, parent:burstcount
+            |vpiTypedefAlias:
+            \_logic_typespec: (Burstcount), line:31, col:11, parent:Burstcount
               |vpiName:Burstcount
               |vpiRange:
               \_range: , line:31, col:18, parent:Burstcount
@@ -26528,9 +25719,9 @@ design: (work@top)
                 \_operation: , line:31, col:18
                   |vpiOpType:11
                   |vpiOperand:
-                  \_ref_obj: (work@test_program.save_command_master.cmd.Command.Command.burstcount.Burstcount.BURST_W), line:31, col:18
+                  \_ref_obj: (work@test_program.save_command_master.cmd.Command.burstcount.Burstcount.Burstcount.BURST_W), line:31, col:18
                     |vpiName:BURST_W
-                    |vpiFullName:work@test_program.save_command_master.cmd.Command.Command.burstcount.Burstcount.BURST_W
+                    |vpiFullName:work@test_program.save_command_master.cmd.Command.burstcount.Burstcount.Burstcount.BURST_W
                     |vpiActual:
                     \_parameter: (work@test_program.BURST_W), line:19, col:14, parent:work@test_program
                   |vpiOperand:
@@ -26545,161 +25736,134 @@ design: (work@top)
                   |vpiDecompile:0
                   |vpiSize:64
                   |UINT:0
-              |vpiTypedefAlias:
-              \_logic_typespec: (Burstcount), line:31, col:11, parent:Burstcount
-                |vpiName:Burstcount
-                |vpiRange:
-                \_range: , line:31, col:18, parent:Burstcount
-                  |vpiLeftRange:
-                  \_operation: , line:31, col:18
-                    |vpiOpType:11
-                    |vpiOperand:
-                    \_ref_obj: (work@test_program.save_command_master.cmd.Command.Command.burstcount.Burstcount.Burstcount.BURST_W), line:31, col:18
-                      |vpiName:BURST_W
-                      |vpiFullName:work@test_program.save_command_master.cmd.Command.Command.burstcount.Burstcount.Burstcount.BURST_W
-                      |vpiActual:
-                      \_parameter: (work@test_program.BURST_W), line:19, col:14, parent:work@test_program
-                    |vpiOperand:
-                    \_constant: , line:31, col:26
-                      |vpiConstType:9
-                      |vpiDecompile:1
-                      |vpiSize:64
-                      |UINT:1
-                  |vpiRightRange:
-                  \_constant: , line:31, col:28
-                    |vpiConstType:9
-                    |vpiDecompile:0
-                    |vpiSize:64
-                    |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (addr), line:49, col:36, parent:Command
-            |vpiName:addr
-            |vpiTypespec:
-            \_logic_typespec: , line:49, col:7, parent:addr
-              |vpiRange:
-              \_range: , line:49, col:14
-                |vpiLeftRange:
-                \_operation: , line:49, col:14
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (work@test_program.save_command_master.cmd.Command.Command.addr.ADDR_W), line:49, col:14
-                    |vpiName:ADDR_W
-                    |vpiFullName:work@test_program.save_command_master.cmd.Command.Command.addr.ADDR_W
-                    |vpiActual:
-                    \_parameter: (work@test_program.ADDR_W), line:13, col:14, parent:work@test_program
-                  |vpiOperand:
-                  \_constant: , line:49, col:21
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:49, col:24
+        |vpiTypespecMember:
+        \_typespec_member: (addr), line:49, col:36, parent:Command
+          |vpiName:addr
+          |vpiTypespec:
+          \_logic_typespec: , line:49, col:7, parent:addr
+            |vpiRange:
+            \_range: , line:49, col:14
+              |vpiLeftRange:
+              \_operation: , line:49, col:14
+                |vpiOpType:11
+                |vpiOperand:
+                \_ref_obj: (work@test_program.save_command_master.cmd.Command.addr.ADDR_W), line:49, col:14
+                  |vpiName:ADDR_W
+                  |vpiFullName:work@test_program.save_command_master.cmd.Command.addr.ADDR_W
+                  |vpiActual:
+                  \_parameter: (work@test_program.ADDR_W), line:13, col:14, parent:work@test_program
+                |vpiOperand:
+                \_constant: , line:49, col:21
                   |vpiConstType:9
-                  |vpiDecompile:0
+                  |vpiDecompile:1
                   |vpiSize:64
-                  |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (data), line:50, col:36, parent:Command
-            |vpiName:data
-            |vpiTypespec:
-            \_logic_typespec: , line:50, col:7, parent:data
-              |vpiRange:
-              \_range: , line:50, col:14
-                |vpiLeftRange:
-                \_operation: , line:50, col:14
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (work@test_program.save_command_master.cmd.Command.Command.data.DATA_W), line:50, col:14
-                    |vpiName:DATA_W
-                    |vpiFullName:work@test_program.save_command_master.cmd.Command.Command.data.DATA_W
-                    |vpiActual:
-                    \_parameter: (work@test_program.DATA_W), line:17, col:14, parent:work@test_program
-                  |vpiOperand:
-                  \_constant: , line:50, col:21
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:50, col:23
+                  |UINT:1
+              |vpiRightRange:
+              \_constant: , line:49, col:24
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+        |vpiTypespecMember:
+        \_typespec_member: (data), line:50, col:36, parent:Command
+          |vpiName:data
+          |vpiTypespec:
+          \_logic_typespec: , line:50, col:7, parent:data
+            |vpiRange:
+            \_range: , line:50, col:14
+              |vpiLeftRange:
+              \_operation: , line:50, col:14
+                |vpiOpType:11
+                |vpiOperand:
+                \_ref_obj: (work@test_program.save_command_master.cmd.Command.data.DATA_W), line:50, col:14
+                  |vpiName:DATA_W
+                  |vpiFullName:work@test_program.save_command_master.cmd.Command.data.DATA_W
+                  |vpiActual:
+                  \_parameter: (work@test_program.DATA_W), line:17, col:14, parent:work@test_program
+                |vpiOperand:
+                \_constant: , line:50, col:21
                   |vpiConstType:9
-                  |vpiDecompile:0
+                  |vpiDecompile:1
                   |vpiSize:64
-                  |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (byteenable), line:51, col:36, parent:Command
-            |vpiName:byteenable
-            |vpiTypespec:
-            \_logic_typespec: , line:51, col:7, parent:byteenable
-              |vpiRange:
-              \_range: , line:51, col:14
-                |vpiLeftRange:
-                \_operation: , line:51, col:14
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (work@test_program.save_command_master.cmd.Command.Command.byteenable.NUM_SYMBOLS), line:51, col:14
-                    |vpiName:NUM_SYMBOLS
-                    |vpiFullName:work@test_program.save_command_master.cmd.Command.Command.byteenable.NUM_SYMBOLS
-                    |vpiActual:
-                    \_parameter: (work@test_program.NUM_SYMBOLS), line:16, col:14, parent:work@test_program
-                  |vpiOperand:
-                  \_constant: , line:51, col:26
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:51, col:28
+                  |UINT:1
+              |vpiRightRange:
+              \_constant: , line:50, col:23
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+        |vpiTypespecMember:
+        \_typespec_member: (byteenable), line:51, col:36, parent:Command
+          |vpiName:byteenable
+          |vpiTypespec:
+          \_logic_typespec: , line:51, col:7, parent:byteenable
+            |vpiRange:
+            \_range: , line:51, col:14
+              |vpiLeftRange:
+              \_operation: , line:51, col:14
+                |vpiOpType:11
+                |vpiOperand:
+                \_ref_obj: (work@test_program.save_command_master.cmd.Command.byteenable.NUM_SYMBOLS), line:51, col:14
+                  |vpiName:NUM_SYMBOLS
+                  |vpiFullName:work@test_program.save_command_master.cmd.Command.byteenable.NUM_SYMBOLS
+                  |vpiActual:
+                  \_parameter: (work@test_program.NUM_SYMBOLS), line:16, col:14, parent:work@test_program
+                |vpiOperand:
+                \_constant: , line:51, col:26
                   |vpiConstType:9
-                  |vpiDecompile:0
+                  |vpiDecompile:1
                   |vpiSize:64
-                  |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (cmd_delay), line:52, col:36, parent:Command
-            |vpiName:cmd_delay
-            |vpiTypespec:
-            \_bit_typespec: , line:52, col:7, parent:cmd_delay
-              |vpiRange:
-              \_range: , line:52, col:12
-                |vpiLeftRange:
-                \_constant: , line:52, col:12
-                  |vpiConstType:9
-                  |vpiDecompile:31
-                  |vpiSize:64
-                  |UINT:31
-                |vpiRightRange:
-                \_constant: , line:52, col:15
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (data_idles), line:53, col:36, parent:Command
-            |vpiName:data_idles
-            |vpiTypespec:
-            \_bit_typespec: , line:53, col:7, parent:data_idles
-              |vpiRange:
-              \_range: , line:53, col:12
-                |vpiLeftRange:
-                \_constant: , line:53, col:12
-                  |vpiConstType:9
-                  |vpiDecompile:31
-                  |vpiSize:64
-                  |UINT:31
-                |vpiRightRange:
-                \_constant: , line:53, col:15
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
+                  |UINT:1
+              |vpiRightRange:
+              \_constant: , line:51, col:28
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+        |vpiTypespecMember:
+        \_typespec_member: (cmd_delay), line:52, col:36, parent:Command
+          |vpiName:cmd_delay
+          |vpiTypespec:
+          \_bit_typespec: , line:52, col:7, parent:cmd_delay
+            |vpiRange:
+            \_range: , line:52, col:12
+              |vpiLeftRange:
+              \_constant: , line:52, col:12
+                |vpiConstType:9
+                |vpiDecompile:31
+                |vpiSize:64
+                |UINT:31
+              |vpiRightRange:
+              \_constant: , line:52, col:15
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+        |vpiTypespecMember:
+        \_typespec_member: (data_idles), line:53, col:36, parent:Command
+          |vpiName:data_idles
+          |vpiTypespec:
+          \_bit_typespec: , line:53, col:7, parent:data_idles
+            |vpiRange:
+            \_range: , line:53, col:12
+              |vpiLeftRange:
+              \_constant: , line:53, col:12
+                |vpiConstType:9
+                |vpiDecompile:31
+                |vpiSize:64
+                |UINT:31
+              |vpiRightRange:
+              \_constant: , line:53, col:15
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
     |vpiIODecl:
     \_io_decl: (master_id), parent:work@test_program.save_command_master
       |vpiName:master_id
       |vpiDirection:1
-      |vpiExpr:
-      \_int_var: (work@test_program.save_command_master.master_id), line:633, col:6, parent:master_id
-        |vpiFullName:work@test_program.save_command_master.master_id
+      |vpiTypedef:
+      \_int_typespec: , line:633, col:6, parent:master_id
     |vpiStmt:
     \_if_else: , line:636, col:9, parent:work@test_program.save_command_master
       |vpiCondition:
@@ -26711,8 +25875,6 @@ design: (work@top)
           |vpiActual:
           \_ref_obj: (cmd), parent:cmd.trans
             |vpiName:cmd
-            |vpiActual:
-            \_struct_var: (cmd.Command), line:632, col:6, parent:cmd
           |vpiActual:
           \_ref_obj: (trans), parent:cmd.trans
             |vpiName:trans
@@ -26787,8 +25949,6 @@ design: (work@top)
           \_ref_obj: (work@test_program.save_command_master.cmd), line:637, col:60, parent:push_back
             |vpiName:cmd
             |vpiFullName:work@test_program.save_command_master.cmd
-            |vpiActual:
-            \_struct_var: (cmd.Command), line:632, col:6, parent:cmd
       |vpiElseStmt:
       \_begin: (work@test_program.save_command_master), line:638, col:18
         |vpiFullName:work@test_program.save_command_master
@@ -26854,8 +26014,6 @@ design: (work@top)
           \_ref_obj: (work@test_program.save_command_master.cmd), line:639, col:59, parent:push_back
             |vpiName:cmd
             |vpiFullName:work@test_program.save_command_master.cmd
-            |vpiActual:
-            \_struct_var: (cmd.Command), line:632, col:6, parent:cmd
   |vpiTaskFunc:
   \_task: (work@test_program.save_command_slave), line:644, col:3, parent:work@test_program
     |vpiVisibility:1
@@ -26868,34 +26026,56 @@ design: (work@top)
     \_io_decl: (cmd), parent:work@test_program.save_command_slave
       |vpiName:cmd
       |vpiDirection:1
-      |vpiExpr:
-      \_struct_var: (work@test_program.save_command_slave.cmd.Command), line:645, col:6, parent:cmd
+      |vpiTypedef:
+      \_struct_typespec: (Command), line:45, col:11, parent:cmd
         |vpiName:Command
-        |vpiFullName:work@test_program.save_command_slave.cmd.Command
-        |vpiTypespec:
-        \_struct_typespec: (Command), line:45, col:11, parent:work@test_program.save_command_slave.cmd.Command
-          |vpiName:Command
-          |vpiTypespecMember:
-          \_typespec_member: (trans), line:47, col:36, parent:Command
-            |vpiName:trans
-            |vpiTypespec:
-            \_enum_typespec: (Transaction), line:37, col:5, parent:trans
-              |vpiName:Transaction
-              |vpiBaseTypespec:
-              \_bit_typespec: , line:33, col:16, parent:Transaction
-              |vpiEnumConst:
-              \_enum_const: (READ), line:36, parent:Transaction
-                |vpiName:READ
-                |UINT:1
-              |vpiEnumConst:
-              \_enum_const: (WRITE), line:35, parent:Transaction
-                |vpiName:WRITE
+        |vpiTypespecMember:
+        \_typespec_member: (trans), line:47, col:36, parent:Command
+          |vpiName:trans
+          |vpiTypespec:
+          \_enum_typespec: (Transaction), line:37, col:5, parent:trans
+            |vpiName:Transaction
+            |vpiBaseTypespec:
+            \_bit_typespec: , line:33, col:16, parent:Transaction
+            |vpiEnumConst:
+            \_enum_const: (READ), line:36, parent:Transaction
+              |vpiName:READ
+              |UINT:1
+            |vpiEnumConst:
+            \_enum_const: (WRITE), line:35, parent:Transaction
+              |vpiName:WRITE
+              |UINT:0
+        |vpiTypespecMember:
+        \_typespec_member: (burstcount), line:48, col:36, parent:Command
+          |vpiName:burstcount
+          |vpiTypespec:
+          \_logic_typespec: (Burstcount), line:31, col:11, parent:burstcount
+            |vpiName:Burstcount
+            |vpiRange:
+            \_range: , line:31, col:18, parent:Burstcount
+              |vpiLeftRange:
+              \_operation: , line:31, col:18
+                |vpiOpType:11
+                |vpiOperand:
+                \_ref_obj: (work@test_program.save_command_slave.cmd.Command.burstcount.Burstcount.BURST_W), line:31, col:18
+                  |vpiName:BURST_W
+                  |vpiFullName:work@test_program.save_command_slave.cmd.Command.burstcount.Burstcount.BURST_W
+                  |vpiActual:
+                  \_parameter: (work@test_program.BURST_W), line:19, col:14, parent:work@test_program
+                |vpiOperand:
+                \_constant: , line:31, col:26
+                  |vpiConstType:9
+                  |vpiDecompile:1
+                  |vpiSize:64
+                  |UINT:1
+              |vpiRightRange:
+              \_constant: , line:31, col:28
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
                 |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (burstcount), line:48, col:36, parent:Command
-            |vpiName:burstcount
-            |vpiTypespec:
-            \_logic_typespec: (Burstcount), line:31, col:11, parent:burstcount
+            |vpiTypedefAlias:
+            \_logic_typespec: (Burstcount), line:31, col:11, parent:Burstcount
               |vpiName:Burstcount
               |vpiRange:
               \_range: , line:31, col:18, parent:Burstcount
@@ -26903,9 +26083,9 @@ design: (work@top)
                 \_operation: , line:31, col:18
                   |vpiOpType:11
                   |vpiOperand:
-                  \_ref_obj: (work@test_program.save_command_slave.cmd.Command.Command.burstcount.Burstcount.BURST_W), line:31, col:18
+                  \_ref_obj: (work@test_program.save_command_slave.cmd.Command.burstcount.Burstcount.Burstcount.BURST_W), line:31, col:18
                     |vpiName:BURST_W
-                    |vpiFullName:work@test_program.save_command_slave.cmd.Command.Command.burstcount.Burstcount.BURST_W
+                    |vpiFullName:work@test_program.save_command_slave.cmd.Command.burstcount.Burstcount.Burstcount.BURST_W
                     |vpiActual:
                     \_parameter: (work@test_program.BURST_W), line:19, col:14, parent:work@test_program
                   |vpiOperand:
@@ -26920,161 +26100,134 @@ design: (work@top)
                   |vpiDecompile:0
                   |vpiSize:64
                   |UINT:0
-              |vpiTypedefAlias:
-              \_logic_typespec: (Burstcount), line:31, col:11, parent:Burstcount
-                |vpiName:Burstcount
-                |vpiRange:
-                \_range: , line:31, col:18, parent:Burstcount
-                  |vpiLeftRange:
-                  \_operation: , line:31, col:18
-                    |vpiOpType:11
-                    |vpiOperand:
-                    \_ref_obj: (work@test_program.save_command_slave.cmd.Command.Command.burstcount.Burstcount.Burstcount.BURST_W), line:31, col:18
-                      |vpiName:BURST_W
-                      |vpiFullName:work@test_program.save_command_slave.cmd.Command.Command.burstcount.Burstcount.Burstcount.BURST_W
-                      |vpiActual:
-                      \_parameter: (work@test_program.BURST_W), line:19, col:14, parent:work@test_program
-                    |vpiOperand:
-                    \_constant: , line:31, col:26
-                      |vpiConstType:9
-                      |vpiDecompile:1
-                      |vpiSize:64
-                      |UINT:1
-                  |vpiRightRange:
-                  \_constant: , line:31, col:28
-                    |vpiConstType:9
-                    |vpiDecompile:0
-                    |vpiSize:64
-                    |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (addr), line:49, col:36, parent:Command
-            |vpiName:addr
-            |vpiTypespec:
-            \_logic_typespec: , line:49, col:7, parent:addr
-              |vpiRange:
-              \_range: , line:49, col:14
-                |vpiLeftRange:
-                \_operation: , line:49, col:14
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (work@test_program.save_command_slave.cmd.Command.Command.addr.ADDR_W), line:49, col:14
-                    |vpiName:ADDR_W
-                    |vpiFullName:work@test_program.save_command_slave.cmd.Command.Command.addr.ADDR_W
-                    |vpiActual:
-                    \_parameter: (work@test_program.ADDR_W), line:13, col:14, parent:work@test_program
-                  |vpiOperand:
-                  \_constant: , line:49, col:21
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:49, col:24
+        |vpiTypespecMember:
+        \_typespec_member: (addr), line:49, col:36, parent:Command
+          |vpiName:addr
+          |vpiTypespec:
+          \_logic_typespec: , line:49, col:7, parent:addr
+            |vpiRange:
+            \_range: , line:49, col:14
+              |vpiLeftRange:
+              \_operation: , line:49, col:14
+                |vpiOpType:11
+                |vpiOperand:
+                \_ref_obj: (work@test_program.save_command_slave.cmd.Command.addr.ADDR_W), line:49, col:14
+                  |vpiName:ADDR_W
+                  |vpiFullName:work@test_program.save_command_slave.cmd.Command.addr.ADDR_W
+                  |vpiActual:
+                  \_parameter: (work@test_program.ADDR_W), line:13, col:14, parent:work@test_program
+                |vpiOperand:
+                \_constant: , line:49, col:21
                   |vpiConstType:9
-                  |vpiDecompile:0
+                  |vpiDecompile:1
                   |vpiSize:64
-                  |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (data), line:50, col:36, parent:Command
-            |vpiName:data
-            |vpiTypespec:
-            \_logic_typespec: , line:50, col:7, parent:data
-              |vpiRange:
-              \_range: , line:50, col:14
-                |vpiLeftRange:
-                \_operation: , line:50, col:14
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (work@test_program.save_command_slave.cmd.Command.Command.data.DATA_W), line:50, col:14
-                    |vpiName:DATA_W
-                    |vpiFullName:work@test_program.save_command_slave.cmd.Command.Command.data.DATA_W
-                    |vpiActual:
-                    \_parameter: (work@test_program.DATA_W), line:17, col:14, parent:work@test_program
-                  |vpiOperand:
-                  \_constant: , line:50, col:21
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:50, col:23
+                  |UINT:1
+              |vpiRightRange:
+              \_constant: , line:49, col:24
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+        |vpiTypespecMember:
+        \_typespec_member: (data), line:50, col:36, parent:Command
+          |vpiName:data
+          |vpiTypespec:
+          \_logic_typespec: , line:50, col:7, parent:data
+            |vpiRange:
+            \_range: , line:50, col:14
+              |vpiLeftRange:
+              \_operation: , line:50, col:14
+                |vpiOpType:11
+                |vpiOperand:
+                \_ref_obj: (work@test_program.save_command_slave.cmd.Command.data.DATA_W), line:50, col:14
+                  |vpiName:DATA_W
+                  |vpiFullName:work@test_program.save_command_slave.cmd.Command.data.DATA_W
+                  |vpiActual:
+                  \_parameter: (work@test_program.DATA_W), line:17, col:14, parent:work@test_program
+                |vpiOperand:
+                \_constant: , line:50, col:21
                   |vpiConstType:9
-                  |vpiDecompile:0
+                  |vpiDecompile:1
                   |vpiSize:64
-                  |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (byteenable), line:51, col:36, parent:Command
-            |vpiName:byteenable
-            |vpiTypespec:
-            \_logic_typespec: , line:51, col:7, parent:byteenable
-              |vpiRange:
-              \_range: , line:51, col:14
-                |vpiLeftRange:
-                \_operation: , line:51, col:14
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (work@test_program.save_command_slave.cmd.Command.Command.byteenable.NUM_SYMBOLS), line:51, col:14
-                    |vpiName:NUM_SYMBOLS
-                    |vpiFullName:work@test_program.save_command_slave.cmd.Command.Command.byteenable.NUM_SYMBOLS
-                    |vpiActual:
-                    \_parameter: (work@test_program.NUM_SYMBOLS), line:16, col:14, parent:work@test_program
-                  |vpiOperand:
-                  \_constant: , line:51, col:26
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:51, col:28
+                  |UINT:1
+              |vpiRightRange:
+              \_constant: , line:50, col:23
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+        |vpiTypespecMember:
+        \_typespec_member: (byteenable), line:51, col:36, parent:Command
+          |vpiName:byteenable
+          |vpiTypespec:
+          \_logic_typespec: , line:51, col:7, parent:byteenable
+            |vpiRange:
+            \_range: , line:51, col:14
+              |vpiLeftRange:
+              \_operation: , line:51, col:14
+                |vpiOpType:11
+                |vpiOperand:
+                \_ref_obj: (work@test_program.save_command_slave.cmd.Command.byteenable.NUM_SYMBOLS), line:51, col:14
+                  |vpiName:NUM_SYMBOLS
+                  |vpiFullName:work@test_program.save_command_slave.cmd.Command.byteenable.NUM_SYMBOLS
+                  |vpiActual:
+                  \_parameter: (work@test_program.NUM_SYMBOLS), line:16, col:14, parent:work@test_program
+                |vpiOperand:
+                \_constant: , line:51, col:26
                   |vpiConstType:9
-                  |vpiDecompile:0
+                  |vpiDecompile:1
                   |vpiSize:64
-                  |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (cmd_delay), line:52, col:36, parent:Command
-            |vpiName:cmd_delay
-            |vpiTypespec:
-            \_bit_typespec: , line:52, col:7, parent:cmd_delay
-              |vpiRange:
-              \_range: , line:52, col:12
-                |vpiLeftRange:
-                \_constant: , line:52, col:12
-                  |vpiConstType:9
-                  |vpiDecompile:31
-                  |vpiSize:64
-                  |UINT:31
-                |vpiRightRange:
-                \_constant: , line:52, col:15
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (data_idles), line:53, col:36, parent:Command
-            |vpiName:data_idles
-            |vpiTypespec:
-            \_bit_typespec: , line:53, col:7, parent:data_idles
-              |vpiRange:
-              \_range: , line:53, col:12
-                |vpiLeftRange:
-                \_constant: , line:53, col:12
-                  |vpiConstType:9
-                  |vpiDecompile:31
-                  |vpiSize:64
-                  |UINT:31
-                |vpiRightRange:
-                \_constant: , line:53, col:15
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
+                  |UINT:1
+              |vpiRightRange:
+              \_constant: , line:51, col:28
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+        |vpiTypespecMember:
+        \_typespec_member: (cmd_delay), line:52, col:36, parent:Command
+          |vpiName:cmd_delay
+          |vpiTypespec:
+          \_bit_typespec: , line:52, col:7, parent:cmd_delay
+            |vpiRange:
+            \_range: , line:52, col:12
+              |vpiLeftRange:
+              \_constant: , line:52, col:12
+                |vpiConstType:9
+                |vpiDecompile:31
+                |vpiSize:64
+                |UINT:31
+              |vpiRightRange:
+              \_constant: , line:52, col:15
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+        |vpiTypespecMember:
+        \_typespec_member: (data_idles), line:53, col:36, parent:Command
+          |vpiName:data_idles
+          |vpiTypespec:
+          \_bit_typespec: , line:53, col:7, parent:data_idles
+            |vpiRange:
+            \_range: , line:53, col:12
+              |vpiLeftRange:
+              \_constant: , line:53, col:12
+                |vpiConstType:9
+                |vpiDecompile:31
+                |vpiSize:64
+                |UINT:31
+              |vpiRightRange:
+              \_constant: , line:53, col:15
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
     |vpiIODecl:
     \_io_decl: (slave_id), parent:work@test_program.save_command_slave
       |vpiName:slave_id
       |vpiDirection:1
-      |vpiExpr:
-      \_int_var: (work@test_program.save_command_slave.slave_id), line:646, col:6, parent:slave_id
-        |vpiFullName:work@test_program.save_command_slave.slave_id
+      |vpiTypedef:
+      \_int_typespec: , line:646, col:6, parent:slave_id
     |vpiStmt:
     \_begin: (work@test_program.save_command_slave), parent:work@test_program.save_command_slave
       |vpiFullName:work@test_program.save_command_slave
@@ -27097,8 +26250,6 @@ design: (work@top)
             |vpiActual:
             \_ref_obj: (cmd), parent:cmd.addr
               |vpiName:cmd
-              |vpiActual:
-              \_struct_var: (cmd.Command), line:645, col:6, parent:cmd
             |vpiActual:
             \_ref_obj: (addr), parent:cmd.addr
               |vpiName:addr
@@ -27113,8 +26264,6 @@ design: (work@top)
             |vpiActual:
             \_ref_obj: (cmd), parent:cmd.trans
               |vpiName:cmd
-              |vpiActual:
-              \_struct_var: (cmd.Command), line:645, col:6, parent:cmd
             |vpiActual:
             \_ref_obj: (trans), parent:cmd.trans
               |vpiName:trans
@@ -27189,8 +26338,6 @@ design: (work@top)
             \_ref_obj: (work@test_program.save_command_slave.cmd), line:651, col:55, parent:push_back
               |vpiName:cmd
               |vpiFullName:work@test_program.save_command_slave.cmd
-              |vpiActual:
-              \_struct_var: (cmd.Command), line:645, col:6, parent:cmd
         |vpiElseStmt:
         \_begin: (work@test_program.save_command_slave), line:652, col:15
           |vpiFullName:work@test_program.save_command_slave
@@ -27256,8 +26403,6 @@ design: (work@top)
             \_ref_obj: (work@test_program.save_command_slave.cmd), line:653, col:54, parent:push_back
               |vpiName:cmd
               |vpiFullName:work@test_program.save_command_slave.cmd
-              |vpiActual:
-              \_struct_var: (cmd.Command), line:645, col:6, parent:cmd
   |vpiTaskFunc:
   \_function: (work@test_program.translate_master_to_slave_address), line:658, col:3, parent:work@test_program
     |vpiVisibility:1
@@ -27272,17 +26417,25 @@ design: (work@top)
     \_io_decl: (addr), parent:work@test_program.translate_master_to_slave_address
       |vpiName:addr
       |vpiDirection:1
-      |vpiExpr:
-      \_logic_var: (work@test_program.translate_master_to_slave_address.addr), line:659, col:6, parent:addr
-        |vpiFullName:work@test_program.translate_master_to_slave_address.addr
+      |vpiTypedef:
+      \_logic_typespec: , line:659, col:6, parent:addr
         |vpiRange:
-        \_range: , line:659, col:13, parent:work@test_program.translate_master_to_slave_address.addr
+        \_range: , line:659, col:13
           |vpiLeftRange:
-          \_constant: , line:659, col:13
-            |vpiConstType:7
-            |vpiDecompile:12
-            |vpiSize:64
-            |INT:12
+          \_operation: , line:659, col:13
+            |vpiOpType:11
+            |vpiOperand:
+            \_ref_obj: (work@test_program.translate_master_to_slave_address.addr.ADDR_W), line:659, col:13
+              |vpiName:ADDR_W
+              |vpiFullName:work@test_program.translate_master_to_slave_address.addr.ADDR_W
+              |vpiActual:
+              \_parameter: (work@test_program.ADDR_W), line:13, col:14, parent:work@test_program
+            |vpiOperand:
+            \_constant: , line:659, col:20
+              |vpiConstType:9
+              |vpiDecompile:1
+              |vpiSize:64
+              |UINT:1
           |vpiRightRange:
           \_constant: , line:659, col:23
             |vpiConstType:9
@@ -27301,8 +26454,6 @@ design: (work@top)
           \_ref_obj: (work@test_program.translate_master_to_slave_address.addr), line:661, col:21
             |vpiName:addr
             |vpiFullName:work@test_program.translate_master_to_slave_address.addr
-            |vpiActual:
-            \_logic_var: (addr), line:659, col:6, parent:addr
           |vpiOperand:
           \_ref_obj: (work@test_program.translate_master_to_slave_address.SLAVE_SPAN), line:661, col:28
             |vpiName:SLAVE_SPAN
@@ -27353,8 +26504,6 @@ design: (work@top)
           \_ref_obj: (work@test_program.translate_master_to_slave_address.addr), line:665, col:15
             |vpiName:addr
             |vpiFullName:work@test_program.translate_master_to_slave_address.addr
-            |vpiActual:
-            \_logic_var: (addr), line:659, col:6, parent:addr
           |vpiOperand:
           \_ref_obj: (work@test_program.translate_master_to_slave_address.base_addr), line:665, col:22
             |vpiName:base_addr
@@ -27444,34 +26593,56 @@ design: (work@top)
     \_io_decl: (cmd), parent:work@test_program.configure_and_push_command_to_master
       |vpiName:cmd
       |vpiDirection:1
-      |vpiExpr:
-      \_struct_var: (work@test_program.configure_and_push_command_to_master.cmd.Command), line:671, col:6, parent:cmd
+      |vpiTypedef:
+      \_struct_typespec: (Command), line:45, col:11, parent:cmd
         |vpiName:Command
-        |vpiFullName:work@test_program.configure_and_push_command_to_master.cmd.Command
-        |vpiTypespec:
-        \_struct_typespec: (Command), line:45, col:11, parent:work@test_program.configure_and_push_command_to_master.cmd.Command
-          |vpiName:Command
-          |vpiTypespecMember:
-          \_typespec_member: (trans), line:47, col:36, parent:Command
-            |vpiName:trans
-            |vpiTypespec:
-            \_enum_typespec: (Transaction), line:37, col:5, parent:trans
-              |vpiName:Transaction
-              |vpiBaseTypespec:
-              \_bit_typespec: , line:33, col:16, parent:Transaction
-              |vpiEnumConst:
-              \_enum_const: (READ), line:36, parent:Transaction
-                |vpiName:READ
-                |UINT:1
-              |vpiEnumConst:
-              \_enum_const: (WRITE), line:35, parent:Transaction
-                |vpiName:WRITE
+        |vpiTypespecMember:
+        \_typespec_member: (trans), line:47, col:36, parent:Command
+          |vpiName:trans
+          |vpiTypespec:
+          \_enum_typespec: (Transaction), line:37, col:5, parent:trans
+            |vpiName:Transaction
+            |vpiBaseTypespec:
+            \_bit_typespec: , line:33, col:16, parent:Transaction
+            |vpiEnumConst:
+            \_enum_const: (READ), line:36, parent:Transaction
+              |vpiName:READ
+              |UINT:1
+            |vpiEnumConst:
+            \_enum_const: (WRITE), line:35, parent:Transaction
+              |vpiName:WRITE
+              |UINT:0
+        |vpiTypespecMember:
+        \_typespec_member: (burstcount), line:48, col:36, parent:Command
+          |vpiName:burstcount
+          |vpiTypespec:
+          \_logic_typespec: (Burstcount), line:31, col:11, parent:burstcount
+            |vpiName:Burstcount
+            |vpiRange:
+            \_range: , line:31, col:18, parent:Burstcount
+              |vpiLeftRange:
+              \_operation: , line:31, col:18
+                |vpiOpType:11
+                |vpiOperand:
+                \_ref_obj: (work@test_program.configure_and_push_command_to_master.cmd.Command.burstcount.Burstcount.BURST_W), line:31, col:18
+                  |vpiName:BURST_W
+                  |vpiFullName:work@test_program.configure_and_push_command_to_master.cmd.Command.burstcount.Burstcount.BURST_W
+                  |vpiActual:
+                  \_parameter: (work@test_program.BURST_W), line:19, col:14, parent:work@test_program
+                |vpiOperand:
+                \_constant: , line:31, col:26
+                  |vpiConstType:9
+                  |vpiDecompile:1
+                  |vpiSize:64
+                  |UINT:1
+              |vpiRightRange:
+              \_constant: , line:31, col:28
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
                 |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (burstcount), line:48, col:36, parent:Command
-            |vpiName:burstcount
-            |vpiTypespec:
-            \_logic_typespec: (Burstcount), line:31, col:11, parent:burstcount
+            |vpiTypedefAlias:
+            \_logic_typespec: (Burstcount), line:31, col:11, parent:Burstcount
               |vpiName:Burstcount
               |vpiRange:
               \_range: , line:31, col:18, parent:Burstcount
@@ -27479,9 +26650,9 @@ design: (work@top)
                 \_operation: , line:31, col:18
                   |vpiOpType:11
                   |vpiOperand:
-                  \_ref_obj: (work@test_program.configure_and_push_command_to_master.cmd.Command.Command.burstcount.Burstcount.BURST_W), line:31, col:18
+                  \_ref_obj: (work@test_program.configure_and_push_command_to_master.cmd.Command.burstcount.Burstcount.Burstcount.BURST_W), line:31, col:18
                     |vpiName:BURST_W
-                    |vpiFullName:work@test_program.configure_and_push_command_to_master.cmd.Command.Command.burstcount.Burstcount.BURST_W
+                    |vpiFullName:work@test_program.configure_and_push_command_to_master.cmd.Command.burstcount.Burstcount.Burstcount.BURST_W
                     |vpiActual:
                     \_parameter: (work@test_program.BURST_W), line:19, col:14, parent:work@test_program
                   |vpiOperand:
@@ -27496,161 +26667,134 @@ design: (work@top)
                   |vpiDecompile:0
                   |vpiSize:64
                   |UINT:0
-              |vpiTypedefAlias:
-              \_logic_typespec: (Burstcount), line:31, col:11, parent:Burstcount
-                |vpiName:Burstcount
-                |vpiRange:
-                \_range: , line:31, col:18, parent:Burstcount
-                  |vpiLeftRange:
-                  \_operation: , line:31, col:18
-                    |vpiOpType:11
-                    |vpiOperand:
-                    \_ref_obj: (work@test_program.configure_and_push_command_to_master.cmd.Command.Command.burstcount.Burstcount.Burstcount.BURST_W), line:31, col:18
-                      |vpiName:BURST_W
-                      |vpiFullName:work@test_program.configure_and_push_command_to_master.cmd.Command.Command.burstcount.Burstcount.Burstcount.BURST_W
-                      |vpiActual:
-                      \_parameter: (work@test_program.BURST_W), line:19, col:14, parent:work@test_program
-                    |vpiOperand:
-                    \_constant: , line:31, col:26
-                      |vpiConstType:9
-                      |vpiDecompile:1
-                      |vpiSize:64
-                      |UINT:1
-                  |vpiRightRange:
-                  \_constant: , line:31, col:28
-                    |vpiConstType:9
-                    |vpiDecompile:0
-                    |vpiSize:64
-                    |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (addr), line:49, col:36, parent:Command
-            |vpiName:addr
-            |vpiTypespec:
-            \_logic_typespec: , line:49, col:7, parent:addr
-              |vpiRange:
-              \_range: , line:49, col:14
-                |vpiLeftRange:
-                \_operation: , line:49, col:14
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (work@test_program.configure_and_push_command_to_master.cmd.Command.Command.addr.ADDR_W), line:49, col:14
-                    |vpiName:ADDR_W
-                    |vpiFullName:work@test_program.configure_and_push_command_to_master.cmd.Command.Command.addr.ADDR_W
-                    |vpiActual:
-                    \_parameter: (work@test_program.ADDR_W), line:13, col:14, parent:work@test_program
-                  |vpiOperand:
-                  \_constant: , line:49, col:21
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:49, col:24
+        |vpiTypespecMember:
+        \_typespec_member: (addr), line:49, col:36, parent:Command
+          |vpiName:addr
+          |vpiTypespec:
+          \_logic_typespec: , line:49, col:7, parent:addr
+            |vpiRange:
+            \_range: , line:49, col:14
+              |vpiLeftRange:
+              \_operation: , line:49, col:14
+                |vpiOpType:11
+                |vpiOperand:
+                \_ref_obj: (work@test_program.configure_and_push_command_to_master.cmd.Command.addr.ADDR_W), line:49, col:14
+                  |vpiName:ADDR_W
+                  |vpiFullName:work@test_program.configure_and_push_command_to_master.cmd.Command.addr.ADDR_W
+                  |vpiActual:
+                  \_parameter: (work@test_program.ADDR_W), line:13, col:14, parent:work@test_program
+                |vpiOperand:
+                \_constant: , line:49, col:21
                   |vpiConstType:9
-                  |vpiDecompile:0
+                  |vpiDecompile:1
                   |vpiSize:64
-                  |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (data), line:50, col:36, parent:Command
-            |vpiName:data
-            |vpiTypespec:
-            \_logic_typespec: , line:50, col:7, parent:data
-              |vpiRange:
-              \_range: , line:50, col:14
-                |vpiLeftRange:
-                \_operation: , line:50, col:14
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (work@test_program.configure_and_push_command_to_master.cmd.Command.Command.data.DATA_W), line:50, col:14
-                    |vpiName:DATA_W
-                    |vpiFullName:work@test_program.configure_and_push_command_to_master.cmd.Command.Command.data.DATA_W
-                    |vpiActual:
-                    \_parameter: (work@test_program.DATA_W), line:17, col:14, parent:work@test_program
-                  |vpiOperand:
-                  \_constant: , line:50, col:21
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:50, col:23
+                  |UINT:1
+              |vpiRightRange:
+              \_constant: , line:49, col:24
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+        |vpiTypespecMember:
+        \_typespec_member: (data), line:50, col:36, parent:Command
+          |vpiName:data
+          |vpiTypespec:
+          \_logic_typespec: , line:50, col:7, parent:data
+            |vpiRange:
+            \_range: , line:50, col:14
+              |vpiLeftRange:
+              \_operation: , line:50, col:14
+                |vpiOpType:11
+                |vpiOperand:
+                \_ref_obj: (work@test_program.configure_and_push_command_to_master.cmd.Command.data.DATA_W), line:50, col:14
+                  |vpiName:DATA_W
+                  |vpiFullName:work@test_program.configure_and_push_command_to_master.cmd.Command.data.DATA_W
+                  |vpiActual:
+                  \_parameter: (work@test_program.DATA_W), line:17, col:14, parent:work@test_program
+                |vpiOperand:
+                \_constant: , line:50, col:21
                   |vpiConstType:9
-                  |vpiDecompile:0
+                  |vpiDecompile:1
                   |vpiSize:64
-                  |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (byteenable), line:51, col:36, parent:Command
-            |vpiName:byteenable
-            |vpiTypespec:
-            \_logic_typespec: , line:51, col:7, parent:byteenable
-              |vpiRange:
-              \_range: , line:51, col:14
-                |vpiLeftRange:
-                \_operation: , line:51, col:14
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (work@test_program.configure_and_push_command_to_master.cmd.Command.Command.byteenable.NUM_SYMBOLS), line:51, col:14
-                    |vpiName:NUM_SYMBOLS
-                    |vpiFullName:work@test_program.configure_and_push_command_to_master.cmd.Command.Command.byteenable.NUM_SYMBOLS
-                    |vpiActual:
-                    \_parameter: (work@test_program.NUM_SYMBOLS), line:16, col:14, parent:work@test_program
-                  |vpiOperand:
-                  \_constant: , line:51, col:26
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:51, col:28
+                  |UINT:1
+              |vpiRightRange:
+              \_constant: , line:50, col:23
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+        |vpiTypespecMember:
+        \_typespec_member: (byteenable), line:51, col:36, parent:Command
+          |vpiName:byteenable
+          |vpiTypespec:
+          \_logic_typespec: , line:51, col:7, parent:byteenable
+            |vpiRange:
+            \_range: , line:51, col:14
+              |vpiLeftRange:
+              \_operation: , line:51, col:14
+                |vpiOpType:11
+                |vpiOperand:
+                \_ref_obj: (work@test_program.configure_and_push_command_to_master.cmd.Command.byteenable.NUM_SYMBOLS), line:51, col:14
+                  |vpiName:NUM_SYMBOLS
+                  |vpiFullName:work@test_program.configure_and_push_command_to_master.cmd.Command.byteenable.NUM_SYMBOLS
+                  |vpiActual:
+                  \_parameter: (work@test_program.NUM_SYMBOLS), line:16, col:14, parent:work@test_program
+                |vpiOperand:
+                \_constant: , line:51, col:26
                   |vpiConstType:9
-                  |vpiDecompile:0
+                  |vpiDecompile:1
                   |vpiSize:64
-                  |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (cmd_delay), line:52, col:36, parent:Command
-            |vpiName:cmd_delay
-            |vpiTypespec:
-            \_bit_typespec: , line:52, col:7, parent:cmd_delay
-              |vpiRange:
-              \_range: , line:52, col:12
-                |vpiLeftRange:
-                \_constant: , line:52, col:12
-                  |vpiConstType:9
-                  |vpiDecompile:31
-                  |vpiSize:64
-                  |UINT:31
-                |vpiRightRange:
-                \_constant: , line:52, col:15
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (data_idles), line:53, col:36, parent:Command
-            |vpiName:data_idles
-            |vpiTypespec:
-            \_bit_typespec: , line:53, col:7, parent:data_idles
-              |vpiRange:
-              \_range: , line:53, col:12
-                |vpiLeftRange:
-                \_constant: , line:53, col:12
-                  |vpiConstType:9
-                  |vpiDecompile:31
-                  |vpiSize:64
-                  |UINT:31
-                |vpiRightRange:
-                \_constant: , line:53, col:15
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
+                  |UINT:1
+              |vpiRightRange:
+              \_constant: , line:51, col:28
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+        |vpiTypespecMember:
+        \_typespec_member: (cmd_delay), line:52, col:36, parent:Command
+          |vpiName:cmd_delay
+          |vpiTypespec:
+          \_bit_typespec: , line:52, col:7, parent:cmd_delay
+            |vpiRange:
+            \_range: , line:52, col:12
+              |vpiLeftRange:
+              \_constant: , line:52, col:12
+                |vpiConstType:9
+                |vpiDecompile:31
+                |vpiSize:64
+                |UINT:31
+              |vpiRightRange:
+              \_constant: , line:52, col:15
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+        |vpiTypespecMember:
+        \_typespec_member: (data_idles), line:53, col:36, parent:Command
+          |vpiName:data_idles
+          |vpiTypespec:
+          \_bit_typespec: , line:53, col:7, parent:data_idles
+            |vpiRange:
+            \_range: , line:53, col:12
+              |vpiLeftRange:
+              \_constant: , line:53, col:12
+                |vpiConstType:9
+                |vpiDecompile:31
+                |vpiSize:64
+                |UINT:31
+              |vpiRightRange:
+              \_constant: , line:53, col:15
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
     |vpiIODecl:
     \_io_decl: (master_id), parent:work@test_program.configure_and_push_command_to_master
       |vpiName:master_id
       |vpiDirection:1
-      |vpiExpr:
-      \_int_var: (work@test_program.configure_and_push_command_to_master.master_id), line:672, col:6, parent:master_id
-        |vpiFullName:work@test_program.configure_and_push_command_to_master.master_id
+      |vpiTypedef:
+      \_int_typespec: , line:672, col:6, parent:master_id
     |vpiStmt:
     \_if_else: , line:674, col:6, parent:work@test_program.configure_and_push_command_to_master
       |vpiCondition:
@@ -27660,8 +26804,6 @@ design: (work@top)
         \_ref_obj: (work@test_program.configure_and_push_command_to_master.master_id), line:674, col:10
           |vpiName:master_id
           |vpiFullName:work@test_program.configure_and_push_command_to_master.master_id
-          |vpiActual:
-          \_int_var: (master_id), line:672, col:6, parent:master_id
         |vpiOperand:
         \_constant: , line:674, col:23
           |vpiConstType:9
@@ -27680,8 +26822,6 @@ design: (work@top)
           \_ref_obj: (work@test_program.configure_and_push_command_to_master.cmd), line:675, col:48, parent:configure_and_push_command_to_master_0
             |vpiName:cmd
             |vpiFullName:work@test_program.configure_and_push_command_to_master.cmd
-            |vpiActual:
-            \_struct_var: (cmd.Command), line:671, col:6, parent:cmd
       |vpiElseStmt:
       \_if_stmt: , line:676, col:19
         |vpiCondition:
@@ -27691,8 +26831,6 @@ design: (work@top)
           \_ref_obj: (work@test_program.configure_and_push_command_to_master.master_id), line:676, col:19
             |vpiName:master_id
             |vpiFullName:work@test_program.configure_and_push_command_to_master.master_id
-            |vpiActual:
-            \_int_var: (master_id), line:672, col:6, parent:master_id
           |vpiOperand:
           \_constant: , line:676, col:32
             |vpiConstType:9
@@ -27711,8 +26849,6 @@ design: (work@top)
             \_ref_obj: (work@test_program.configure_and_push_command_to_master.cmd), line:677, col:48, parent:configure_and_push_command_to_master_1
               |vpiName:cmd
               |vpiFullName:work@test_program.configure_and_push_command_to_master.cmd
-              |vpiActual:
-              \_struct_var: (cmd.Command), line:671, col:6, parent:cmd
   |vpiTaskFunc:
   \_function: (work@test_program.get_expected_command_for_slave), line:682, col:3, parent:work@test_program
     |vpiVisibility:1
@@ -27727,34 +26863,56 @@ design: (work@top)
     \_io_decl: (cmd), parent:work@test_program.get_expected_command_for_slave
       |vpiName:cmd
       |vpiDirection:1
-      |vpiExpr:
-      \_struct_var: (work@test_program.get_expected_command_for_slave.cmd.Command), line:683, col:6, parent:cmd
+      |vpiTypedef:
+      \_struct_typespec: (Command), line:45, col:11, parent:cmd
         |vpiName:Command
-        |vpiFullName:work@test_program.get_expected_command_for_slave.cmd.Command
-        |vpiTypespec:
-        \_struct_typespec: (Command), line:45, col:11, parent:work@test_program.get_expected_command_for_slave.cmd.Command
-          |vpiName:Command
-          |vpiTypespecMember:
-          \_typespec_member: (trans), line:47, col:36, parent:Command
-            |vpiName:trans
-            |vpiTypespec:
-            \_enum_typespec: (Transaction), line:37, col:5, parent:trans
-              |vpiName:Transaction
-              |vpiBaseTypespec:
-              \_bit_typespec: , line:33, col:16, parent:Transaction
-              |vpiEnumConst:
-              \_enum_const: (READ), line:36, parent:Transaction
-                |vpiName:READ
-                |UINT:1
-              |vpiEnumConst:
-              \_enum_const: (WRITE), line:35, parent:Transaction
-                |vpiName:WRITE
+        |vpiTypespecMember:
+        \_typespec_member: (trans), line:47, col:36, parent:Command
+          |vpiName:trans
+          |vpiTypespec:
+          \_enum_typespec: (Transaction), line:37, col:5, parent:trans
+            |vpiName:Transaction
+            |vpiBaseTypespec:
+            \_bit_typespec: , line:33, col:16, parent:Transaction
+            |vpiEnumConst:
+            \_enum_const: (READ), line:36, parent:Transaction
+              |vpiName:READ
+              |UINT:1
+            |vpiEnumConst:
+            \_enum_const: (WRITE), line:35, parent:Transaction
+              |vpiName:WRITE
+              |UINT:0
+        |vpiTypespecMember:
+        \_typespec_member: (burstcount), line:48, col:36, parent:Command
+          |vpiName:burstcount
+          |vpiTypespec:
+          \_logic_typespec: (Burstcount), line:31, col:11, parent:burstcount
+            |vpiName:Burstcount
+            |vpiRange:
+            \_range: , line:31, col:18, parent:Burstcount
+              |vpiLeftRange:
+              \_operation: , line:31, col:18
+                |vpiOpType:11
+                |vpiOperand:
+                \_ref_obj: (work@test_program.get_expected_command_for_slave.cmd.Command.burstcount.Burstcount.BURST_W), line:31, col:18
+                  |vpiName:BURST_W
+                  |vpiFullName:work@test_program.get_expected_command_for_slave.cmd.Command.burstcount.Burstcount.BURST_W
+                  |vpiActual:
+                  \_parameter: (work@test_program.BURST_W), line:19, col:14, parent:work@test_program
+                |vpiOperand:
+                \_constant: , line:31, col:26
+                  |vpiConstType:9
+                  |vpiDecompile:1
+                  |vpiSize:64
+                  |UINT:1
+              |vpiRightRange:
+              \_constant: , line:31, col:28
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
                 |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (burstcount), line:48, col:36, parent:Command
-            |vpiName:burstcount
-            |vpiTypespec:
-            \_logic_typespec: (Burstcount), line:31, col:11, parent:burstcount
+            |vpiTypedefAlias:
+            \_logic_typespec: (Burstcount), line:31, col:11, parent:Burstcount
               |vpiName:Burstcount
               |vpiRange:
               \_range: , line:31, col:18, parent:Burstcount
@@ -27762,9 +26920,9 @@ design: (work@top)
                 \_operation: , line:31, col:18
                   |vpiOpType:11
                   |vpiOperand:
-                  \_ref_obj: (work@test_program.get_expected_command_for_slave.cmd.Command.Command.burstcount.Burstcount.BURST_W), line:31, col:18
+                  \_ref_obj: (work@test_program.get_expected_command_for_slave.cmd.Command.burstcount.Burstcount.Burstcount.BURST_W), line:31, col:18
                     |vpiName:BURST_W
-                    |vpiFullName:work@test_program.get_expected_command_for_slave.cmd.Command.Command.burstcount.Burstcount.BURST_W
+                    |vpiFullName:work@test_program.get_expected_command_for_slave.cmd.Command.burstcount.Burstcount.Burstcount.BURST_W
                     |vpiActual:
                     \_parameter: (work@test_program.BURST_W), line:19, col:14, parent:work@test_program
                   |vpiOperand:
@@ -27779,161 +26937,134 @@ design: (work@top)
                   |vpiDecompile:0
                   |vpiSize:64
                   |UINT:0
-              |vpiTypedefAlias:
-              \_logic_typespec: (Burstcount), line:31, col:11, parent:Burstcount
-                |vpiName:Burstcount
-                |vpiRange:
-                \_range: , line:31, col:18, parent:Burstcount
-                  |vpiLeftRange:
-                  \_operation: , line:31, col:18
-                    |vpiOpType:11
-                    |vpiOperand:
-                    \_ref_obj: (work@test_program.get_expected_command_for_slave.cmd.Command.Command.burstcount.Burstcount.Burstcount.BURST_W), line:31, col:18
-                      |vpiName:BURST_W
-                      |vpiFullName:work@test_program.get_expected_command_for_slave.cmd.Command.Command.burstcount.Burstcount.Burstcount.BURST_W
-                      |vpiActual:
-                      \_parameter: (work@test_program.BURST_W), line:19, col:14, parent:work@test_program
-                    |vpiOperand:
-                    \_constant: , line:31, col:26
-                      |vpiConstType:9
-                      |vpiDecompile:1
-                      |vpiSize:64
-                      |UINT:1
-                  |vpiRightRange:
-                  \_constant: , line:31, col:28
-                    |vpiConstType:9
-                    |vpiDecompile:0
-                    |vpiSize:64
-                    |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (addr), line:49, col:36, parent:Command
-            |vpiName:addr
-            |vpiTypespec:
-            \_logic_typespec: , line:49, col:7, parent:addr
-              |vpiRange:
-              \_range: , line:49, col:14
-                |vpiLeftRange:
-                \_operation: , line:49, col:14
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (work@test_program.get_expected_command_for_slave.cmd.Command.Command.addr.ADDR_W), line:49, col:14
-                    |vpiName:ADDR_W
-                    |vpiFullName:work@test_program.get_expected_command_for_slave.cmd.Command.Command.addr.ADDR_W
-                    |vpiActual:
-                    \_parameter: (work@test_program.ADDR_W), line:13, col:14, parent:work@test_program
-                  |vpiOperand:
-                  \_constant: , line:49, col:21
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:49, col:24
+        |vpiTypespecMember:
+        \_typespec_member: (addr), line:49, col:36, parent:Command
+          |vpiName:addr
+          |vpiTypespec:
+          \_logic_typespec: , line:49, col:7, parent:addr
+            |vpiRange:
+            \_range: , line:49, col:14
+              |vpiLeftRange:
+              \_operation: , line:49, col:14
+                |vpiOpType:11
+                |vpiOperand:
+                \_ref_obj: (work@test_program.get_expected_command_for_slave.cmd.Command.addr.ADDR_W), line:49, col:14
+                  |vpiName:ADDR_W
+                  |vpiFullName:work@test_program.get_expected_command_for_slave.cmd.Command.addr.ADDR_W
+                  |vpiActual:
+                  \_parameter: (work@test_program.ADDR_W), line:13, col:14, parent:work@test_program
+                |vpiOperand:
+                \_constant: , line:49, col:21
                   |vpiConstType:9
-                  |vpiDecompile:0
+                  |vpiDecompile:1
                   |vpiSize:64
-                  |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (data), line:50, col:36, parent:Command
-            |vpiName:data
-            |vpiTypespec:
-            \_logic_typespec: , line:50, col:7, parent:data
-              |vpiRange:
-              \_range: , line:50, col:14
-                |vpiLeftRange:
-                \_operation: , line:50, col:14
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (work@test_program.get_expected_command_for_slave.cmd.Command.Command.data.DATA_W), line:50, col:14
-                    |vpiName:DATA_W
-                    |vpiFullName:work@test_program.get_expected_command_for_slave.cmd.Command.Command.data.DATA_W
-                    |vpiActual:
-                    \_parameter: (work@test_program.DATA_W), line:17, col:14, parent:work@test_program
-                  |vpiOperand:
-                  \_constant: , line:50, col:21
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:50, col:23
+                  |UINT:1
+              |vpiRightRange:
+              \_constant: , line:49, col:24
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+        |vpiTypespecMember:
+        \_typespec_member: (data), line:50, col:36, parent:Command
+          |vpiName:data
+          |vpiTypespec:
+          \_logic_typespec: , line:50, col:7, parent:data
+            |vpiRange:
+            \_range: , line:50, col:14
+              |vpiLeftRange:
+              \_operation: , line:50, col:14
+                |vpiOpType:11
+                |vpiOperand:
+                \_ref_obj: (work@test_program.get_expected_command_for_slave.cmd.Command.data.DATA_W), line:50, col:14
+                  |vpiName:DATA_W
+                  |vpiFullName:work@test_program.get_expected_command_for_slave.cmd.Command.data.DATA_W
+                  |vpiActual:
+                  \_parameter: (work@test_program.DATA_W), line:17, col:14, parent:work@test_program
+                |vpiOperand:
+                \_constant: , line:50, col:21
                   |vpiConstType:9
-                  |vpiDecompile:0
+                  |vpiDecompile:1
                   |vpiSize:64
-                  |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (byteenable), line:51, col:36, parent:Command
-            |vpiName:byteenable
-            |vpiTypespec:
-            \_logic_typespec: , line:51, col:7, parent:byteenable
-              |vpiRange:
-              \_range: , line:51, col:14
-                |vpiLeftRange:
-                \_operation: , line:51, col:14
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (work@test_program.get_expected_command_for_slave.cmd.Command.Command.byteenable.NUM_SYMBOLS), line:51, col:14
-                    |vpiName:NUM_SYMBOLS
-                    |vpiFullName:work@test_program.get_expected_command_for_slave.cmd.Command.Command.byteenable.NUM_SYMBOLS
-                    |vpiActual:
-                    \_parameter: (work@test_program.NUM_SYMBOLS), line:16, col:14, parent:work@test_program
-                  |vpiOperand:
-                  \_constant: , line:51, col:26
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:51, col:28
+                  |UINT:1
+              |vpiRightRange:
+              \_constant: , line:50, col:23
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+        |vpiTypespecMember:
+        \_typespec_member: (byteenable), line:51, col:36, parent:Command
+          |vpiName:byteenable
+          |vpiTypespec:
+          \_logic_typespec: , line:51, col:7, parent:byteenable
+            |vpiRange:
+            \_range: , line:51, col:14
+              |vpiLeftRange:
+              \_operation: , line:51, col:14
+                |vpiOpType:11
+                |vpiOperand:
+                \_ref_obj: (work@test_program.get_expected_command_for_slave.cmd.Command.byteenable.NUM_SYMBOLS), line:51, col:14
+                  |vpiName:NUM_SYMBOLS
+                  |vpiFullName:work@test_program.get_expected_command_for_slave.cmd.Command.byteenable.NUM_SYMBOLS
+                  |vpiActual:
+                  \_parameter: (work@test_program.NUM_SYMBOLS), line:16, col:14, parent:work@test_program
+                |vpiOperand:
+                \_constant: , line:51, col:26
                   |vpiConstType:9
-                  |vpiDecompile:0
+                  |vpiDecompile:1
                   |vpiSize:64
-                  |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (cmd_delay), line:52, col:36, parent:Command
-            |vpiName:cmd_delay
-            |vpiTypespec:
-            \_bit_typespec: , line:52, col:7, parent:cmd_delay
-              |vpiRange:
-              \_range: , line:52, col:12
-                |vpiLeftRange:
-                \_constant: , line:52, col:12
-                  |vpiConstType:9
-                  |vpiDecompile:31
-                  |vpiSize:64
-                  |UINT:31
-                |vpiRightRange:
-                \_constant: , line:52, col:15
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (data_idles), line:53, col:36, parent:Command
-            |vpiName:data_idles
-            |vpiTypespec:
-            \_bit_typespec: , line:53, col:7, parent:data_idles
-              |vpiRange:
-              \_range: , line:53, col:12
-                |vpiLeftRange:
-                \_constant: , line:53, col:12
-                  |vpiConstType:9
-                  |vpiDecompile:31
-                  |vpiSize:64
-                  |UINT:31
-                |vpiRightRange:
-                \_constant: , line:53, col:15
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
+                  |UINT:1
+              |vpiRightRange:
+              \_constant: , line:51, col:28
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+        |vpiTypespecMember:
+        \_typespec_member: (cmd_delay), line:52, col:36, parent:Command
+          |vpiName:cmd_delay
+          |vpiTypespec:
+          \_bit_typespec: , line:52, col:7, parent:cmd_delay
+            |vpiRange:
+            \_range: , line:52, col:12
+              |vpiLeftRange:
+              \_constant: , line:52, col:12
+                |vpiConstType:9
+                |vpiDecompile:31
+                |vpiSize:64
+                |UINT:31
+              |vpiRightRange:
+              \_constant: , line:52, col:15
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+        |vpiTypespecMember:
+        \_typespec_member: (data_idles), line:53, col:36, parent:Command
+          |vpiName:data_idles
+          |vpiTypespec:
+          \_bit_typespec: , line:53, col:7, parent:data_idles
+            |vpiRange:
+            \_range: , line:53, col:12
+              |vpiLeftRange:
+              \_constant: , line:53, col:12
+                |vpiConstType:9
+                |vpiDecompile:31
+                |vpiSize:64
+                |UINT:31
+              |vpiRightRange:
+              \_constant: , line:53, col:15
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
     |vpiIODecl:
     \_io_decl: (slave_id), parent:work@test_program.get_expected_command_for_slave
       |vpiName:slave_id
       |vpiDirection:1
-      |vpiExpr:
-      \_int_var: (work@test_program.get_expected_command_for_slave.slave_id), line:684, col:6, parent:slave_id
-        |vpiFullName:work@test_program.get_expected_command_for_slave.slave_id
+      |vpiTypedef:
+      \_int_typespec: , line:684, col:6, parent:slave_id
     |vpiStmt:
     \_begin: (work@test_program.get_expected_command_for_slave), parent:work@test_program.get_expected_command_for_slave
       |vpiFullName:work@test_program.get_expected_command_for_slave
@@ -27960,8 +27091,6 @@ design: (work@top)
             |vpiActual:
             \_ref_obj: (cmd), parent:cmd.trans
               |vpiName:cmd
-              |vpiActual:
-              \_struct_var: (cmd.Command), line:683, col:6, parent:cmd
             |vpiActual:
             \_ref_obj: (trans), parent:cmd.trans
               |vpiName:trans
@@ -28006,8 +27135,6 @@ design: (work@top)
                   \_ref_obj: (work@test_program.get_expected_command_for_slave.write_command_queue_slave.slave_id), line:692, col:48, parent:work@test_program.get_expected_command_for_slave.write_command_queue_slave
                     |vpiName:slave_id
                     |vpiFullName:work@test_program.get_expected_command_for_slave.write_command_queue_slave.slave_id
-                    |vpiActual:
-                    \_int_var: (slave_id), line:684, col:6, parent:slave_id
                   |vpiIndex:
                   \_ref_obj: (work@test_program.get_expected_command_for_slave.write_command_queue_slave.i), line:692, col:58, parent:work@test_program.get_expected_command_for_slave.write_command_queue_slave
                     |vpiName:i
@@ -28034,8 +27161,6 @@ design: (work@top)
                     |vpiActual:
                     \_ref_obj: (cmd), parent:cmd.addr
                       |vpiName:cmd
-                      |vpiActual:
-                      \_struct_var: (cmd.Command), line:683, col:6, parent:cmd
                     |vpiActual:
                     \_ref_obj: (addr), parent:cmd.addr
                       |vpiName:addr
@@ -28109,8 +27234,6 @@ design: (work@top)
                     \_ref_obj: (work@test_program.get_expected_command_for_slave.write_command_queue_slave[slave_id].pop_front.write_command_queue_slave.slave_id), line:700, col:48, parent:write_command_queue_slave
                       |vpiName:slave_id
                       |vpiFullName:work@test_program.get_expected_command_for_slave.write_command_queue_slave[slave_id].pop_front.write_command_queue_slave.slave_id
-                      |vpiActual:
-                      \_int_var: (slave_id), line:684, col:6, parent:slave_id
                   |vpiActual:
                   \_ref_obj: (pop_front), parent:write_command_queue_slave[slave_id].pop_front
                     |vpiName:pop_front
@@ -28149,8 +27272,6 @@ design: (work@top)
                   \_ref_obj: (work@test_program.get_expected_command_for_slave.read_command_queue_slave.slave_id), line:704, col:47, parent:work@test_program.get_expected_command_for_slave.read_command_queue_slave
                     |vpiName:slave_id
                     |vpiFullName:work@test_program.get_expected_command_for_slave.read_command_queue_slave.slave_id
-                    |vpiActual:
-                    \_int_var: (slave_id), line:684, col:6, parent:slave_id
                   |vpiIndex:
                   \_ref_obj: (work@test_program.get_expected_command_for_slave.read_command_queue_slave.i), line:704, col:57, parent:work@test_program.get_expected_command_for_slave.read_command_queue_slave
                     |vpiName:i
@@ -28177,8 +27298,6 @@ design: (work@top)
                     |vpiActual:
                     \_ref_obj: (cmd), parent:cmd.addr
                       |vpiName:cmd
-                      |vpiActual:
-                      \_struct_var: (cmd.Command), line:683, col:6, parent:cmd
                     |vpiActual:
                     \_ref_obj: (addr), parent:cmd.addr
                       |vpiName:addr
@@ -28252,8 +27371,6 @@ design: (work@top)
                     \_ref_obj: (work@test_program.get_expected_command_for_slave.read_command_queue_slave[slave_id].pop_front.read_command_queue_slave.slave_id), line:712, col:47, parent:read_command_queue_slave
                       |vpiName:slave_id
                       |vpiFullName:work@test_program.get_expected_command_for_slave.read_command_queue_slave[slave_id].pop_front.read_command_queue_slave.slave_id
-                      |vpiActual:
-                      \_int_var: (slave_id), line:684, col:6, parent:slave_id
                   |vpiActual:
                   \_ref_obj: (pop_front), parent:read_command_queue_slave[slave_id].pop_front
                     |vpiName:pop_front
@@ -28477,34 +27594,56 @@ design: (work@top)
     \_io_decl: (actual_cmd), parent:work@test_program.verify_command
       |vpiName:actual_cmd
       |vpiDirection:1
-      |vpiExpr:
-      \_struct_var: (work@test_program.verify_command.actual_cmd.Command), line:720, col:6, parent:actual_cmd
+      |vpiTypedef:
+      \_struct_typespec: (Command), line:45, col:11, parent:actual_cmd
         |vpiName:Command
-        |vpiFullName:work@test_program.verify_command.actual_cmd.Command
-        |vpiTypespec:
-        \_struct_typespec: (Command), line:45, col:11, parent:work@test_program.verify_command.actual_cmd.Command
-          |vpiName:Command
-          |vpiTypespecMember:
-          \_typespec_member: (trans), line:47, col:36, parent:Command
-            |vpiName:trans
-            |vpiTypespec:
-            \_enum_typespec: (Transaction), line:37, col:5, parent:trans
-              |vpiName:Transaction
-              |vpiBaseTypespec:
-              \_bit_typespec: , line:33, col:16, parent:Transaction
-              |vpiEnumConst:
-              \_enum_const: (READ), line:36, parent:Transaction
-                |vpiName:READ
-                |UINT:1
-              |vpiEnumConst:
-              \_enum_const: (WRITE), line:35, parent:Transaction
-                |vpiName:WRITE
+        |vpiTypespecMember:
+        \_typespec_member: (trans), line:47, col:36, parent:Command
+          |vpiName:trans
+          |vpiTypespec:
+          \_enum_typespec: (Transaction), line:37, col:5, parent:trans
+            |vpiName:Transaction
+            |vpiBaseTypespec:
+            \_bit_typespec: , line:33, col:16, parent:Transaction
+            |vpiEnumConst:
+            \_enum_const: (READ), line:36, parent:Transaction
+              |vpiName:READ
+              |UINT:1
+            |vpiEnumConst:
+            \_enum_const: (WRITE), line:35, parent:Transaction
+              |vpiName:WRITE
+              |UINT:0
+        |vpiTypespecMember:
+        \_typespec_member: (burstcount), line:48, col:36, parent:Command
+          |vpiName:burstcount
+          |vpiTypespec:
+          \_logic_typespec: (Burstcount), line:31, col:11, parent:burstcount
+            |vpiName:Burstcount
+            |vpiRange:
+            \_range: , line:31, col:18, parent:Burstcount
+              |vpiLeftRange:
+              \_operation: , line:31, col:18
+                |vpiOpType:11
+                |vpiOperand:
+                \_ref_obj: (work@test_program.verify_command.actual_cmd.Command.burstcount.Burstcount.BURST_W), line:31, col:18
+                  |vpiName:BURST_W
+                  |vpiFullName:work@test_program.verify_command.actual_cmd.Command.burstcount.Burstcount.BURST_W
+                  |vpiActual:
+                  \_parameter: (work@test_program.BURST_W), line:19, col:14, parent:work@test_program
+                |vpiOperand:
+                \_constant: , line:31, col:26
+                  |vpiConstType:9
+                  |vpiDecompile:1
+                  |vpiSize:64
+                  |UINT:1
+              |vpiRightRange:
+              \_constant: , line:31, col:28
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
                 |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (burstcount), line:48, col:36, parent:Command
-            |vpiName:burstcount
-            |vpiTypespec:
-            \_logic_typespec: (Burstcount), line:31, col:11, parent:burstcount
+            |vpiTypedefAlias:
+            \_logic_typespec: (Burstcount), line:31, col:11, parent:Burstcount
               |vpiName:Burstcount
               |vpiRange:
               \_range: , line:31, col:18, parent:Burstcount
@@ -28512,9 +27651,9 @@ design: (work@top)
                 \_operation: , line:31, col:18
                   |vpiOpType:11
                   |vpiOperand:
-                  \_ref_obj: (work@test_program.verify_command.actual_cmd.Command.Command.burstcount.Burstcount.BURST_W), line:31, col:18
+                  \_ref_obj: (work@test_program.verify_command.actual_cmd.Command.burstcount.Burstcount.Burstcount.BURST_W), line:31, col:18
                     |vpiName:BURST_W
-                    |vpiFullName:work@test_program.verify_command.actual_cmd.Command.Command.burstcount.Burstcount.BURST_W
+                    |vpiFullName:work@test_program.verify_command.actual_cmd.Command.burstcount.Burstcount.Burstcount.BURST_W
                     |vpiActual:
                     \_parameter: (work@test_program.BURST_W), line:19, col:14, parent:work@test_program
                   |vpiOperand:
@@ -28529,186 +27668,182 @@ design: (work@top)
                   |vpiDecompile:0
                   |vpiSize:64
                   |UINT:0
-              |vpiTypedefAlias:
-              \_logic_typespec: (Burstcount), line:31, col:11, parent:Burstcount
-                |vpiName:Burstcount
-                |vpiRange:
-                \_range: , line:31, col:18, parent:Burstcount
-                  |vpiLeftRange:
-                  \_operation: , line:31, col:18
-                    |vpiOpType:11
-                    |vpiOperand:
-                    \_ref_obj: (work@test_program.verify_command.actual_cmd.Command.Command.burstcount.Burstcount.Burstcount.BURST_W), line:31, col:18
-                      |vpiName:BURST_W
-                      |vpiFullName:work@test_program.verify_command.actual_cmd.Command.Command.burstcount.Burstcount.Burstcount.BURST_W
-                      |vpiActual:
-                      \_parameter: (work@test_program.BURST_W), line:19, col:14, parent:work@test_program
-                    |vpiOperand:
-                    \_constant: , line:31, col:26
-                      |vpiConstType:9
-                      |vpiDecompile:1
-                      |vpiSize:64
-                      |UINT:1
-                  |vpiRightRange:
-                  \_constant: , line:31, col:28
-                    |vpiConstType:9
-                    |vpiDecompile:0
-                    |vpiSize:64
-                    |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (addr), line:49, col:36, parent:Command
-            |vpiName:addr
-            |vpiTypespec:
-            \_logic_typespec: , line:49, col:7, parent:addr
-              |vpiRange:
-              \_range: , line:49, col:14
-                |vpiLeftRange:
-                \_operation: , line:49, col:14
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (work@test_program.verify_command.actual_cmd.Command.Command.addr.ADDR_W), line:49, col:14
-                    |vpiName:ADDR_W
-                    |vpiFullName:work@test_program.verify_command.actual_cmd.Command.Command.addr.ADDR_W
-                    |vpiActual:
-                    \_parameter: (work@test_program.ADDR_W), line:13, col:14, parent:work@test_program
-                  |vpiOperand:
-                  \_constant: , line:49, col:21
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:49, col:24
+        |vpiTypespecMember:
+        \_typespec_member: (addr), line:49, col:36, parent:Command
+          |vpiName:addr
+          |vpiTypespec:
+          \_logic_typespec: , line:49, col:7, parent:addr
+            |vpiRange:
+            \_range: , line:49, col:14
+              |vpiLeftRange:
+              \_operation: , line:49, col:14
+                |vpiOpType:11
+                |vpiOperand:
+                \_ref_obj: (work@test_program.verify_command.actual_cmd.Command.addr.ADDR_W), line:49, col:14
+                  |vpiName:ADDR_W
+                  |vpiFullName:work@test_program.verify_command.actual_cmd.Command.addr.ADDR_W
+                  |vpiActual:
+                  \_parameter: (work@test_program.ADDR_W), line:13, col:14, parent:work@test_program
+                |vpiOperand:
+                \_constant: , line:49, col:21
                   |vpiConstType:9
-                  |vpiDecompile:0
+                  |vpiDecompile:1
                   |vpiSize:64
-                  |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (data), line:50, col:36, parent:Command
-            |vpiName:data
-            |vpiTypespec:
-            \_logic_typespec: , line:50, col:7, parent:data
-              |vpiRange:
-              \_range: , line:50, col:14
-                |vpiLeftRange:
-                \_operation: , line:50, col:14
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (work@test_program.verify_command.actual_cmd.Command.Command.data.DATA_W), line:50, col:14
-                    |vpiName:DATA_W
-                    |vpiFullName:work@test_program.verify_command.actual_cmd.Command.Command.data.DATA_W
-                    |vpiActual:
-                    \_parameter: (work@test_program.DATA_W), line:17, col:14, parent:work@test_program
-                  |vpiOperand:
-                  \_constant: , line:50, col:21
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:50, col:23
+                  |UINT:1
+              |vpiRightRange:
+              \_constant: , line:49, col:24
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+        |vpiTypespecMember:
+        \_typespec_member: (data), line:50, col:36, parent:Command
+          |vpiName:data
+          |vpiTypespec:
+          \_logic_typespec: , line:50, col:7, parent:data
+            |vpiRange:
+            \_range: , line:50, col:14
+              |vpiLeftRange:
+              \_operation: , line:50, col:14
+                |vpiOpType:11
+                |vpiOperand:
+                \_ref_obj: (work@test_program.verify_command.actual_cmd.Command.data.DATA_W), line:50, col:14
+                  |vpiName:DATA_W
+                  |vpiFullName:work@test_program.verify_command.actual_cmd.Command.data.DATA_W
+                  |vpiActual:
+                  \_parameter: (work@test_program.DATA_W), line:17, col:14, parent:work@test_program
+                |vpiOperand:
+                \_constant: , line:50, col:21
                   |vpiConstType:9
-                  |vpiDecompile:0
+                  |vpiDecompile:1
                   |vpiSize:64
-                  |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (byteenable), line:51, col:36, parent:Command
-            |vpiName:byteenable
-            |vpiTypespec:
-            \_logic_typespec: , line:51, col:7, parent:byteenable
-              |vpiRange:
-              \_range: , line:51, col:14
-                |vpiLeftRange:
-                \_operation: , line:51, col:14
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (work@test_program.verify_command.actual_cmd.Command.Command.byteenable.NUM_SYMBOLS), line:51, col:14
-                    |vpiName:NUM_SYMBOLS
-                    |vpiFullName:work@test_program.verify_command.actual_cmd.Command.Command.byteenable.NUM_SYMBOLS
-                    |vpiActual:
-                    \_parameter: (work@test_program.NUM_SYMBOLS), line:16, col:14, parent:work@test_program
-                  |vpiOperand:
-                  \_constant: , line:51, col:26
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:51, col:28
+                  |UINT:1
+              |vpiRightRange:
+              \_constant: , line:50, col:23
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+        |vpiTypespecMember:
+        \_typespec_member: (byteenable), line:51, col:36, parent:Command
+          |vpiName:byteenable
+          |vpiTypespec:
+          \_logic_typespec: , line:51, col:7, parent:byteenable
+            |vpiRange:
+            \_range: , line:51, col:14
+              |vpiLeftRange:
+              \_operation: , line:51, col:14
+                |vpiOpType:11
+                |vpiOperand:
+                \_ref_obj: (work@test_program.verify_command.actual_cmd.Command.byteenable.NUM_SYMBOLS), line:51, col:14
+                  |vpiName:NUM_SYMBOLS
+                  |vpiFullName:work@test_program.verify_command.actual_cmd.Command.byteenable.NUM_SYMBOLS
+                  |vpiActual:
+                  \_parameter: (work@test_program.NUM_SYMBOLS), line:16, col:14, parent:work@test_program
+                |vpiOperand:
+                \_constant: , line:51, col:26
                   |vpiConstType:9
-                  |vpiDecompile:0
+                  |vpiDecompile:1
                   |vpiSize:64
-                  |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (cmd_delay), line:52, col:36, parent:Command
-            |vpiName:cmd_delay
-            |vpiTypespec:
-            \_bit_typespec: , line:52, col:7, parent:cmd_delay
-              |vpiRange:
-              \_range: , line:52, col:12
-                |vpiLeftRange:
-                \_constant: , line:52, col:12
-                  |vpiConstType:9
-                  |vpiDecompile:31
-                  |vpiSize:64
-                  |UINT:31
-                |vpiRightRange:
-                \_constant: , line:52, col:15
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (data_idles), line:53, col:36, parent:Command
-            |vpiName:data_idles
-            |vpiTypespec:
-            \_bit_typespec: , line:53, col:7, parent:data_idles
-              |vpiRange:
-              \_range: , line:53, col:12
-                |vpiLeftRange:
-                \_constant: , line:53, col:12
-                  |vpiConstType:9
-                  |vpiDecompile:31
-                  |vpiSize:64
-                  |UINT:31
-                |vpiRightRange:
-                \_constant: , line:53, col:15
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
+                  |UINT:1
+              |vpiRightRange:
+              \_constant: , line:51, col:28
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+        |vpiTypespecMember:
+        \_typespec_member: (cmd_delay), line:52, col:36, parent:Command
+          |vpiName:cmd_delay
+          |vpiTypespec:
+          \_bit_typespec: , line:52, col:7, parent:cmd_delay
+            |vpiRange:
+            \_range: , line:52, col:12
+              |vpiLeftRange:
+              \_constant: , line:52, col:12
+                |vpiConstType:9
+                |vpiDecompile:31
+                |vpiSize:64
+                |UINT:31
+              |vpiRightRange:
+              \_constant: , line:52, col:15
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+        |vpiTypespecMember:
+        \_typespec_member: (data_idles), line:53, col:36, parent:Command
+          |vpiName:data_idles
+          |vpiTypespec:
+          \_bit_typespec: , line:53, col:7, parent:data_idles
+            |vpiRange:
+            \_range: , line:53, col:12
+              |vpiLeftRange:
+              \_constant: , line:53, col:12
+                |vpiConstType:9
+                |vpiDecompile:31
+                |vpiSize:64
+                |UINT:31
+              |vpiRightRange:
+              \_constant: , line:53, col:15
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
     |vpiIODecl:
     \_io_decl: (exp_cmd), parent:work@test_program.verify_command
       |vpiName:exp_cmd
       |vpiDirection:1
-      |vpiExpr:
-      \_struct_var: (work@test_program.verify_command.exp_cmd.Command), line:720, col:6, parent:exp_cmd
+      |vpiTypedef:
+      \_struct_typespec: (Command), line:45, col:11, parent:exp_cmd
         |vpiName:Command
-        |vpiFullName:work@test_program.verify_command.exp_cmd.Command
-        |vpiTypespec:
-        \_struct_typespec: (Command), line:45, col:11, parent:work@test_program.verify_command.exp_cmd.Command
-          |vpiName:Command
-          |vpiTypespecMember:
-          \_typespec_member: (trans), line:47, col:36, parent:Command
-            |vpiName:trans
-            |vpiTypespec:
-            \_enum_typespec: (Transaction), line:37, col:5, parent:trans
-              |vpiName:Transaction
-              |vpiBaseTypespec:
-              \_bit_typespec: , line:33, col:16, parent:Transaction
-              |vpiEnumConst:
-              \_enum_const: (READ), line:36, parent:Transaction
-                |vpiName:READ
-                |UINT:1
-              |vpiEnumConst:
-              \_enum_const: (WRITE), line:35, parent:Transaction
-                |vpiName:WRITE
+        |vpiTypespecMember:
+        \_typespec_member: (trans), line:47, col:36, parent:Command
+          |vpiName:trans
+          |vpiTypespec:
+          \_enum_typespec: (Transaction), line:37, col:5, parent:trans
+            |vpiName:Transaction
+            |vpiBaseTypespec:
+            \_bit_typespec: , line:33, col:16, parent:Transaction
+            |vpiEnumConst:
+            \_enum_const: (READ), line:36, parent:Transaction
+              |vpiName:READ
+              |UINT:1
+            |vpiEnumConst:
+            \_enum_const: (WRITE), line:35, parent:Transaction
+              |vpiName:WRITE
+              |UINT:0
+        |vpiTypespecMember:
+        \_typespec_member: (burstcount), line:48, col:36, parent:Command
+          |vpiName:burstcount
+          |vpiTypespec:
+          \_logic_typespec: (Burstcount), line:31, col:11, parent:burstcount
+            |vpiName:Burstcount
+            |vpiRange:
+            \_range: , line:31, col:18, parent:Burstcount
+              |vpiLeftRange:
+              \_operation: , line:31, col:18
+                |vpiOpType:11
+                |vpiOperand:
+                \_ref_obj: (work@test_program.verify_command.exp_cmd.Command.burstcount.Burstcount.BURST_W), line:31, col:18
+                  |vpiName:BURST_W
+                  |vpiFullName:work@test_program.verify_command.exp_cmd.Command.burstcount.Burstcount.BURST_W
+                  |vpiActual:
+                  \_parameter: (work@test_program.BURST_W), line:19, col:14, parent:work@test_program
+                |vpiOperand:
+                \_constant: , line:31, col:26
+                  |vpiConstType:9
+                  |vpiDecompile:1
+                  |vpiSize:64
+                  |UINT:1
+              |vpiRightRange:
+              \_constant: , line:31, col:28
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
                 |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (burstcount), line:48, col:36, parent:Command
-            |vpiName:burstcount
-            |vpiTypespec:
-            \_logic_typespec: (Burstcount), line:31, col:11, parent:burstcount
+            |vpiTypedefAlias:
+            \_logic_typespec: (Burstcount), line:31, col:11, parent:Burstcount
               |vpiName:Burstcount
               |vpiRange:
               \_range: , line:31, col:18, parent:Burstcount
@@ -28716,9 +27851,9 @@ design: (work@top)
                 \_operation: , line:31, col:18
                   |vpiOpType:11
                   |vpiOperand:
-                  \_ref_obj: (work@test_program.verify_command.exp_cmd.Command.Command.burstcount.Burstcount.BURST_W), line:31, col:18
+                  \_ref_obj: (work@test_program.verify_command.exp_cmd.Command.burstcount.Burstcount.Burstcount.BURST_W), line:31, col:18
                     |vpiName:BURST_W
-                    |vpiFullName:work@test_program.verify_command.exp_cmd.Command.Command.burstcount.Burstcount.BURST_W
+                    |vpiFullName:work@test_program.verify_command.exp_cmd.Command.burstcount.Burstcount.Burstcount.BURST_W
                     |vpiActual:
                     \_parameter: (work@test_program.BURST_W), line:19, col:14, parent:work@test_program
                   |vpiOperand:
@@ -28733,154 +27868,128 @@ design: (work@top)
                   |vpiDecompile:0
                   |vpiSize:64
                   |UINT:0
-              |vpiTypedefAlias:
-              \_logic_typespec: (Burstcount), line:31, col:11, parent:Burstcount
-                |vpiName:Burstcount
-                |vpiRange:
-                \_range: , line:31, col:18, parent:Burstcount
-                  |vpiLeftRange:
-                  \_operation: , line:31, col:18
-                    |vpiOpType:11
-                    |vpiOperand:
-                    \_ref_obj: (work@test_program.verify_command.exp_cmd.Command.Command.burstcount.Burstcount.Burstcount.BURST_W), line:31, col:18
-                      |vpiName:BURST_W
-                      |vpiFullName:work@test_program.verify_command.exp_cmd.Command.Command.burstcount.Burstcount.Burstcount.BURST_W
-                      |vpiActual:
-                      \_parameter: (work@test_program.BURST_W), line:19, col:14, parent:work@test_program
-                    |vpiOperand:
-                    \_constant: , line:31, col:26
-                      |vpiConstType:9
-                      |vpiDecompile:1
-                      |vpiSize:64
-                      |UINT:1
-                  |vpiRightRange:
-                  \_constant: , line:31, col:28
-                    |vpiConstType:9
-                    |vpiDecompile:0
-                    |vpiSize:64
-                    |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (addr), line:49, col:36, parent:Command
-            |vpiName:addr
-            |vpiTypespec:
-            \_logic_typespec: , line:49, col:7, parent:addr
-              |vpiRange:
-              \_range: , line:49, col:14
-                |vpiLeftRange:
-                \_operation: , line:49, col:14
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (work@test_program.verify_command.exp_cmd.Command.Command.addr.ADDR_W), line:49, col:14
-                    |vpiName:ADDR_W
-                    |vpiFullName:work@test_program.verify_command.exp_cmd.Command.Command.addr.ADDR_W
-                    |vpiActual:
-                    \_parameter: (work@test_program.ADDR_W), line:13, col:14, parent:work@test_program
-                  |vpiOperand:
-                  \_constant: , line:49, col:21
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:49, col:24
+        |vpiTypespecMember:
+        \_typespec_member: (addr), line:49, col:36, parent:Command
+          |vpiName:addr
+          |vpiTypespec:
+          \_logic_typespec: , line:49, col:7, parent:addr
+            |vpiRange:
+            \_range: , line:49, col:14
+              |vpiLeftRange:
+              \_operation: , line:49, col:14
+                |vpiOpType:11
+                |vpiOperand:
+                \_ref_obj: (work@test_program.verify_command.exp_cmd.Command.addr.ADDR_W), line:49, col:14
+                  |vpiName:ADDR_W
+                  |vpiFullName:work@test_program.verify_command.exp_cmd.Command.addr.ADDR_W
+                  |vpiActual:
+                  \_parameter: (work@test_program.ADDR_W), line:13, col:14, parent:work@test_program
+                |vpiOperand:
+                \_constant: , line:49, col:21
                   |vpiConstType:9
-                  |vpiDecompile:0
+                  |vpiDecompile:1
                   |vpiSize:64
-                  |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (data), line:50, col:36, parent:Command
-            |vpiName:data
-            |vpiTypespec:
-            \_logic_typespec: , line:50, col:7, parent:data
-              |vpiRange:
-              \_range: , line:50, col:14
-                |vpiLeftRange:
-                \_operation: , line:50, col:14
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (work@test_program.verify_command.exp_cmd.Command.Command.data.DATA_W), line:50, col:14
-                    |vpiName:DATA_W
-                    |vpiFullName:work@test_program.verify_command.exp_cmd.Command.Command.data.DATA_W
-                    |vpiActual:
-                    \_parameter: (work@test_program.DATA_W), line:17, col:14, parent:work@test_program
-                  |vpiOperand:
-                  \_constant: , line:50, col:21
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:50, col:23
+                  |UINT:1
+              |vpiRightRange:
+              \_constant: , line:49, col:24
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+        |vpiTypespecMember:
+        \_typespec_member: (data), line:50, col:36, parent:Command
+          |vpiName:data
+          |vpiTypespec:
+          \_logic_typespec: , line:50, col:7, parent:data
+            |vpiRange:
+            \_range: , line:50, col:14
+              |vpiLeftRange:
+              \_operation: , line:50, col:14
+                |vpiOpType:11
+                |vpiOperand:
+                \_ref_obj: (work@test_program.verify_command.exp_cmd.Command.data.DATA_W), line:50, col:14
+                  |vpiName:DATA_W
+                  |vpiFullName:work@test_program.verify_command.exp_cmd.Command.data.DATA_W
+                  |vpiActual:
+                  \_parameter: (work@test_program.DATA_W), line:17, col:14, parent:work@test_program
+                |vpiOperand:
+                \_constant: , line:50, col:21
                   |vpiConstType:9
-                  |vpiDecompile:0
+                  |vpiDecompile:1
                   |vpiSize:64
-                  |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (byteenable), line:51, col:36, parent:Command
-            |vpiName:byteenable
-            |vpiTypespec:
-            \_logic_typespec: , line:51, col:7, parent:byteenable
-              |vpiRange:
-              \_range: , line:51, col:14
-                |vpiLeftRange:
-                \_operation: , line:51, col:14
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (work@test_program.verify_command.exp_cmd.Command.Command.byteenable.NUM_SYMBOLS), line:51, col:14
-                    |vpiName:NUM_SYMBOLS
-                    |vpiFullName:work@test_program.verify_command.exp_cmd.Command.Command.byteenable.NUM_SYMBOLS
-                    |vpiActual:
-                    \_parameter: (work@test_program.NUM_SYMBOLS), line:16, col:14, parent:work@test_program
-                  |vpiOperand:
-                  \_constant: , line:51, col:26
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:51, col:28
+                  |UINT:1
+              |vpiRightRange:
+              \_constant: , line:50, col:23
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+        |vpiTypespecMember:
+        \_typespec_member: (byteenable), line:51, col:36, parent:Command
+          |vpiName:byteenable
+          |vpiTypespec:
+          \_logic_typespec: , line:51, col:7, parent:byteenable
+            |vpiRange:
+            \_range: , line:51, col:14
+              |vpiLeftRange:
+              \_operation: , line:51, col:14
+                |vpiOpType:11
+                |vpiOperand:
+                \_ref_obj: (work@test_program.verify_command.exp_cmd.Command.byteenable.NUM_SYMBOLS), line:51, col:14
+                  |vpiName:NUM_SYMBOLS
+                  |vpiFullName:work@test_program.verify_command.exp_cmd.Command.byteenable.NUM_SYMBOLS
+                  |vpiActual:
+                  \_parameter: (work@test_program.NUM_SYMBOLS), line:16, col:14, parent:work@test_program
+                |vpiOperand:
+                \_constant: , line:51, col:26
                   |vpiConstType:9
-                  |vpiDecompile:0
+                  |vpiDecompile:1
                   |vpiSize:64
-                  |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (cmd_delay), line:52, col:36, parent:Command
-            |vpiName:cmd_delay
-            |vpiTypespec:
-            \_bit_typespec: , line:52, col:7, parent:cmd_delay
-              |vpiRange:
-              \_range: , line:52, col:12
-                |vpiLeftRange:
-                \_constant: , line:52, col:12
-                  |vpiConstType:9
-                  |vpiDecompile:31
-                  |vpiSize:64
-                  |UINT:31
-                |vpiRightRange:
-                \_constant: , line:52, col:15
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (data_idles), line:53, col:36, parent:Command
-            |vpiName:data_idles
-            |vpiTypespec:
-            \_bit_typespec: , line:53, col:7, parent:data_idles
-              |vpiRange:
-              \_range: , line:53, col:12
-                |vpiLeftRange:
-                \_constant: , line:53, col:12
-                  |vpiConstType:9
-                  |vpiDecompile:31
-                  |vpiSize:64
-                  |UINT:31
-                |vpiRightRange:
-                \_constant: , line:53, col:15
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
+                  |UINT:1
+              |vpiRightRange:
+              \_constant: , line:51, col:28
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+        |vpiTypespecMember:
+        \_typespec_member: (cmd_delay), line:52, col:36, parent:Command
+          |vpiName:cmd_delay
+          |vpiTypespec:
+          \_bit_typespec: , line:52, col:7, parent:cmd_delay
+            |vpiRange:
+            \_range: , line:52, col:12
+              |vpiLeftRange:
+              \_constant: , line:52, col:12
+                |vpiConstType:9
+                |vpiDecompile:31
+                |vpiSize:64
+                |UINT:31
+              |vpiRightRange:
+              \_constant: , line:52, col:15
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+        |vpiTypespecMember:
+        \_typespec_member: (data_idles), line:53, col:36, parent:Command
+          |vpiName:data_idles
+          |vpiTypespec:
+          \_bit_typespec: , line:53, col:7, parent:data_idles
+            |vpiRange:
+            \_range: , line:53, col:12
+              |vpiLeftRange:
+              \_constant: , line:53, col:12
+                |vpiConstType:9
+                |vpiDecompile:31
+                |vpiSize:64
+                |UINT:31
+              |vpiRightRange:
+              \_constant: , line:53, col:15
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
     |vpiStmt:
     \_begin: (work@test_program.verify_command), parent:work@test_program.verify_command
       |vpiFullName:work@test_program.verify_command
@@ -28901,8 +28010,6 @@ design: (work@top)
           |vpiActual:
           \_ref_obj: (exp_cmd), parent:exp_cmd.addr
             |vpiName:exp_cmd
-            |vpiActual:
-            \_struct_var: (exp_cmd.Command), line:720, col:6, parent:exp_cmd
           |vpiActual:
           \_ref_obj: (addr), parent:exp_cmd.addr
             |vpiName:addr
@@ -28912,8 +28019,6 @@ design: (work@top)
           |vpiActual:
           \_ref_obj: (actual_cmd), parent:actual_cmd.addr
             |vpiName:actual_cmd
-            |vpiActual:
-            \_struct_var: (actual_cmd.Command), line:720, col:6, parent:actual_cmd
           |vpiActual:
           \_ref_obj: (addr), parent:actual_cmd.addr
             |vpiName:addr
@@ -28934,8 +28039,6 @@ design: (work@top)
           |vpiActual:
           \_ref_obj: (exp_cmd), parent:exp_cmd.burstcount
             |vpiName:exp_cmd
-            |vpiActual:
-            \_struct_var: (exp_cmd.Command), line:720, col:6, parent:exp_cmd
           |vpiActual:
           \_ref_obj: (burstcount), parent:exp_cmd.burstcount
             |vpiName:burstcount
@@ -28945,8 +28048,6 @@ design: (work@top)
           |vpiActual:
           \_ref_obj: (actual_cmd), parent:actual_cmd.burstcount
             |vpiName:actual_cmd
-            |vpiActual:
-            \_struct_var: (actual_cmd.Command), line:720, col:6, parent:actual_cmd
           |vpiActual:
           \_ref_obj: (burstcount), parent:actual_cmd.burstcount
             |vpiName:burstcount
@@ -28961,8 +28062,6 @@ design: (work@top)
             |vpiActual:
             \_ref_obj: (actual_cmd), parent:actual_cmd.trans
               |vpiName:actual_cmd
-              |vpiActual:
-              \_struct_var: (actual_cmd.Command), line:720, col:6, parent:actual_cmd
             |vpiActual:
             \_ref_obj: (trans), parent:actual_cmd.trans
               |vpiName:trans
@@ -28991,8 +28090,6 @@ design: (work@top)
                 |vpiActual:
                 \_ref_obj: (actual_cmd), parent:actual_cmd.burstcount
                   |vpiName:actual_cmd
-                  |vpiActual:
-                  \_struct_var: (actual_cmd.Command), line:720, col:6, parent:actual_cmd
                 |vpiActual:
                 \_ref_obj: (burstcount), parent:actual_cmd.burstcount
                   |vpiName:burstcount
@@ -29035,8 +28132,6 @@ design: (work@top)
                   |vpiActual:
                   \_ref_obj: (exp_cmd), parent:exp_cmd.data[i]
                     |vpiName:exp_cmd
-                    |vpiActual:
-                    \_struct_var: (exp_cmd.Command), line:720, col:6, parent:exp_cmd
                   |vpiActual:
                   \_bit_select: (data), parent:exp_cmd.data[i]
                     |vpiName:data
@@ -29050,8 +28145,6 @@ design: (work@top)
                   |vpiActual:
                   \_ref_obj: (actual_cmd), parent:actual_cmd.data[i]
                     |vpiName:actual_cmd
-                    |vpiActual:
-                    \_struct_var: (actual_cmd.Command), line:720, col:6, parent:actual_cmd
                   |vpiActual:
                   \_bit_select: (data), parent:actual_cmd.data[i]
                     |vpiName:data
@@ -29076,8 +28169,6 @@ design: (work@top)
                   |vpiActual:
                   \_ref_obj: (exp_cmd), parent:exp_cmd.byteenable[i]
                     |vpiName:exp_cmd
-                    |vpiActual:
-                    \_struct_var: (exp_cmd.Command), line:720, col:6, parent:exp_cmd
                   |vpiActual:
                   \_bit_select: (byteenable), parent:exp_cmd.byteenable[i]
                     |vpiName:byteenable
@@ -29091,8 +28182,6 @@ design: (work@top)
                   |vpiActual:
                   \_ref_obj: (actual_cmd), parent:actual_cmd.byteenable[i]
                     |vpiName:actual_cmd
-                    |vpiActual:
-                    \_struct_var: (actual_cmd.Command), line:720, col:6, parent:actual_cmd
                   |vpiActual:
                   \_bit_select: (byteenable), parent:actual_cmd.byteenable[i]
                     |vpiName:byteenable
@@ -29112,18 +28201,16 @@ design: (work@top)
     \_io_decl: (message), parent:work@test_program.assert_equals
       |vpiName:message
       |vpiDirection:1
-      |vpiExpr:
-      \_string_var: (work@test_program.assert_equals.message), line:736, col:6, parent:message
-        |vpiFullName:work@test_program.assert_equals.message
+      |vpiTypedef:
+      \_string_typespec: , line:736, col:6, parent:message
     |vpiIODecl:
     \_io_decl: (expected_obj), parent:work@test_program.assert_equals
       |vpiName:expected_obj
       |vpiDirection:1
-      |vpiExpr:
-      \_logic_var: (work@test_program.assert_equals.expected_obj), line:737, col:6, parent:expected_obj
-        |vpiFullName:work@test_program.assert_equals.expected_obj
+      |vpiTypedef:
+      \_logic_typespec: , line:737, col:6, parent:expected_obj
         |vpiRange:
-        \_range: , line:737, col:13, parent:work@test_program.assert_equals.expected_obj
+        \_range: , line:737, col:13
           |vpiLeftRange:
           \_constant: , line:737, col:13
             |vpiConstType:9
@@ -29140,11 +28227,10 @@ design: (work@top)
     \_io_decl: (actual_obj), parent:work@test_program.assert_equals
       |vpiName:actual_obj
       |vpiDirection:1
-      |vpiExpr:
-      \_logic_var: (work@test_program.assert_equals.actual_obj), line:738, col:6, parent:actual_obj
-        |vpiFullName:work@test_program.assert_equals.actual_obj
+      |vpiTypedef:
+      \_logic_typespec: , line:738, col:6, parent:actual_obj
         |vpiRange:
-        \_range: , line:738, col:13, parent:work@test_program.assert_equals.actual_obj
+        \_range: , line:738, col:13
           |vpiLeftRange:
           \_constant: , line:738, col:13
             |vpiConstType:9
@@ -29172,14 +28258,10 @@ design: (work@top)
             \_ref_obj: (work@test_program.assert_equals.actual_obj), line:743, col:13
               |vpiName:actual_obj
               |vpiFullName:work@test_program.assert_equals.actual_obj
-              |vpiActual:
-              \_logic_var: (actual_obj), line:738, col:6, parent:actual_obj
             |vpiOperand:
             \_ref_obj: (work@test_program.assert_equals.expected_obj), line:743, col:27
               |vpiName:expected_obj
               |vpiFullName:work@test_program.assert_equals.expected_obj
-              |vpiActual:
-              \_logic_var: (expected_obj), line:737, col:6, parent:expected_obj
           |vpiStmt:
           \_begin: (work@test_program.assert_equals), line:743, col:41
             |vpiFullName:work@test_program.assert_equals
@@ -29205,20 +28287,14 @@ design: (work@top)
               \_ref_obj: (work@test_program.assert_equals.message), line:749, col:15, parent:$sformat
                 |vpiName:message
                 |vpiFullName:work@test_program.assert_equals.message
-                |vpiActual:
-                \_string_var: (message), line:736, col:6, parent:message
               |vpiArgument:
               \_ref_obj: (work@test_program.assert_equals.expected_obj), line:750, col:15, parent:$sformat
                 |vpiName:expected_obj
                 |vpiFullName:work@test_program.assert_equals.expected_obj
-                |vpiActual:
-                \_logic_var: (expected_obj), line:737, col:6, parent:expected_obj
               |vpiArgument:
               \_ref_obj: (work@test_program.assert_equals.actual_obj), line:751, col:15, parent:$sformat
                 |vpiName:actual_obj
                 |vpiFullName:work@test_program.assert_equals.actual_obj
-                |vpiActual:
-                \_logic_var: (actual_obj), line:738, col:6, parent:actual_obj
             |vpiStmt:
             \_func_call: (print), line:752, col:12, parent:work@test_program.assert_equals
               |vpiName:print
@@ -29270,12 +28346,11 @@ design: (work@top)
     \_io_decl: (burstcount), parent:work@test_program.create_response
       |vpiName:burstcount
       |vpiDirection:1
-      |vpiExpr:
-      \_logic_var: (work@test_program.create_response.burstcount.Burstcount), line:760, col:6, parent:burstcount
+      |vpiTypedef:
+      \_logic_typespec: (Burstcount), line:31, col:11, parent:burstcount
         |vpiName:Burstcount
-        |vpiFullName:work@test_program.create_response.burstcount.Burstcount
         |vpiRange:
-        \_range: , line:31, col:18, parent:work@test_program.create_response.burstcount.Burstcount
+        \_range: , line:31, col:18, parent:Burstcount
           |vpiLeftRange:
           \_operation: , line:31, col:18
             |vpiOpType:11
@@ -29297,8 +28372,8 @@ design: (work@top)
             |vpiDecompile:0
             |vpiSize:64
             |UINT:0
-        |vpiTypespec:
-        \_logic_typespec: (Burstcount), line:31, col:11, parent:work@test_program.create_response.burstcount.Burstcount
+        |vpiTypedefAlias:
+        \_logic_typespec: (Burstcount), line:31, col:11, parent:Burstcount
           |vpiName:Burstcount
           |vpiRange:
           \_range: , line:31, col:18, parent:Burstcount
@@ -29338,8 +28413,6 @@ design: (work@top)
         \_ref_obj: (work@test_program.create_response.burstcount), line:765, col:29
           |vpiName:burstcount
           |vpiFullName:work@test_program.create_response.burstcount
-          |vpiActual:
-          \_logic_var: (burstcount.Burstcount), line:760, col:6, parent:burstcount
       |vpiStmt:
       \_for_stmt: (work@test_program.create_response), line:766, col:6, parent:work@test_program.create_response
         |vpiFullName:work@test_program.create_response
@@ -29354,8 +28427,6 @@ design: (work@top)
           \_ref_obj: (work@test_program.create_response.burstcount), line:766, col:25
             |vpiName:burstcount
             |vpiFullName:work@test_program.create_response.burstcount
-            |vpiActual:
-            \_logic_var: (burstcount.Burstcount), line:760, col:6, parent:burstcount
         |vpiForInitStmt:
         \_assign_stmt: , parent:work@test_program.create_response
           |vpiRhs:
@@ -29551,34 +28622,56 @@ design: (work@top)
     \_io_decl: (cmd), parent:work@test_program.get_expected_read_response
       |vpiName:cmd
       |vpiDirection:1
-      |vpiExpr:
-      \_struct_var: (work@test_program.get_expected_read_response.cmd.Command), line:775, col:6, parent:cmd
+      |vpiTypedef:
+      \_struct_typespec: (Command), line:45, col:11, parent:cmd
         |vpiName:Command
-        |vpiFullName:work@test_program.get_expected_read_response.cmd.Command
-        |vpiTypespec:
-        \_struct_typespec: (Command), line:45, col:11, parent:work@test_program.get_expected_read_response.cmd.Command
-          |vpiName:Command
-          |vpiTypespecMember:
-          \_typespec_member: (trans), line:47, col:36, parent:Command
-            |vpiName:trans
-            |vpiTypespec:
-            \_enum_typespec: (Transaction), line:37, col:5, parent:trans
-              |vpiName:Transaction
-              |vpiBaseTypespec:
-              \_bit_typespec: , line:33, col:16, parent:Transaction
-              |vpiEnumConst:
-              \_enum_const: (READ), line:36, parent:Transaction
-                |vpiName:READ
-                |UINT:1
-              |vpiEnumConst:
-              \_enum_const: (WRITE), line:35, parent:Transaction
-                |vpiName:WRITE
+        |vpiTypespecMember:
+        \_typespec_member: (trans), line:47, col:36, parent:Command
+          |vpiName:trans
+          |vpiTypespec:
+          \_enum_typespec: (Transaction), line:37, col:5, parent:trans
+            |vpiName:Transaction
+            |vpiBaseTypespec:
+            \_bit_typespec: , line:33, col:16, parent:Transaction
+            |vpiEnumConst:
+            \_enum_const: (READ), line:36, parent:Transaction
+              |vpiName:READ
+              |UINT:1
+            |vpiEnumConst:
+            \_enum_const: (WRITE), line:35, parent:Transaction
+              |vpiName:WRITE
+              |UINT:0
+        |vpiTypespecMember:
+        \_typespec_member: (burstcount), line:48, col:36, parent:Command
+          |vpiName:burstcount
+          |vpiTypespec:
+          \_logic_typespec: (Burstcount), line:31, col:11, parent:burstcount
+            |vpiName:Burstcount
+            |vpiRange:
+            \_range: , line:31, col:18, parent:Burstcount
+              |vpiLeftRange:
+              \_operation: , line:31, col:18
+                |vpiOpType:11
+                |vpiOperand:
+                \_ref_obj: (work@test_program.get_expected_read_response.cmd.Command.burstcount.Burstcount.BURST_W), line:31, col:18
+                  |vpiName:BURST_W
+                  |vpiFullName:work@test_program.get_expected_read_response.cmd.Command.burstcount.Burstcount.BURST_W
+                  |vpiActual:
+                  \_parameter: (work@test_program.BURST_W), line:19, col:14, parent:work@test_program
+                |vpiOperand:
+                \_constant: , line:31, col:26
+                  |vpiConstType:9
+                  |vpiDecompile:1
+                  |vpiSize:64
+                  |UINT:1
+              |vpiRightRange:
+              \_constant: , line:31, col:28
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
                 |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (burstcount), line:48, col:36, parent:Command
-            |vpiName:burstcount
-            |vpiTypespec:
-            \_logic_typespec: (Burstcount), line:31, col:11, parent:burstcount
+            |vpiTypedefAlias:
+            \_logic_typespec: (Burstcount), line:31, col:11, parent:Burstcount
               |vpiName:Burstcount
               |vpiRange:
               \_range: , line:31, col:18, parent:Burstcount
@@ -29586,9 +28679,9 @@ design: (work@top)
                 \_operation: , line:31, col:18
                   |vpiOpType:11
                   |vpiOperand:
-                  \_ref_obj: (work@test_program.get_expected_read_response.cmd.Command.Command.burstcount.Burstcount.BURST_W), line:31, col:18
+                  \_ref_obj: (work@test_program.get_expected_read_response.cmd.Command.burstcount.Burstcount.Burstcount.BURST_W), line:31, col:18
                     |vpiName:BURST_W
-                    |vpiFullName:work@test_program.get_expected_read_response.cmd.Command.Command.burstcount.Burstcount.BURST_W
+                    |vpiFullName:work@test_program.get_expected_read_response.cmd.Command.burstcount.Burstcount.Burstcount.BURST_W
                     |vpiActual:
                     \_parameter: (work@test_program.BURST_W), line:19, col:14, parent:work@test_program
                   |vpiOperand:
@@ -29603,154 +28696,128 @@ design: (work@top)
                   |vpiDecompile:0
                   |vpiSize:64
                   |UINT:0
-              |vpiTypedefAlias:
-              \_logic_typespec: (Burstcount), line:31, col:11, parent:Burstcount
-                |vpiName:Burstcount
-                |vpiRange:
-                \_range: , line:31, col:18, parent:Burstcount
-                  |vpiLeftRange:
-                  \_operation: , line:31, col:18
-                    |vpiOpType:11
-                    |vpiOperand:
-                    \_ref_obj: (work@test_program.get_expected_read_response.cmd.Command.Command.burstcount.Burstcount.Burstcount.BURST_W), line:31, col:18
-                      |vpiName:BURST_W
-                      |vpiFullName:work@test_program.get_expected_read_response.cmd.Command.Command.burstcount.Burstcount.Burstcount.BURST_W
-                      |vpiActual:
-                      \_parameter: (work@test_program.BURST_W), line:19, col:14, parent:work@test_program
-                    |vpiOperand:
-                    \_constant: , line:31, col:26
-                      |vpiConstType:9
-                      |vpiDecompile:1
-                      |vpiSize:64
-                      |UINT:1
-                  |vpiRightRange:
-                  \_constant: , line:31, col:28
-                    |vpiConstType:9
-                    |vpiDecompile:0
-                    |vpiSize:64
-                    |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (addr), line:49, col:36, parent:Command
-            |vpiName:addr
-            |vpiTypespec:
-            \_logic_typespec: , line:49, col:7, parent:addr
-              |vpiRange:
-              \_range: , line:49, col:14
-                |vpiLeftRange:
-                \_operation: , line:49, col:14
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (work@test_program.get_expected_read_response.cmd.Command.Command.addr.ADDR_W), line:49, col:14
-                    |vpiName:ADDR_W
-                    |vpiFullName:work@test_program.get_expected_read_response.cmd.Command.Command.addr.ADDR_W
-                    |vpiActual:
-                    \_parameter: (work@test_program.ADDR_W), line:13, col:14, parent:work@test_program
-                  |vpiOperand:
-                  \_constant: , line:49, col:21
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:49, col:24
+        |vpiTypespecMember:
+        \_typespec_member: (addr), line:49, col:36, parent:Command
+          |vpiName:addr
+          |vpiTypespec:
+          \_logic_typespec: , line:49, col:7, parent:addr
+            |vpiRange:
+            \_range: , line:49, col:14
+              |vpiLeftRange:
+              \_operation: , line:49, col:14
+                |vpiOpType:11
+                |vpiOperand:
+                \_ref_obj: (work@test_program.get_expected_read_response.cmd.Command.addr.ADDR_W), line:49, col:14
+                  |vpiName:ADDR_W
+                  |vpiFullName:work@test_program.get_expected_read_response.cmd.Command.addr.ADDR_W
+                  |vpiActual:
+                  \_parameter: (work@test_program.ADDR_W), line:13, col:14, parent:work@test_program
+                |vpiOperand:
+                \_constant: , line:49, col:21
                   |vpiConstType:9
-                  |vpiDecompile:0
+                  |vpiDecompile:1
                   |vpiSize:64
-                  |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (data), line:50, col:36, parent:Command
-            |vpiName:data
-            |vpiTypespec:
-            \_logic_typespec: , line:50, col:7, parent:data
-              |vpiRange:
-              \_range: , line:50, col:14
-                |vpiLeftRange:
-                \_operation: , line:50, col:14
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (work@test_program.get_expected_read_response.cmd.Command.Command.data.DATA_W), line:50, col:14
-                    |vpiName:DATA_W
-                    |vpiFullName:work@test_program.get_expected_read_response.cmd.Command.Command.data.DATA_W
-                    |vpiActual:
-                    \_parameter: (work@test_program.DATA_W), line:17, col:14, parent:work@test_program
-                  |vpiOperand:
-                  \_constant: , line:50, col:21
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:50, col:23
+                  |UINT:1
+              |vpiRightRange:
+              \_constant: , line:49, col:24
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+        |vpiTypespecMember:
+        \_typespec_member: (data), line:50, col:36, parent:Command
+          |vpiName:data
+          |vpiTypespec:
+          \_logic_typespec: , line:50, col:7, parent:data
+            |vpiRange:
+            \_range: , line:50, col:14
+              |vpiLeftRange:
+              \_operation: , line:50, col:14
+                |vpiOpType:11
+                |vpiOperand:
+                \_ref_obj: (work@test_program.get_expected_read_response.cmd.Command.data.DATA_W), line:50, col:14
+                  |vpiName:DATA_W
+                  |vpiFullName:work@test_program.get_expected_read_response.cmd.Command.data.DATA_W
+                  |vpiActual:
+                  \_parameter: (work@test_program.DATA_W), line:17, col:14, parent:work@test_program
+                |vpiOperand:
+                \_constant: , line:50, col:21
                   |vpiConstType:9
-                  |vpiDecompile:0
+                  |vpiDecompile:1
                   |vpiSize:64
-                  |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (byteenable), line:51, col:36, parent:Command
-            |vpiName:byteenable
-            |vpiTypespec:
-            \_logic_typespec: , line:51, col:7, parent:byteenable
-              |vpiRange:
-              \_range: , line:51, col:14
-                |vpiLeftRange:
-                \_operation: , line:51, col:14
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (work@test_program.get_expected_read_response.cmd.Command.Command.byteenable.NUM_SYMBOLS), line:51, col:14
-                    |vpiName:NUM_SYMBOLS
-                    |vpiFullName:work@test_program.get_expected_read_response.cmd.Command.Command.byteenable.NUM_SYMBOLS
-                    |vpiActual:
-                    \_parameter: (work@test_program.NUM_SYMBOLS), line:16, col:14, parent:work@test_program
-                  |vpiOperand:
-                  \_constant: , line:51, col:26
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:51, col:28
+                  |UINT:1
+              |vpiRightRange:
+              \_constant: , line:50, col:23
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+        |vpiTypespecMember:
+        \_typespec_member: (byteenable), line:51, col:36, parent:Command
+          |vpiName:byteenable
+          |vpiTypespec:
+          \_logic_typespec: , line:51, col:7, parent:byteenable
+            |vpiRange:
+            \_range: , line:51, col:14
+              |vpiLeftRange:
+              \_operation: , line:51, col:14
+                |vpiOpType:11
+                |vpiOperand:
+                \_ref_obj: (work@test_program.get_expected_read_response.cmd.Command.byteenable.NUM_SYMBOLS), line:51, col:14
+                  |vpiName:NUM_SYMBOLS
+                  |vpiFullName:work@test_program.get_expected_read_response.cmd.Command.byteenable.NUM_SYMBOLS
+                  |vpiActual:
+                  \_parameter: (work@test_program.NUM_SYMBOLS), line:16, col:14, parent:work@test_program
+                |vpiOperand:
+                \_constant: , line:51, col:26
                   |vpiConstType:9
-                  |vpiDecompile:0
+                  |vpiDecompile:1
                   |vpiSize:64
-                  |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (cmd_delay), line:52, col:36, parent:Command
-            |vpiName:cmd_delay
-            |vpiTypespec:
-            \_bit_typespec: , line:52, col:7, parent:cmd_delay
-              |vpiRange:
-              \_range: , line:52, col:12
-                |vpiLeftRange:
-                \_constant: , line:52, col:12
-                  |vpiConstType:9
-                  |vpiDecompile:31
-                  |vpiSize:64
-                  |UINT:31
-                |vpiRightRange:
-                \_constant: , line:52, col:15
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (data_idles), line:53, col:36, parent:Command
-            |vpiName:data_idles
-            |vpiTypespec:
-            \_bit_typespec: , line:53, col:7, parent:data_idles
-              |vpiRange:
-              \_range: , line:53, col:12
-                |vpiLeftRange:
-                \_constant: , line:53, col:12
-                  |vpiConstType:9
-                  |vpiDecompile:31
-                  |vpiSize:64
-                  |UINT:31
-                |vpiRightRange:
-                \_constant: , line:53, col:15
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
+                  |UINT:1
+              |vpiRightRange:
+              \_constant: , line:51, col:28
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+        |vpiTypespecMember:
+        \_typespec_member: (cmd_delay), line:52, col:36, parent:Command
+          |vpiName:cmd_delay
+          |vpiTypespec:
+          \_bit_typespec: , line:52, col:7, parent:cmd_delay
+            |vpiRange:
+            \_range: , line:52, col:12
+              |vpiLeftRange:
+              \_constant: , line:52, col:12
+                |vpiConstType:9
+                |vpiDecompile:31
+                |vpiSize:64
+                |UINT:31
+              |vpiRightRange:
+              \_constant: , line:52, col:15
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+        |vpiTypespecMember:
+        \_typespec_member: (data_idles), line:53, col:36, parent:Command
+          |vpiName:data_idles
+          |vpiTypespec:
+          \_bit_typespec: , line:53, col:7, parent:data_idles
+            |vpiRange:
+            \_range: , line:53, col:12
+              |vpiLeftRange:
+              \_constant: , line:53, col:12
+                |vpiConstType:9
+                |vpiDecompile:31
+                |vpiSize:64
+                |UINT:31
+              |vpiRightRange:
+              \_constant: , line:53, col:15
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
     |vpiStmt:
     \_begin: (work@test_program.get_expected_read_response), parent:work@test_program.get_expected_read_response
       |vpiFullName:work@test_program.get_expected_read_response
@@ -29765,8 +28832,6 @@ design: (work@top)
             |vpiActual:
             \_ref_obj: (cmd), parent:cmd.addr
               |vpiName:cmd
-              |vpiActual:
-              \_struct_var: (cmd.Command), line:775, col:6, parent:cmd
             |vpiActual:
             \_ref_obj: (addr), parent:cmd.addr
               |vpiName:addr
@@ -29932,18 +28997,40 @@ design: (work@top)
     \_io_decl: (actual_rsp), parent:work@test_program.verify_response
       |vpiName:actual_rsp
       |vpiDirection:1
-      |vpiExpr:
-      \_struct_var: (work@test_program.verify_response.actual_rsp.Response), line:787, col:6, parent:actual_rsp
+      |vpiTypedef:
+      \_struct_typespec: (Response), line:56, col:11, parent:actual_rsp
         |vpiName:Response
-        |vpiFullName:work@test_program.verify_response.actual_rsp.Response
-        |vpiTypespec:
-        \_struct_typespec: (Response), line:56, col:11, parent:work@test_program.verify_response.actual_rsp.Response
-          |vpiName:Response
-          |vpiTypespecMember:
-          \_typespec_member: (burstcount), line:58, col:36, parent:Response
-            |vpiName:burstcount
-            |vpiTypespec:
-            \_logic_typespec: (Burstcount), line:31, col:11, parent:burstcount
+        |vpiTypespecMember:
+        \_typespec_member: (burstcount), line:58, col:36, parent:Response
+          |vpiName:burstcount
+          |vpiTypespec:
+          \_logic_typespec: (Burstcount), line:31, col:11, parent:burstcount
+            |vpiName:Burstcount
+            |vpiRange:
+            \_range: , line:31, col:18, parent:Burstcount
+              |vpiLeftRange:
+              \_operation: , line:31, col:18
+                |vpiOpType:11
+                |vpiOperand:
+                \_ref_obj: (work@test_program.verify_response.actual_rsp.Response.burstcount.Burstcount.BURST_W), line:31, col:18
+                  |vpiName:BURST_W
+                  |vpiFullName:work@test_program.verify_response.actual_rsp.Response.burstcount.Burstcount.BURST_W
+                  |vpiActual:
+                  \_parameter: (work@test_program.BURST_W), line:19, col:14, parent:work@test_program
+                |vpiOperand:
+                \_constant: , line:31, col:26
+                  |vpiConstType:9
+                  |vpiDecompile:1
+                  |vpiSize:64
+                  |UINT:1
+              |vpiRightRange:
+              \_constant: , line:31, col:28
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+            |vpiTypedefAlias:
+            \_logic_typespec: (Burstcount), line:31, col:11, parent:Burstcount
               |vpiName:Burstcount
               |vpiRange:
               \_range: , line:31, col:18, parent:Burstcount
@@ -29951,9 +29038,9 @@ design: (work@top)
                 \_operation: , line:31, col:18
                   |vpiOpType:11
                   |vpiOperand:
-                  \_ref_obj: (work@test_program.verify_response.actual_rsp.Response.Response.burstcount.Burstcount.BURST_W), line:31, col:18
+                  \_ref_obj: (work@test_program.verify_response.actual_rsp.Response.burstcount.Burstcount.Burstcount.BURST_W), line:31, col:18
                     |vpiName:BURST_W
-                    |vpiFullName:work@test_program.verify_response.actual_rsp.Response.Response.burstcount.Burstcount.BURST_W
+                    |vpiFullName:work@test_program.verify_response.actual_rsp.Response.burstcount.Burstcount.Burstcount.BURST_W
                     |vpiActual:
                     \_parameter: (work@test_program.BURST_W), line:19, col:14, parent:work@test_program
                   |vpiOperand:
@@ -29968,95 +29055,91 @@ design: (work@top)
                   |vpiDecompile:0
                   |vpiSize:64
                   |UINT:0
-              |vpiTypedefAlias:
-              \_logic_typespec: (Burstcount), line:31, col:11, parent:Burstcount
-                |vpiName:Burstcount
-                |vpiRange:
-                \_range: , line:31, col:18, parent:Burstcount
-                  |vpiLeftRange:
-                  \_operation: , line:31, col:18
-                    |vpiOpType:11
-                    |vpiOperand:
-                    \_ref_obj: (work@test_program.verify_response.actual_rsp.Response.Response.burstcount.Burstcount.Burstcount.BURST_W), line:31, col:18
-                      |vpiName:BURST_W
-                      |vpiFullName:work@test_program.verify_response.actual_rsp.Response.Response.burstcount.Burstcount.Burstcount.BURST_W
-                      |vpiActual:
-                      \_parameter: (work@test_program.BURST_W), line:19, col:14, parent:work@test_program
-                    |vpiOperand:
-                    \_constant: , line:31, col:26
-                      |vpiConstType:9
-                      |vpiDecompile:1
-                      |vpiSize:64
-                      |UINT:1
-                  |vpiRightRange:
-                  \_constant: , line:31, col:28
-                    |vpiConstType:9
-                    |vpiDecompile:0
-                    |vpiSize:64
-                    |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (data), line:59, col:36, parent:Response
-            |vpiName:data
-            |vpiTypespec:
-            \_logic_typespec: , line:59, col:6, parent:data
-              |vpiRange:
-              \_range: , line:59, col:13
-                |vpiLeftRange:
-                \_operation: , line:59, col:13
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (work@test_program.verify_response.actual_rsp.Response.Response.data.DATA_W), line:59, col:13
-                    |vpiName:DATA_W
-                    |vpiFullName:work@test_program.verify_response.actual_rsp.Response.Response.data.DATA_W
-                    |vpiActual:
-                    \_parameter: (work@test_program.DATA_W), line:17, col:14, parent:work@test_program
-                  |vpiOperand:
-                  \_constant: , line:59, col:20
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:59, col:22
+        |vpiTypespecMember:
+        \_typespec_member: (data), line:59, col:36, parent:Response
+          |vpiName:data
+          |vpiTypespec:
+          \_logic_typespec: , line:59, col:6, parent:data
+            |vpiRange:
+            \_range: , line:59, col:13
+              |vpiLeftRange:
+              \_operation: , line:59, col:13
+                |vpiOpType:11
+                |vpiOperand:
+                \_ref_obj: (work@test_program.verify_response.actual_rsp.Response.data.DATA_W), line:59, col:13
+                  |vpiName:DATA_W
+                  |vpiFullName:work@test_program.verify_response.actual_rsp.Response.data.DATA_W
+                  |vpiActual:
+                  \_parameter: (work@test_program.DATA_W), line:17, col:14, parent:work@test_program
+                |vpiOperand:
+                \_constant: , line:59, col:20
                   |vpiConstType:9
-                  |vpiDecompile:0
+                  |vpiDecompile:1
                   |vpiSize:64
-                  |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (latency), line:60, col:36, parent:Response
-            |vpiName:latency
-            |vpiTypespec:
-            \_bit_typespec: , line:60, col:6, parent:latency
-              |vpiRange:
-              \_range: , line:60, col:11
-                |vpiLeftRange:
-                \_constant: , line:60, col:11
-                  |vpiConstType:9
-                  |vpiDecompile:31
-                  |vpiSize:64
-                  |UINT:31
-                |vpiRightRange:
-                \_constant: , line:60, col:14
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
+                  |UINT:1
+              |vpiRightRange:
+              \_constant: , line:59, col:22
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+        |vpiTypespecMember:
+        \_typespec_member: (latency), line:60, col:36, parent:Response
+          |vpiName:latency
+          |vpiTypespec:
+          \_bit_typespec: , line:60, col:6, parent:latency
+            |vpiRange:
+            \_range: , line:60, col:11
+              |vpiLeftRange:
+              \_constant: , line:60, col:11
+                |vpiConstType:9
+                |vpiDecompile:31
+                |vpiSize:64
+                |UINT:31
+              |vpiRightRange:
+              \_constant: , line:60, col:14
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
     |vpiIODecl:
     \_io_decl: (exp_rsp), parent:work@test_program.verify_response
       |vpiName:exp_rsp
       |vpiDirection:1
-      |vpiExpr:
-      \_struct_var: (work@test_program.verify_response.exp_rsp.Response), line:787, col:6, parent:exp_rsp
+      |vpiTypedef:
+      \_struct_typespec: (Response), line:56, col:11, parent:exp_rsp
         |vpiName:Response
-        |vpiFullName:work@test_program.verify_response.exp_rsp.Response
-        |vpiTypespec:
-        \_struct_typespec: (Response), line:56, col:11, parent:work@test_program.verify_response.exp_rsp.Response
-          |vpiName:Response
-          |vpiTypespecMember:
-          \_typespec_member: (burstcount), line:58, col:36, parent:Response
-            |vpiName:burstcount
-            |vpiTypespec:
-            \_logic_typespec: (Burstcount), line:31, col:11, parent:burstcount
+        |vpiTypespecMember:
+        \_typespec_member: (burstcount), line:58, col:36, parent:Response
+          |vpiName:burstcount
+          |vpiTypespec:
+          \_logic_typespec: (Burstcount), line:31, col:11, parent:burstcount
+            |vpiName:Burstcount
+            |vpiRange:
+            \_range: , line:31, col:18, parent:Burstcount
+              |vpiLeftRange:
+              \_operation: , line:31, col:18
+                |vpiOpType:11
+                |vpiOperand:
+                \_ref_obj: (work@test_program.verify_response.exp_rsp.Response.burstcount.Burstcount.BURST_W), line:31, col:18
+                  |vpiName:BURST_W
+                  |vpiFullName:work@test_program.verify_response.exp_rsp.Response.burstcount.Burstcount.BURST_W
+                  |vpiActual:
+                  \_parameter: (work@test_program.BURST_W), line:19, col:14, parent:work@test_program
+                |vpiOperand:
+                \_constant: , line:31, col:26
+                  |vpiConstType:9
+                  |vpiDecompile:1
+                  |vpiSize:64
+                  |UINT:1
+              |vpiRightRange:
+              \_constant: , line:31, col:28
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+            |vpiTypedefAlias:
+            \_logic_typespec: (Burstcount), line:31, col:11, parent:Burstcount
               |vpiName:Burstcount
               |vpiRange:
               \_range: , line:31, col:18, parent:Burstcount
@@ -30064,9 +29147,9 @@ design: (work@top)
                 \_operation: , line:31, col:18
                   |vpiOpType:11
                   |vpiOperand:
-                  \_ref_obj: (work@test_program.verify_response.exp_rsp.Response.Response.burstcount.Burstcount.BURST_W), line:31, col:18
+                  \_ref_obj: (work@test_program.verify_response.exp_rsp.Response.burstcount.Burstcount.Burstcount.BURST_W), line:31, col:18
                     |vpiName:BURST_W
-                    |vpiFullName:work@test_program.verify_response.exp_rsp.Response.Response.burstcount.Burstcount.BURST_W
+                    |vpiFullName:work@test_program.verify_response.exp_rsp.Response.burstcount.Burstcount.Burstcount.BURST_W
                     |vpiActual:
                     \_parameter: (work@test_program.BURST_W), line:19, col:14, parent:work@test_program
                   |vpiOperand:
@@ -30081,79 +29164,53 @@ design: (work@top)
                   |vpiDecompile:0
                   |vpiSize:64
                   |UINT:0
-              |vpiTypedefAlias:
-              \_logic_typespec: (Burstcount), line:31, col:11, parent:Burstcount
-                |vpiName:Burstcount
-                |vpiRange:
-                \_range: , line:31, col:18, parent:Burstcount
-                  |vpiLeftRange:
-                  \_operation: , line:31, col:18
-                    |vpiOpType:11
-                    |vpiOperand:
-                    \_ref_obj: (work@test_program.verify_response.exp_rsp.Response.Response.burstcount.Burstcount.Burstcount.BURST_W), line:31, col:18
-                      |vpiName:BURST_W
-                      |vpiFullName:work@test_program.verify_response.exp_rsp.Response.Response.burstcount.Burstcount.Burstcount.BURST_W
-                      |vpiActual:
-                      \_parameter: (work@test_program.BURST_W), line:19, col:14, parent:work@test_program
-                    |vpiOperand:
-                    \_constant: , line:31, col:26
-                      |vpiConstType:9
-                      |vpiDecompile:1
-                      |vpiSize:64
-                      |UINT:1
-                  |vpiRightRange:
-                  \_constant: , line:31, col:28
-                    |vpiConstType:9
-                    |vpiDecompile:0
-                    |vpiSize:64
-                    |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (data), line:59, col:36, parent:Response
-            |vpiName:data
-            |vpiTypespec:
-            \_logic_typespec: , line:59, col:6, parent:data
-              |vpiRange:
-              \_range: , line:59, col:13
-                |vpiLeftRange:
-                \_operation: , line:59, col:13
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (work@test_program.verify_response.exp_rsp.Response.Response.data.DATA_W), line:59, col:13
-                    |vpiName:DATA_W
-                    |vpiFullName:work@test_program.verify_response.exp_rsp.Response.Response.data.DATA_W
-                    |vpiActual:
-                    \_parameter: (work@test_program.DATA_W), line:17, col:14, parent:work@test_program
-                  |vpiOperand:
-                  \_constant: , line:59, col:20
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:59, col:22
+        |vpiTypespecMember:
+        \_typespec_member: (data), line:59, col:36, parent:Response
+          |vpiName:data
+          |vpiTypespec:
+          \_logic_typespec: , line:59, col:6, parent:data
+            |vpiRange:
+            \_range: , line:59, col:13
+              |vpiLeftRange:
+              \_operation: , line:59, col:13
+                |vpiOpType:11
+                |vpiOperand:
+                \_ref_obj: (work@test_program.verify_response.exp_rsp.Response.data.DATA_W), line:59, col:13
+                  |vpiName:DATA_W
+                  |vpiFullName:work@test_program.verify_response.exp_rsp.Response.data.DATA_W
+                  |vpiActual:
+                  \_parameter: (work@test_program.DATA_W), line:17, col:14, parent:work@test_program
+                |vpiOperand:
+                \_constant: , line:59, col:20
                   |vpiConstType:9
-                  |vpiDecompile:0
+                  |vpiDecompile:1
                   |vpiSize:64
-                  |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (latency), line:60, col:36, parent:Response
-            |vpiName:latency
-            |vpiTypespec:
-            \_bit_typespec: , line:60, col:6, parent:latency
-              |vpiRange:
-              \_range: , line:60, col:11
-                |vpiLeftRange:
-                \_constant: , line:60, col:11
-                  |vpiConstType:9
-                  |vpiDecompile:31
-                  |vpiSize:64
-                  |UINT:31
-                |vpiRightRange:
-                \_constant: , line:60, col:14
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
+                  |UINT:1
+              |vpiRightRange:
+              \_constant: , line:59, col:22
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+        |vpiTypespecMember:
+        \_typespec_member: (latency), line:60, col:36, parent:Response
+          |vpiName:latency
+          |vpiTypespec:
+          \_bit_typespec: , line:60, col:6, parent:latency
+            |vpiRange:
+            \_range: , line:60, col:11
+              |vpiLeftRange:
+              \_constant: , line:60, col:11
+                |vpiConstType:9
+                |vpiDecompile:31
+                |vpiSize:64
+                |UINT:31
+              |vpiRightRange:
+              \_constant: , line:60, col:14
+                |vpiConstType:9
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
     |vpiStmt:
     \_begin: (work@test_program.verify_response), parent:work@test_program.verify_response
       |vpiFullName:work@test_program.verify_response
@@ -30174,8 +29231,6 @@ design: (work@top)
           |vpiActual:
           \_ref_obj: (exp_rsp), parent:exp_rsp.burstcount
             |vpiName:exp_rsp
-            |vpiActual:
-            \_struct_var: (exp_rsp.Response), line:787, col:6, parent:exp_rsp
           |vpiActual:
           \_ref_obj: (burstcount), parent:exp_rsp.burstcount
             |vpiName:burstcount
@@ -30185,8 +29240,6 @@ design: (work@top)
           |vpiActual:
           \_ref_obj: (actual_rsp), parent:actual_rsp.burstcount
             |vpiName:actual_rsp
-            |vpiActual:
-            \_struct_var: (actual_rsp.Response), line:787, col:6, parent:actual_rsp
           |vpiActual:
           \_ref_obj: (burstcount), parent:actual_rsp.burstcount
             |vpiName:burstcount
@@ -30206,8 +29259,6 @@ design: (work@top)
             |vpiActual:
             \_ref_obj: (actual_rsp), parent:actual_rsp.burstcount
               |vpiName:actual_rsp
-              |vpiActual:
-              \_struct_var: (actual_rsp.Response), line:787, col:6, parent:actual_rsp
             |vpiActual:
             \_ref_obj: (burstcount), parent:actual_rsp.burstcount
               |vpiName:burstcount
@@ -30250,8 +29301,6 @@ design: (work@top)
               |vpiActual:
               \_ref_obj: (exp_rsp), parent:exp_rsp.data[i]
                 |vpiName:exp_rsp
-                |vpiActual:
-                \_struct_var: (exp_rsp.Response), line:787, col:6, parent:exp_rsp
               |vpiActual:
               \_bit_select: (data), parent:exp_rsp.data[i]
                 |vpiName:data
@@ -30265,8 +29314,6 @@ design: (work@top)
               |vpiActual:
               \_ref_obj: (actual_rsp), parent:actual_rsp.data[i]
                 |vpiName:actual_rsp
-                |vpiActual:
-                \_struct_var: (actual_rsp.Response), line:787, col:6, parent:actual_rsp
               |vpiActual:
               \_bit_select: (data), parent:actual_rsp.data[i]
                 |vpiName:data

--- a/tests/DpiChandle/DpiChandle.log
+++ b/tests/DpiChandle/DpiChandle.log
@@ -110,9 +110,14 @@ design: (work@top)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -304,9 +309,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -317,9 +327,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -330,9 +345,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -345,9 +365,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@top (work@top) dut.sv:1: , endline:7:9: , parent:work@top
   |vpiDefName:work@top
@@ -376,9 +401,6 @@ design: (work@top)
     \_io_decl: (in)
       |vpiName:in
       |vpiDirection:1
-      |vpiExpr:
-      \_chandle_var: (in), line:6, col:27, parent:in
-        |vpiFullName:in
 |uhdmtopModules:
 \_module: work@top (work@top) dut.sv:1: , endline:7:9: 
   |vpiDefName:work@top
@@ -420,9 +442,6 @@ design: (work@top)
         \_io_decl: (in)
           |vpiName:in
           |vpiDirection:1
-          |vpiExpr:
-          \_chandle_var: (in), line:6, col:27, parent:in
-            |vpiFullName:in
   |vpiTaskFunc:
   \_function: (work@top.test_input), line:5, col:3, parent:work@top
     |vpiAccessType:4
@@ -436,9 +455,6 @@ design: (work@top)
     \_io_decl: (in), parent:work@top.test_input
       |vpiName:in
       |vpiDirection:1
-      |vpiExpr:
-      \_chandle_var: (work@top.test_input.in), line:6, col:27, parent:in
-        |vpiFullName:work@top.test_input.in
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/DpiFunc/DpiFunc.log
+++ b/tests/DpiFunc/DpiFunc.log
@@ -113,9 +113,14 @@ design: (work@top)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -307,9 +312,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -320,9 +330,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -333,9 +348,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -348,9 +368,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@top (work@top) dut.sv:1: , endline:6:9: , parent:work@top
   |vpiDefName:work@top

--- a/tests/DpiTask/DpiTask.log
+++ b/tests/DpiTask/DpiTask.log
@@ -122,9 +122,14 @@ design: (work@top)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -316,9 +321,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -329,9 +339,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -342,9 +357,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -357,9 +377,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@top (work@top) dut.sv:1: , endline:8:9: , parent:work@top
   |vpiDefName:work@top
@@ -377,9 +402,8 @@ design: (work@top)
     \_io_decl: (ret)
       |vpiName:ret
       |vpiDirection:2
-      |vpiExpr:
-      \_int_var: (ret), line:4, col:21, parent:ret
-        |vpiFullName:ret
+      |vpiTypedef:
+      \_int_typespec: , line:4, col:21
     |vpiStmt:
     \_assignment: , line:5, col:4, parent:work@top.task_1
       |vpiOpType:82
@@ -424,9 +448,8 @@ design: (work@top)
         \_io_decl: (ret)
           |vpiName:ret
           |vpiDirection:2
-          |vpiExpr:
-          \_int_var: (ret), line:4, col:21, parent:ret
-            |vpiFullName:ret
+          |vpiTypedef:
+          \_int_typespec: , line:4, col:21
         |vpiStmt:
         \_assignment: , line:5, col:4, parent:work@top.task_1
           |vpiOpType:82
@@ -447,9 +470,8 @@ design: (work@top)
     \_io_decl: (ret), parent:work@top.task_1
       |vpiName:ret
       |vpiDirection:2
-      |vpiExpr:
-      \_int_var: (work@top.task_1.ret), line:4, col:21, parent:ret
-        |vpiFullName:work@top.task_1.ret
+      |vpiTypedef:
+      \_int_typespec: , line:4, col:21, parent:ret
     |vpiStmt:
     \_assignment: , line:5, col:4, parent:work@top.task_1
       |vpiOpType:82
@@ -458,8 +480,6 @@ design: (work@top)
       \_ref_obj: (work@top.task_1.ret), line:5, col:4
         |vpiName:ret
         |vpiFullName:work@top.task_1.ret
-        |vpiActual:
-        \_int_var: (ret), line:4, col:21, parent:ret
       |vpiRhs:
       \_constant: , line:5, col:10
         |vpiConstType:9

--- a/tests/ElabCParam/ElabCParam.log
+++ b/tests/ElabCParam/ElabCParam.log
@@ -655,9 +655,14 @@ design: (work@socket_1n)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -849,9 +854,14 @@ design: (work@socket_1n)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -862,9 +872,14 @@ design: (work@socket_1n)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -875,9 +890,14 @@ design: (work@socket_1n)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -890,9 +910,14 @@ design: (work@socket_1n)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@all_zero (work@all_zero) dut.sv:54: , endline:67:9: , parent:work@socket_1n
   |vpiDefName:work@all_zero

--- a/tests/ElabIf/ElabIf.log
+++ b/tests/ElabIf/ElabIf.log
@@ -89,9 +89,14 @@ design: (work@top)
     \_io_decl: (bound)
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16
       |vpiExpr:
-      \_int_var: (bound), line:6, col:16, parent:bound
-        |vpiFullName:bound
+      \_constant: , line:6, col:28
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -262,9 +267,14 @@ design: (work@top)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15
       |vpiExpr:
-      \_int_var: (keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:60, col:30
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -275,9 +285,14 @@ design: (work@top)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11
       |vpiExpr:
-      \_int_var: (keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:63, col:26
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -288,9 +303,14 @@ design: (work@top)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11
       |vpiExpr:
-      \_int_var: (keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:66, col:26
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -303,9 +323,14 @@ design: (work@top)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23
       |vpiExpr:
-      \_int_var: (keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:69, col:38
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@assigner (work@assigner) dut.sv:6: , endline:11:9: , parent:work@top
   |vpiDefName:work@assigner

--- a/tests/ElabParam/ElabParam.log
+++ b/tests/ElabParam/ElabParam.log
@@ -326,9 +326,14 @@ design: (work@dut)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -520,9 +525,14 @@ design: (work@dut)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -533,9 +543,14 @@ design: (work@dut)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -546,9 +561,14 @@ design: (work@dut)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -561,9 +581,14 @@ design: (work@dut)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@dut (work@dut) dut.sv:11:1: , endline:18:10: , parent:work@dut
   |vpiDefName:work@dut

--- a/tests/EvalFunc/EvalFunc.log
+++ b/tests/EvalFunc/EvalFunc.log
@@ -790,9 +790,10 @@ design: (work@top)
     \_io_decl: (value)
       |vpiName:value
       |vpiDirection:1
-      |vpiExpr:
-      \_int_var: (value), line:3, col:36, parent:value
-        |vpiFullName:value
+      |vpiTypedef:
+      \_int_typespec: , line:3, col:36
+        |vpiInstance:
+        \_package: prim_util_pkg (prim_util_pkg::) dut.sv:1: , parent:work@top
     |vpiStmt:
     \_begin: (prim_util_pkg::_clog2), parent:prim_util_pkg::_clog2
       |vpiFullName:prim_util_pkg::_clog2
@@ -918,9 +919,10 @@ design: (work@top)
     \_io_decl: (value)
       |vpiName:value
       |vpiDirection:1
-      |vpiExpr:
-      \_int_var: (value), line:12, col:35, parent:value
-        |vpiFullName:value
+      |vpiTypedef:
+      \_int_typespec: , line:12, col:35
+        |vpiInstance:
+        \_package: prim_util_pkg (prim_util_pkg::) dut.sv:1: , parent:work@top
     |vpiStmt:
     \_return_stmt: , line:14, col:4, parent:prim_util_pkg::vbits
       |vpiCondition:
@@ -972,9 +974,14 @@ design: (work@top)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -1166,9 +1173,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -1179,9 +1191,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -1192,9 +1209,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -1207,9 +1229,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@top (work@top) dut.sv:22: , endline:68:9: , parent:work@top
   |vpiDefName:work@top
@@ -1228,9 +1255,8 @@ design: (work@top)
     \_io_decl: (value)
       |vpiName:value
       |vpiDirection:1
-      |vpiExpr:
-      \_int_var: (value), line:24, col:33, parent:value
-        |vpiFullName:value
+      |vpiTypedef:
+      \_int_typespec: , line:24, col:33
     |vpiStmt:
     \_return_stmt: , line:25, col:2, parent:work@top.vbits
       |vpiCondition:
@@ -1720,9 +1746,8 @@ design: (work@top)
         \_io_decl: (value)
           |vpiName:value
           |vpiDirection:1
-          |vpiExpr:
-          \_int_var: (value), line:24, col:33, parent:value
-            |vpiFullName:value
+          |vpiTypedef:
+          \_int_typespec: , line:24, col:33
         |vpiStmt:
         \_return_stmt: , line:25, col:2, parent:work@top.vbits
           |vpiCondition:
@@ -2186,9 +2211,8 @@ design: (work@top)
     \_io_decl: (value), parent:work@top.vbits
       |vpiName:value
       |vpiDirection:1
-      |vpiExpr:
-      \_int_var: (work@top.vbits.value), line:24, col:33, parent:value
-        |vpiFullName:work@top.vbits.value
+      |vpiTypedef:
+      \_int_typespec: , line:24, col:33, parent:value
     |vpiStmt:
     \_return_stmt: , line:25, col:2, parent:work@top.vbits
       |vpiCondition:
@@ -2201,8 +2225,6 @@ design: (work@top)
           \_ref_obj: (work@top.vbits.value), line:25, col:10
             |vpiName:value
             |vpiFullName:work@top.vbits.value
-            |vpiActual:
-            \_int_var: (value), line:24, col:33, parent:value
           |vpiOperand:
           \_constant: , line:25, col:19
             |vpiConstType:9
@@ -2222,8 +2244,6 @@ design: (work@top)
           \_ref_obj: (work@top.vbits.value), line:25, col:35, parent:$clog2
             |vpiName:value
             |vpiFullName:work@top.vbits.value
-            |vpiActual:
-            \_int_var: (value), line:24, col:33, parent:value
   |vpiTaskFunc:
   \_function: (work@top.foo), line:28, parent:work@top
     |vpiVisibility:1

--- a/tests/EvalFuncArray/EvalFuncArray.log
+++ b/tests/EvalFuncArray/EvalFuncArray.log
@@ -260,30 +260,29 @@ design: (unnamed)
     \_io_decl: (infos)
       |vpiName:infos
       |vpiDirection:1
-      |vpiExpr:
-      \_array_var: (infos), parent:infos
-        |vpiFullName:infos
-        |vpiReg:
-        \_int_var: , line:12, col:45
-        |vpiRange:
-        \_range: , line:12, col:55
-          |vpiLeftRange:
-          \_constant: , line:12, col:55
-            |vpiConstType:9
-            |vpiDecompile:0
+      |vpiTypedef:
+      \_int_typespec: , line:12, col:45
+        |vpiInstance:
+        \_package: earlgrey (earlgrey::) dut.sv:1: , parent:unnamed
+      |vpiRange:
+      \_range: , line:12, col:55
+        |vpiLeftRange:
+        \_constant: , line:12, col:55
+          |vpiConstType:9
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+        |vpiRightRange:
+        \_operation: 
+          |vpiOpType:11
+          |vpiOperand:
+          \_ref_obj: (InfoTypes), line:12, col:55
+            |vpiName:InfoTypes
+          |vpiOperand:
+          \_constant: 
+            |vpiConstType:7
             |vpiSize:64
-            |UINT:0
-          |vpiRightRange:
-          \_operation: 
-            |vpiOpType:11
-            |vpiOperand:
-            \_ref_obj: (InfoTypes), line:12, col:55
-              |vpiName:InfoTypes
-            |vpiOperand:
-            \_constant: 
-              |vpiConstType:7
-              |vpiSize:64
-              |INT:1
+            |INT:1
     |vpiStmt:
     \_begin: (earlgrey::max_info_pages), parent:earlgrey::max_info_pages
       |vpiFullName:earlgrey::max_info_pages
@@ -432,9 +431,14 @@ design: (unnamed)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -626,9 +630,14 @@ design: (unnamed)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -639,9 +648,14 @@ design: (unnamed)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -652,9 +666,14 @@ design: (unnamed)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -667,9 +686,14 @@ design: (unnamed)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/EvalFuncCont/EvalFuncCont.log
+++ b/tests/EvalFuncCont/EvalFuncCont.log
@@ -364,9 +364,14 @@ design: (work@t)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -558,9 +563,14 @@ design: (work@t)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -571,9 +581,14 @@ design: (work@t)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -584,9 +599,14 @@ design: (work@t)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -599,9 +619,14 @@ design: (work@t)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@t (work@t) dut.sv:8: , endline:35:9: , parent:work@t
   |vpiDefName:work@t

--- a/tests/EvalFuncNamed/EvalFuncNamed.log
+++ b/tests/EvalFuncNamed/EvalFuncNamed.log
@@ -313,16 +313,18 @@ design: (work@t)
         \_io_decl: (value1)
           |vpiName:value1
           |vpiDirection:1
-          |vpiExpr:
-          \_int_var: (value1), line:9, col:45, parent:value1
-            |vpiFullName:value1
+          |vpiTypedef:
+          \_int_typespec: , line:9, col:45
+            |vpiInstance:
+            \_package: my_funcs (my_funcs::) dut.sv:1: , parent:work@t
         |vpiIODecl:
         \_io_decl: (value2)
           |vpiName:value2
           |vpiDirection:1
-          |vpiExpr:
-          \_int_var: (value2), line:9, col:63, parent:value2
-            |vpiFullName:value2
+          |vpiTypedef:
+          \_int_typespec: , line:9, col:63
+            |vpiInstance:
+            \_package: my_funcs (my_funcs::) dut.sv:1: , parent:work@t
         |vpiStmt:
         \_begin: (my_module_types::simple_func), line:10, col:6, parent:my_module_types::simple_func
           |vpiFullName:my_module_types::simple_func
@@ -383,16 +385,18 @@ design: (work@t)
     \_io_decl: (value1)
       |vpiName:value1
       |vpiDirection:1
-      |vpiExpr:
-      \_int_var: (value1), line:3, col:46, parent:value1
-        |vpiFullName:value1
+      |vpiTypedef:
+      \_int_typespec: , line:3, col:46
+        |vpiInstance:
+        \_package: my_funcs (my_funcs::) dut.sv:1: , parent:work@t
     |vpiIODecl:
     \_io_decl: (value2)
       |vpiName:value2
       |vpiDirection:1
-      |vpiExpr:
-      \_int_var: (value2), line:3, col:64, parent:value2
-        |vpiFullName:value2
+      |vpiTypedef:
+      \_int_typespec: , line:3, col:64
+        |vpiInstance:
+        \_package: my_funcs (my_funcs::) dut.sv:1: , parent:work@t
     |vpiStmt:
     \_begin: (my_module_types::simple_minus), line:4, col:6, parent:my_module_types::simple_minus
       |vpiFullName:my_module_types::simple_minus
@@ -441,9 +445,14 @@ design: (work@t)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -635,9 +644,14 @@ design: (work@t)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -648,9 +662,14 @@ design: (work@t)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -661,9 +680,14 @@ design: (work@t)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -676,9 +700,14 @@ design: (work@t)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@t (work@t) dut.sv:23: , endline:31:9: , parent:work@t
   |vpiDefName:work@t
@@ -743,16 +772,25 @@ design: (work@t)
         \_io_decl: (value1)
           |vpiName:value1
           |vpiDirection:1
-          |vpiExpr:
-          \_int_var: (value1), line:9, col:45, parent:value1
-            |vpiFullName:value1
+          |vpiTypedef:
+          \_int_typespec: , line:9, col:45
+            |vpiInstance:
+            \_package: my_funcs (my_funcs::) dut.sv:1: , parent:work@t
+              |vpiDefName:my_funcs
+              |vpiName:my_funcs
+              |vpiFullName:my_funcs::
+              |vpiTaskFunc:
+              \_function: (my_module_types::simple_minus), line:3, col:3, parent:my_module_types::
+              |vpiTaskFunc:
+              \_function: (my_module_types::simple_func), line:9, col:3, parent:my_module_types::
         |vpiIODecl:
         \_io_decl: (value2)
           |vpiName:value2
           |vpiDirection:1
-          |vpiExpr:
-          \_int_var: (value2), line:9, col:63, parent:value2
-            |vpiFullName:value2
+          |vpiTypedef:
+          \_int_typespec: , line:9, col:63
+            |vpiInstance:
+            \_package: my_funcs (my_funcs::) dut.sv:1: , parent:work@t
         |vpiStmt:
         \_begin: (my_module_types::simple_func), line:10, col:6, parent:my_module_types::simple_func
           |vpiFullName:my_module_types::simple_func
@@ -813,16 +851,18 @@ design: (work@t)
     \_io_decl: (value1)
       |vpiName:value1
       |vpiDirection:1
-      |vpiExpr:
-      \_int_var: (value1), line:3, col:46, parent:value1
-        |vpiFullName:value1
+      |vpiTypedef:
+      \_int_typespec: , line:3, col:46
+        |vpiInstance:
+        \_package: my_funcs (my_funcs::) dut.sv:1: , parent:work@t
     |vpiIODecl:
     \_io_decl: (value2)
       |vpiName:value2
       |vpiDirection:1
-      |vpiExpr:
-      \_int_var: (value2), line:3, col:64, parent:value2
-        |vpiFullName:value2
+      |vpiTypedef:
+      \_int_typespec: , line:3, col:64
+        |vpiInstance:
+        \_package: my_funcs (my_funcs::) dut.sv:1: , parent:work@t
     |vpiStmt:
     \_begin: (my_module_types::simple_minus), line:4, col:6, parent:my_module_types::simple_minus
       |vpiFullName:my_module_types::simple_minus
@@ -989,16 +1029,73 @@ design: (work@t)
         \_io_decl: (value1)
           |vpiName:value1
           |vpiDirection:1
-          |vpiExpr:
-          \_int_var: (value1), line:3, col:46, parent:value1
-            |vpiFullName:value1
+          |vpiTypedef:
+          \_int_typespec: , line:3, col:46
+            |vpiInstance:
+            \_package: my_funcs (my_funcs::) dut.sv:1: , parent:work@t
+              |vpiDefName:my_funcs
+              |vpiName:my_funcs
+              |vpiFullName:my_funcs::
+              |vpiTaskFunc:
+              \_function: (my_module_types::simple_minus), line:3, col:3, parent:my_module_types::
+              |vpiTaskFunc:
+              \_function: (my_module_types::simple_func), line:9, col:3, parent:my_module_types::
+                |vpiVisibility:1
+                |vpiAutomatic:1
+                |vpiName:simple_func
+                |vpiFullName:my_module_types::simple_func
+                |vpiReturn:
+                \_int_var: , line:9, col:22
+                |vpiInstance:
+                \_package: my_module_types (my_module_types::) dut.sv:16: , parent:work@t
+                |vpiIODecl:
+                \_io_decl: (value1)
+                  |vpiName:value1
+                  |vpiDirection:1
+                  |vpiTypedef:
+                  \_int_typespec: , line:9, col:45
+                    |vpiInstance:
+                    \_package: my_funcs (my_funcs::) dut.sv:1: , parent:work@t
+                |vpiIODecl:
+                \_io_decl: (value2)
+                  |vpiName:value2
+                  |vpiDirection:1
+                  |vpiTypedef:
+                  \_int_typespec: , line:9, col:63
+                    |vpiInstance:
+                    \_package: my_funcs (my_funcs::) dut.sv:1: , parent:work@t
+                |vpiStmt:
+                \_begin: (my_module_types::simple_func), line:10, col:6, parent:my_module_types::simple_func
+                  |vpiFullName:my_module_types::simple_func
+                  |vpiStmt:
+                  \_assignment: , line:11, col:7, parent:my_module_types::simple_func
+                    |vpiOpType:82
+                    |vpiBlocking:1
+                    |vpiLhs:
+                    \_ref_obj: (my_module_types::simple_func::simple_func), line:11, col:7, parent:my_module_types::simple_func
+                      |vpiName:simple_func
+                      |vpiFullName:my_module_types::simple_func::simple_func
+                    |vpiRhs:
+                    \_func_call: (simple_minus), line:11, col:21
+                      |vpiName:simple_minus
+                      |vpiFunction:
+                      \_function: (my_module_types::simple_minus), line:3, col:3, parent:my_module_types::
+                      |vpiArgument:
+                      \_ref_obj: (my_module_types::simple_func::value1), line:11, col:59, parent:simple_minus
+                        |vpiName:value1
+                        |vpiFullName:my_module_types::simple_func::value1
+                      |vpiArgument:
+                      \_ref_obj: (my_module_types::simple_func::value2), line:11, col:42, parent:simple_minus
+                        |vpiName:value2
+                        |vpiFullName:my_module_types::simple_func::value2
         |vpiIODecl:
         \_io_decl: (value2)
           |vpiName:value2
           |vpiDirection:1
-          |vpiExpr:
-          \_int_var: (value2), line:3, col:64, parent:value2
-            |vpiFullName:value2
+          |vpiTypedef:
+          \_int_typespec: , line:3, col:64
+            |vpiInstance:
+            \_package: my_funcs (my_funcs::) dut.sv:1: , parent:work@t
         |vpiStmt:
         \_begin: (my_module_types::simple_minus), line:4, col:6, parent:my_module_types::simple_minus
           |vpiFullName:my_module_types::simple_minus
@@ -1027,52 +1124,6 @@ design: (work@t)
                 \_io_decl: (value2)
       |vpiTaskFunc:
       \_function: (my_module_types::simple_func), line:9, col:3, parent:my_module_types::
-        |vpiVisibility:1
-        |vpiAutomatic:1
-        |vpiName:simple_func
-        |vpiFullName:my_module_types::simple_func
-        |vpiReturn:
-        \_int_var: , line:9, col:22
-        |vpiInstance:
-        \_package: my_module_types (my_module_types::) dut.sv:16: , parent:work@t
-        |vpiIODecl:
-        \_io_decl: (value1)
-          |vpiName:value1
-          |vpiDirection:1
-          |vpiExpr:
-          \_int_var: (value1), line:9, col:45, parent:value1
-            |vpiFullName:value1
-        |vpiIODecl:
-        \_io_decl: (value2)
-          |vpiName:value2
-          |vpiDirection:1
-          |vpiExpr:
-          \_int_var: (value2), line:9, col:63, parent:value2
-            |vpiFullName:value2
-        |vpiStmt:
-        \_begin: (my_module_types::simple_func), line:10, col:6, parent:my_module_types::simple_func
-          |vpiFullName:my_module_types::simple_func
-          |vpiStmt:
-          \_assignment: , line:11, col:7, parent:my_module_types::simple_func
-            |vpiOpType:82
-            |vpiBlocking:1
-            |vpiLhs:
-            \_ref_obj: (my_module_types::simple_func::simple_func), line:11, col:7, parent:my_module_types::simple_func
-              |vpiName:simple_func
-              |vpiFullName:my_module_types::simple_func::simple_func
-            |vpiRhs:
-            \_func_call: (simple_minus), line:11, col:21
-              |vpiName:simple_minus
-              |vpiFunction:
-              \_function: (my_module_types::simple_minus), line:3, col:3, parent:my_module_types::
-              |vpiArgument:
-              \_ref_obj: (my_module_types::simple_func::value1), line:11, col:59, parent:simple_minus
-                |vpiName:value1
-                |vpiFullName:my_module_types::simple_func::value1
-              |vpiArgument:
-              \_ref_obj: (my_module_types::simple_func::value2), line:11, col:42, parent:simple_minus
-                |vpiName:value2
-                |vpiFullName:my_module_types::simple_func::value2
       |vpiTypedef:
       \_import: (my_funcs), line:17, col:10
       |vpiParamAssign:
@@ -1109,16 +1160,18 @@ design: (work@t)
     \_io_decl: (value1), parent:my_module_types::simple_minus
       |vpiName:value1
       |vpiDirection:1
-      |vpiExpr:
-      \_int_var: (work@t.simple_minus.value1), line:3, col:46, parent:value1
-        |vpiFullName:work@t.simple_minus.value1
+      |vpiTypedef:
+      \_int_typespec: , line:3, col:46, parent:value1
+        |vpiInstance:
+        \_package: my_funcs (my_funcs::) dut.sv:1: , parent:work@t
     |vpiIODecl:
     \_io_decl: (value2), parent:my_module_types::simple_minus
       |vpiName:value2
       |vpiDirection:1
-      |vpiExpr:
-      \_int_var: (work@t.simple_minus.value2), line:3, col:64, parent:value2
-        |vpiFullName:work@t.simple_minus.value2
+      |vpiTypedef:
+      \_int_typespec: , line:3, col:64, parent:value2
+        |vpiInstance:
+        \_package: my_funcs (my_funcs::) dut.sv:1: , parent:work@t
     |vpiStmt:
     \_begin: (work@t.simple_minus), line:4, col:6, parent:my_module_types::simple_minus
       |vpiFullName:work@t.simple_minus
@@ -1137,14 +1190,10 @@ design: (work@t)
           \_ref_obj: (work@t.simple_minus.value1), line:5, col:22
             |vpiName:value1
             |vpiFullName:work@t.simple_minus.value1
-            |vpiActual:
-            \_int_var: (value1), line:3, col:46, parent:value1
           |vpiOperand:
           \_ref_obj: (work@t.simple_minus.value2), line:5, col:31
             |vpiName:value2
             |vpiFullName:work@t.simple_minus.value2
-            |vpiActual:
-            \_int_var: (value2), line:3, col:64, parent:value2
   |vpiTaskFunc:
   \_function: (my_module_types::simple_func), line:9, col:3, parent:work@t
     |vpiVisibility:1
@@ -1159,16 +1208,18 @@ design: (work@t)
     \_io_decl: (value1), parent:my_module_types::simple_func
       |vpiName:value1
       |vpiDirection:1
-      |vpiExpr:
-      \_int_var: (work@t.simple_func.value1), line:9, col:45, parent:value1
-        |vpiFullName:work@t.simple_func.value1
+      |vpiTypedef:
+      \_int_typespec: , line:9, col:45, parent:value1
+        |vpiInstance:
+        \_package: my_funcs (my_funcs::) dut.sv:1: , parent:work@t
     |vpiIODecl:
     \_io_decl: (value2), parent:my_module_types::simple_func
       |vpiName:value2
       |vpiDirection:1
-      |vpiExpr:
-      \_int_var: (work@t.simple_func.value2), line:9, col:63, parent:value2
-        |vpiFullName:work@t.simple_func.value2
+      |vpiTypedef:
+      \_int_typespec: , line:9, col:63, parent:value2
+        |vpiInstance:
+        \_package: my_funcs (my_funcs::) dut.sv:1: , parent:work@t
     |vpiStmt:
     \_begin: (work@t.simple_func), line:10, col:6, parent:my_module_types::simple_func
       |vpiFullName:work@t.simple_func
@@ -1189,14 +1240,10 @@ design: (work@t)
           \_ref_obj: (work@t.simple_func.value1), line:11, col:59, parent:simple_minus
             |vpiName:value1
             |vpiFullName:work@t.simple_func.value1
-            |vpiActual:
-            \_int_var: (value1), line:9, col:45, parent:value1
           |vpiArgument:
           \_ref_obj: (work@t.simple_func.value2), line:11, col:42, parent:simple_minus
             |vpiName:value2
             |vpiFullName:work@t.simple_func.value2
-            |vpiActual:
-            \_int_var: (value2), line:9, col:63, parent:value2
   |vpiNet:
   \_logic_net: (work@t.i_clk), line:26, col:13, parent:work@t
   |vpiNet:

--- a/tests/EvalFuncPack/EvalFuncPack.log
+++ b/tests/EvalFuncPack/EvalFuncPack.log
@@ -541,30 +541,29 @@ design: (work@flash_ctrl_info_cfg)
     \_io_decl: (infos)
       |vpiName:infos
       |vpiDirection:1
-      |vpiExpr:
-      \_array_var: (infos), parent:infos
-        |vpiFullName:infos
-        |vpiReg:
-        \_int_var: , line:35, col:42
-        |vpiRange:
-        \_range: , line:35, col:52
-          |vpiLeftRange:
-          \_constant: , line:35, col:52
-            |vpiConstType:9
-            |vpiDecompile:0
+      |vpiTypedef:
+      \_int_typespec: , line:35, col:42
+        |vpiInstance:
+        \_package: flash_ctrl_pkg (flash_ctrl_pkg::) dut.sv:24: , parent:work@flash_ctrl_info_cfg
+      |vpiRange:
+      \_range: , line:35, col:52
+        |vpiLeftRange:
+        \_constant: , line:35, col:52
+          |vpiConstType:9
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+        |vpiRightRange:
+        \_operation: 
+          |vpiOpType:11
+          |vpiOperand:
+          \_ref_obj: (InfoTypes), line:35, col:52
+            |vpiName:InfoTypes
+          |vpiOperand:
+          \_constant: 
+            |vpiConstType:7
             |vpiSize:64
-            |UINT:0
-          |vpiRightRange:
-          \_operation: 
-            |vpiOpType:11
-            |vpiOperand:
-            \_ref_obj: (InfoTypes), line:35, col:52
-              |vpiName:InfoTypes
-            |vpiOperand:
-            \_constant: 
-              |vpiConstType:7
-              |vpiSize:64
-              |INT:1
+            |INT:1
     |vpiStmt:
     \_begin: (flash_ctrl_pkg::max_info_pages), parent:flash_ctrl_pkg::max_info_pages
       |vpiFullName:flash_ctrl_pkg::max_info_pages
@@ -759,9 +758,10 @@ design: (work@flash_ctrl_info_cfg)
         \_io_decl: (value)
           |vpiName:value
           |vpiDirection:1
-          |vpiExpr:
-          \_int_var: (value), line:15, col:33, parent:value
-            |vpiFullName:value
+          |vpiTypedef:
+          \_int_typespec: , line:15, col:33
+            |vpiInstance:
+            \_package: prim_util_pkg (prim_util_pkg::) dut.sv:2: , parent:work@flash_ctrl_info_cfg
         |vpiStmt:
         \_return_stmt: , line:17, col:4, parent:prim_util_pkg::vbits
           |vpiCondition:
@@ -799,9 +799,10 @@ design: (work@flash_ctrl_info_cfg)
     \_io_decl: (value)
       |vpiName:value
       |vpiDirection:1
-      |vpiExpr:
-      \_int_var: (value), line:6, col:36, parent:value
-        |vpiFullName:value
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:36
+        |vpiInstance:
+        \_package: prim_util_pkg (prim_util_pkg::) dut.sv:2: , parent:work@flash_ctrl_info_cfg
     |vpiStmt:
     \_begin: (prim_util_pkg::_clog2), parent:prim_util_pkg::_clog2
       |vpiFullName:prim_util_pkg::_clog2
@@ -958,9 +959,14 @@ design: (work@flash_ctrl_info_cfg)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -1152,9 +1158,14 @@ design: (work@flash_ctrl_info_cfg)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -1165,9 +1176,14 @@ design: (work@flash_ctrl_info_cfg)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -1178,9 +1194,14 @@ design: (work@flash_ctrl_info_cfg)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -1193,9 +1214,14 @@ design: (work@flash_ctrl_info_cfg)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@flash_ctrl_info_cfg (work@flash_ctrl_info_cfg) dut.sv:59: , endline:63:9: , parent:work@flash_ctrl_info_cfg
   |vpiDefName:work@flash_ctrl_info_cfg
@@ -1276,30 +1302,29 @@ design: (work@flash_ctrl_info_cfg)
     \_io_decl: (infos)
       |vpiName:infos
       |vpiDirection:1
-      |vpiExpr:
-      \_array_var: (infos), parent:infos
-        |vpiFullName:infos
-        |vpiReg:
-        \_int_var: , line:35, col:42
-        |vpiRange:
-        \_range: , line:35, col:52
-          |vpiLeftRange:
-          \_constant: , line:35, col:52
-            |vpiConstType:9
-            |vpiDecompile:0
+      |vpiTypedef:
+      \_int_typespec: , line:35, col:42
+        |vpiInstance:
+        \_package: flash_ctrl_pkg (flash_ctrl_pkg::) dut.sv:24: , parent:work@flash_ctrl_info_cfg
+      |vpiRange:
+      \_range: , line:35, col:52
+        |vpiLeftRange:
+        \_constant: , line:35, col:52
+          |vpiConstType:9
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+        |vpiRightRange:
+        \_operation: 
+          |vpiOpType:11
+          |vpiOperand:
+          \_ref_obj: (InfoTypes), line:35, col:52
+            |vpiName:InfoTypes
+          |vpiOperand:
+          \_constant: 
+            |vpiConstType:7
             |vpiSize:64
-            |UINT:0
-          |vpiRightRange:
-          \_operation: 
-            |vpiOpType:11
-            |vpiOperand:
-            \_ref_obj: (InfoTypes), line:35, col:52
-              |vpiName:InfoTypes
-            |vpiOperand:
-            \_constant: 
-              |vpiConstType:7
-              |vpiSize:64
-              |INT:1
+            |INT:1
     |vpiStmt:
     \_begin: (flash_ctrl_pkg::max_info_pages), parent:flash_ctrl_pkg::max_info_pages
       |vpiFullName:flash_ctrl_pkg::max_info_pages
@@ -1525,30 +1550,29 @@ design: (work@flash_ctrl_info_cfg)
         \_io_decl: (infos)
           |vpiName:infos
           |vpiDirection:1
-          |vpiExpr:
-          \_array_var: (infos), parent:infos
-            |vpiFullName:infos
-            |vpiReg:
-            \_int_var: , line:35, col:42
-            |vpiRange:
-            \_range: , line:35, col:52
-              |vpiLeftRange:
-              \_constant: , line:35, col:52
-                |vpiConstType:9
-                |vpiDecompile:0
+          |vpiTypedef:
+          \_int_typespec: , line:35, col:42
+            |vpiInstance:
+            \_package: flash_ctrl_pkg (flash_ctrl_pkg::) dut.sv:24: , parent:work@flash_ctrl_info_cfg
+          |vpiRange:
+          \_range: , line:35, col:52
+            |vpiLeftRange:
+            \_constant: , line:35, col:52
+              |vpiConstType:9
+              |vpiDecompile:0
+              |vpiSize:64
+              |UINT:0
+            |vpiRightRange:
+            \_operation: 
+              |vpiOpType:11
+              |vpiOperand:
+              \_ref_obj: (InfoTypes), line:35, col:52
+                |vpiName:InfoTypes
+              |vpiOperand:
+              \_constant: 
+                |vpiConstType:7
                 |vpiSize:64
-                |UINT:0
-              |vpiRightRange:
-              \_operation: 
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (InfoTypes), line:35, col:52
-                  |vpiName:InfoTypes
-                |vpiOperand:
-                \_constant: 
-                  |vpiConstType:7
-                  |vpiSize:64
-                  |INT:1
+                |INT:1
         |vpiStmt:
         \_begin: (flash_ctrl_pkg::max_info_pages), parent:flash_ctrl_pkg::max_info_pages
           |vpiFullName:flash_ctrl_pkg::max_info_pages
@@ -1713,34 +1737,32 @@ design: (work@flash_ctrl_info_cfg)
     \_io_decl: (infos), parent:flash_ctrl_pkg::max_info_pages
       |vpiName:infos
       |vpiDirection:1
-      |vpiExpr:
-      \_array_var: (work@flash_ctrl_info_cfg.max_info_pages.infos), parent:infos
-        |vpiFullName:work@flash_ctrl_info_cfg.max_info_pages.infos
-        |vpiReg:
-        \_int_var: (work@flash_ctrl_info_cfg.max_info_pages.infos), line:35, col:42, parent:work@flash_ctrl_info_cfg.max_info_pages.infos
-          |vpiFullName:work@flash_ctrl_info_cfg.max_info_pages.infos
-        |vpiRange:
-        \_range: , line:35, col:52, parent:work@flash_ctrl_info_cfg.max_info_pages.infos
-          |vpiLeftRange:
-          \_constant: , line:35, col:52
-            |vpiConstType:9
-            |vpiDecompile:0
+      |vpiTypedef:
+      \_int_typespec: , line:35, col:42, parent:infos
+        |vpiInstance:
+        \_package: flash_ctrl_pkg (flash_ctrl_pkg::) dut.sv:24: , parent:work@flash_ctrl_info_cfg
+      |vpiRange:
+      \_range: , line:35, col:52, parent:infos
+        |vpiLeftRange:
+        \_constant: , line:35, col:52
+          |vpiConstType:9
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+        |vpiRightRange:
+        \_operation: 
+          |vpiOpType:11
+          |vpiOperand:
+          \_ref_obj: (work@flash_ctrl_info_cfg.max_info_pages.infos.InfoTypes), line:35, col:52
+            |vpiName:InfoTypes
+            |vpiFullName:work@flash_ctrl_info_cfg.max_info_pages.infos.InfoTypes
+            |vpiActual:
+            \_parameter: (work@flash_ctrl_info_cfg.InfoTypes), line:26, col:14, parent:work@flash_ctrl_info_cfg
+          |vpiOperand:
+          \_constant: 
+            |vpiConstType:7
             |vpiSize:64
-            |UINT:0
-          |vpiRightRange:
-          \_operation: 
-            |vpiOpType:11
-            |vpiOperand:
-            \_ref_obj: (work@flash_ctrl_info_cfg.max_info_pages.infos.InfoTypes), line:35, col:52
-              |vpiName:InfoTypes
-              |vpiFullName:work@flash_ctrl_info_cfg.max_info_pages.infos.InfoTypes
-              |vpiActual:
-              \_parameter: (work@flash_ctrl_info_cfg.InfoTypes), line:26, col:14, parent:work@flash_ctrl_info_cfg
-            |vpiOperand:
-            \_constant: 
-              |vpiConstType:7
-              |vpiSize:64
-              |INT:1
+            |INT:1
     |vpiStmt:
     \_begin: (work@flash_ctrl_info_cfg.max_info_pages), parent:flash_ctrl_pkg::max_info_pages
       |vpiFullName:work@flash_ctrl_info_cfg.max_info_pages

--- a/tests/FSM2Always/FSM2Always.log
+++ b/tests/FSM2Always/FSM2Always.log
@@ -905,9 +905,14 @@ design: (work@fsm_using_always)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -1099,9 +1104,14 @@ design: (work@fsm_using_always)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -1112,9 +1122,14 @@ design: (work@fsm_using_always)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -1125,9 +1140,14 @@ design: (work@fsm_using_always)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -1140,9 +1160,14 @@ design: (work@fsm_using_always)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@fsm_using_always (work@fsm_using_always) top.sv:6: , endline:91:9: , parent:work@fsm_using_always
   |vpiDefName:work@fsm_using_always

--- a/tests/FSMBsp13/FSMBsp13.log
+++ b/tests/FSMBsp13/FSMBsp13.log
@@ -6043,9 +6043,14 @@ design: (work@top)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -6237,9 +6242,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -6250,9 +6260,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -6263,9 +6278,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -6278,9 +6298,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@FSM1 (work@FSM1) fsm1.v:1: , endline:158:9: , parent:work@top
   |vpiDefName:work@FSM1

--- a/tests/FSMFunction/FSMFunction.log
+++ b/tests/FSMFunction/FSMFunction.log
@@ -943,9 +943,14 @@ design: (work@fsm_using_function)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -1137,9 +1142,14 @@ design: (work@fsm_using_function)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -1150,9 +1160,14 @@ design: (work@fsm_using_function)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -1163,9 +1178,14 @@ design: (work@fsm_using_function)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -1178,9 +1198,14 @@ design: (work@fsm_using_function)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@fsm_using_function (work@fsm_using_function) top.sv:6: , endline:94:9: , parent:work@fsm_using_function
   |vpiDefName:work@fsm_using_function

--- a/tests/FSMSingleAlways/FSMSingleAlways.log
+++ b/tests/FSMSingleAlways/FSMSingleAlways.log
@@ -663,9 +663,14 @@ design: (work@fsm_using_single_always)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -857,9 +862,14 @@ design: (work@fsm_using_single_always)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -870,9 +880,14 @@ design: (work@fsm_using_single_always)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -883,9 +898,14 @@ design: (work@fsm_using_single_always)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -898,9 +918,14 @@ design: (work@fsm_using_single_always)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@fsm_using_single_always (work@fsm_using_single_always) top.sv:7: , endline:63:9: , parent:work@fsm_using_single_always
   |vpiDefName:work@fsm_using_single_always

--- a/tests/ForElab/ForElab.log
+++ b/tests/ForElab/ForElab.log
@@ -146,9 +146,14 @@ design: (work@tlul_socket_m1)
     \_io_decl: (bound)
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16
       |vpiExpr:
-      \_int_var: (bound), line:6, col:16, parent:bound
-        |vpiFullName:bound
+      \_constant: , line:6, col:28
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -319,9 +324,14 @@ design: (work@tlul_socket_m1)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15
       |vpiExpr:
-      \_int_var: (keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:60, col:30
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -332,9 +342,14 @@ design: (work@tlul_socket_m1)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11
       |vpiExpr:
-      \_int_var: (keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:63, col:26
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -345,9 +360,14 @@ design: (work@tlul_socket_m1)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11
       |vpiExpr:
-      \_int_var: (keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:66, col:26
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -360,9 +380,14 @@ design: (work@tlul_socket_m1)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23
       |vpiExpr:
-      \_int_var: (keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:69, col:38
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@prim_arbiter_tree (work@prim_arbiter_tree) top.v:16: , endline:47:9: , parent:work@tlul_socket_m1
   |vpiDefName:work@prim_arbiter_tree

--- a/tests/ForLoop/ForLoop.log
+++ b/tests/ForLoop/ForLoop.log
@@ -860,9 +860,14 @@ design: (work@t)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -1054,9 +1059,14 @@ design: (work@t)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -1067,9 +1077,14 @@ design: (work@t)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -1080,9 +1095,14 @@ design: (work@t)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -1095,9 +1115,14 @@ design: (work@t)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@t (work@t) dut.sv:1: , endline:28:9: , parent:work@t
   |vpiDefName:work@t

--- a/tests/FuncArgDirection/FuncArgDirection.log
+++ b/tests/FuncArgDirection/FuncArgDirection.log
@@ -278,9 +278,14 @@ design: (work@dut)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -472,9 +477,14 @@ design: (work@dut)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -485,9 +495,14 @@ design: (work@dut)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -498,9 +513,14 @@ design: (work@dut)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -513,9 +533,14 @@ design: (work@dut)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@dut (work@dut) dut.sv:1: , endline:15:9: , parent:work@dut
   |vpiDefName:work@dut
@@ -594,9 +619,8 @@ design: (work@dut)
     \_io_decl: (in)
       |vpiName:in
       |vpiDirection:1
-      |vpiExpr:
-      \_logic_var: (in), line:2, col:49, parent:in
-        |vpiFullName:in
+      |vpiTypedef:
+      \_logic_typespec: , line:2, col:49
         |vpiRange:
         \_range: , line:2, col:56
           |vpiLeftRange:
@@ -854,9 +878,8 @@ design: (work@dut)
         \_io_decl: (in)
           |vpiName:in
           |vpiDirection:1
-          |vpiExpr:
-          \_logic_var: (in), line:2, col:49, parent:in
-            |vpiFullName:in
+          |vpiTypedef:
+          \_logic_typespec: , line:2, col:49
             |vpiRange:
             \_range: , line:2, col:56
               |vpiLeftRange:
@@ -978,11 +1001,10 @@ design: (work@dut)
     \_io_decl: (in), parent:work@dut.aes_rev_order_bit
       |vpiName:in
       |vpiDirection:1
-      |vpiExpr:
-      \_logic_var: (work@dut.aes_rev_order_bit.in), line:2, col:49, parent:in
-        |vpiFullName:work@dut.aes_rev_order_bit.in
+      |vpiTypedef:
+      \_logic_typespec: , line:2, col:49, parent:in
         |vpiRange:
-        \_range: , line:2, col:56, parent:work@dut.aes_rev_order_bit.in
+        \_range: , line:2, col:56
           |vpiLeftRange:
           \_constant: , line:2, col:56
             |vpiConstType:9

--- a/tests/FuncArgsByName/FuncArgsByName.log
+++ b/tests/FuncArgsByName/FuncArgsByName.log
@@ -165,9 +165,14 @@ design: (work@top)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -359,9 +364,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -372,9 +382,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -385,9 +400,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -400,9 +420,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@top (work@top) dut.sv:1: , endline:18:9: , parent:work@top
   |vpiDefName:work@top
@@ -420,16 +445,14 @@ design: (work@top)
     \_io_decl: (match_type_pair)
       |vpiName:match_type_pair
       |vpiDirection:1
-      |vpiExpr:
-      \_string_var: (match_type_pair), line:3, col:36, parent:match_type_pair
-        |vpiFullName:match_type_pair
+      |vpiTypedef:
+      \_string_typespec: , line:3, col:36
     |vpiIODecl:
     \_io_decl: (requested_type)
       |vpiName:requested_type
       |vpiDirection:1
-      |vpiExpr:
-      \_string_var: (requested_type), line:4, col:6, parent:requested_type
-        |vpiFullName:requested_type
+      |vpiTypedef:
+      \_string_typespec: , line:4, col:6
   |vpiTaskFunc:
   \_function: (work@top.func), line:7, col:3, parent:work@top
     |vpiVisibility:1
@@ -519,16 +542,14 @@ design: (work@top)
         \_io_decl: (match_type_pair)
           |vpiName:match_type_pair
           |vpiDirection:1
-          |vpiExpr:
-          \_string_var: (match_type_pair), line:3, col:36, parent:match_type_pair
-            |vpiFullName:match_type_pair
+          |vpiTypedef:
+          \_string_typespec: , line:3, col:36
         |vpiIODecl:
         \_io_decl: (requested_type)
           |vpiName:requested_type
           |vpiDirection:1
-          |vpiExpr:
-          \_string_var: (requested_type), line:4, col:6, parent:requested_type
-            |vpiFullName:requested_type
+          |vpiTypedef:
+          \_string_typespec: , line:4, col:6
       |vpiTaskFunc:
       \_function: (work@top.func), line:7, col:3, parent:work@top
         |vpiVisibility:1
@@ -594,16 +615,14 @@ design: (work@top)
     \_io_decl: (match_type_pair), parent:work@top.m_matches_type_pair
       |vpiName:match_type_pair
       |vpiDirection:1
-      |vpiExpr:
-      \_string_var: (work@top.m_matches_type_pair.match_type_pair), line:3, col:36, parent:match_type_pair
-        |vpiFullName:work@top.m_matches_type_pair.match_type_pair
+      |vpiTypedef:
+      \_string_typespec: , line:3, col:36, parent:match_type_pair
     |vpiIODecl:
     \_io_decl: (requested_type), parent:work@top.m_matches_type_pair
       |vpiName:requested_type
       |vpiDirection:1
-      |vpiExpr:
-      \_string_var: (work@top.m_matches_type_pair.requested_type), line:4, col:6, parent:requested_type
-        |vpiFullName:work@top.m_matches_type_pair.requested_type
+      |vpiTypedef:
+      \_string_typespec: , line:4, col:6, parent:requested_type
   |vpiTaskFunc:
   \_function: (work@top.func), line:7, col:3, parent:work@top
     |vpiVisibility:1

--- a/tests/FuncBinding/FuncBinding.log
+++ b/tests/FuncBinding/FuncBinding.log
@@ -286,9 +286,8 @@ design: (work@fsm_using_function)
     \_io_decl: (state)
       |vpiName:state
       |vpiDirection:1
-      |vpiExpr:
-      \_logic_var: (state), line:21, col:28, parent:state
-        |vpiFullName:state
+      |vpiTypedef:
+      \_logic_typespec: , line:21, col:28
         |vpiRange:
         \_range: , line:21, col:35
           |vpiLeftRange:
@@ -307,23 +306,20 @@ design: (work@fsm_using_function)
     \_io_decl: (req_0)
       |vpiName:req_0
       |vpiDirection:1
-      |vpiExpr:
-      \_bit_var: (req_0), line:21, col:53, parent:req_0
-        |vpiFullName:req_0
+      |vpiTypedef:
+      \_bit_typespec: , line:21, col:53
     |vpiIODecl:
     \_io_decl: (req_1)
       |vpiName:req_1
       |vpiDirection:1
-      |vpiExpr:
-      \_bit_var: (req_1), line:21, col:69, parent:req_1
-        |vpiFullName:req_1
+      |vpiTypedef:
+      \_bit_typespec: , line:21, col:69
     |vpiIODecl:
     \_io_decl: (future_state)
       |vpiName:future_state
       |vpiDirection:2
-      |vpiExpr:
-      \_logic_var: (future_state), line:21, col:87, parent:future_state
-        |vpiFullName:future_state
+      |vpiTypedef:
+      \_logic_typespec: , line:21, col:87
         |vpiRange:
         \_range: , line:21, col:94
           |vpiLeftRange:
@@ -1055,9 +1051,8 @@ design: (work@fsm_using_function)
         \_io_decl: (state)
           |vpiName:state
           |vpiDirection:1
-          |vpiExpr:
-          \_logic_var: (state), line:21, col:28, parent:state
-            |vpiFullName:state
+          |vpiTypedef:
+          \_logic_typespec: , line:21, col:28
             |vpiRange:
             \_range: , line:21, col:35
               |vpiLeftRange:
@@ -1076,23 +1071,20 @@ design: (work@fsm_using_function)
         \_io_decl: (req_0)
           |vpiName:req_0
           |vpiDirection:1
-          |vpiExpr:
-          \_bit_var: (req_0), line:21, col:53, parent:req_0
-            |vpiFullName:req_0
+          |vpiTypedef:
+          \_bit_typespec: , line:21, col:53
         |vpiIODecl:
         \_io_decl: (req_1)
           |vpiName:req_1
           |vpiDirection:1
-          |vpiExpr:
-          \_bit_var: (req_1), line:21, col:69, parent:req_1
-            |vpiFullName:req_1
+          |vpiTypedef:
+          \_bit_typespec: , line:21, col:69
         |vpiIODecl:
         \_io_decl: (future_state)
           |vpiName:future_state
           |vpiDirection:2
-          |vpiExpr:
-          \_logic_var: (future_state), line:21, col:87, parent:future_state
-            |vpiFullName:future_state
+          |vpiTypedef:
+          \_logic_typespec: , line:21, col:87
             |vpiRange:
             \_range: , line:21, col:94
               |vpiLeftRange:
@@ -1369,11 +1361,10 @@ design: (work@fsm_using_function)
     \_io_decl: (state), parent:work@fsm_using_function.fsm_function
       |vpiName:state
       |vpiDirection:1
-      |vpiExpr:
-      \_logic_var: (work@fsm_using_function.fsm_function.state), line:21, col:28, parent:state
-        |vpiFullName:work@fsm_using_function.fsm_function.state
+      |vpiTypedef:
+      \_logic_typespec: , line:21, col:28, parent:state
         |vpiRange:
-        \_range: , line:21, col:35, parent:work@fsm_using_function.fsm_function.state
+        \_range: , line:21, col:35
           |vpiLeftRange:
           \_constant: , line:21, col:35
             |vpiConstType:9
@@ -1390,25 +1381,22 @@ design: (work@fsm_using_function)
     \_io_decl: (req_0), parent:work@fsm_using_function.fsm_function
       |vpiName:req_0
       |vpiDirection:1
-      |vpiExpr:
-      \_bit_var: (work@fsm_using_function.fsm_function.req_0), line:21, col:53, parent:req_0
-        |vpiFullName:work@fsm_using_function.fsm_function.req_0
+      |vpiTypedef:
+      \_bit_typespec: , line:21, col:53, parent:req_0
     |vpiIODecl:
     \_io_decl: (req_1), parent:work@fsm_using_function.fsm_function
       |vpiName:req_1
       |vpiDirection:1
-      |vpiExpr:
-      \_bit_var: (work@fsm_using_function.fsm_function.req_1), line:21, col:69, parent:req_1
-        |vpiFullName:work@fsm_using_function.fsm_function.req_1
+      |vpiTypedef:
+      \_bit_typespec: , line:21, col:69, parent:req_1
     |vpiIODecl:
     \_io_decl: (future_state), parent:work@fsm_using_function.fsm_function
       |vpiName:future_state
       |vpiDirection:2
-      |vpiExpr:
-      \_logic_var: (work@fsm_using_function.fsm_function.future_state), line:21, col:87, parent:future_state
-        |vpiFullName:work@fsm_using_function.fsm_function.future_state
+      |vpiTypedef:
+      \_logic_typespec: , line:21, col:87, parent:future_state
         |vpiRange:
-        \_range: , line:21, col:94, parent:work@fsm_using_function.fsm_function.future_state
+        \_range: , line:21, col:94
           |vpiLeftRange:
           \_constant: , line:21, col:94
             |vpiConstType:9
@@ -1428,8 +1416,6 @@ design: (work@fsm_using_function)
       \_ref_obj: (work@fsm_using_function.fsm_function.state), line:22, col:5
         |vpiName:state
         |vpiFullName:work@fsm_using_function.fsm_function.state
-        |vpiActual:
-        \_logic_var: (state), line:21, col:28, parent:state
       |vpiCaseItem:
       \_case_item: , line:23, col:2
         |vpiExpr:
@@ -1448,7 +1434,7 @@ design: (work@fsm_using_function)
               |vpiName:req_0
               |vpiFullName:work@fsm_using_function.fsm_function.req_0
               |vpiActual:
-              \_bit_var: (req_0), line:21, col:53, parent:req_0
+              \_bit_var: (work@fsm_using_function.req_0), line:4, col:10, parent:work@fsm_using_function
             |vpiOperand:
             \_constant: , line:23, col:22
               |vpiConstType:3
@@ -1466,8 +1452,6 @@ design: (work@fsm_using_function)
               \_ref_obj: (work@fsm_using_function.fsm_function.future_state), line:24, col:11
                 |vpiName:future_state
                 |vpiFullName:work@fsm_using_function.fsm_function.future_state
-                |vpiActual:
-                \_logic_var: (future_state), line:21, col:87, parent:future_state
               |vpiRhs:
               \_ref_obj: (work@fsm_using_function.fsm_function.GNT0), line:24, col:26
                 |vpiName:GNT0
@@ -1484,7 +1468,7 @@ design: (work@fsm_using_function)
                 |vpiName:req_1
                 |vpiFullName:work@fsm_using_function.fsm_function.req_1
                 |vpiActual:
-                \_bit_var: (req_1), line:21, col:69, parent:req_1
+                \_bit_var: (work@fsm_using_function.req_1), line:5, col:10, parent:work@fsm_using_function
               |vpiOperand:
               \_constant: , line:25, col:31
                 |vpiConstType:3
@@ -1502,8 +1486,6 @@ design: (work@fsm_using_function)
                 \_ref_obj: (work@fsm_using_function.fsm_function.future_state), line:26, col:11
                   |vpiName:future_state
                   |vpiFullName:work@fsm_using_function.fsm_function.future_state
-                  |vpiActual:
-                  \_logic_var: (future_state), line:21, col:87, parent:future_state
                 |vpiRhs:
                 \_ref_obj: (work@fsm_using_function.fsm_function.GNT1), line:26, col:25
                   |vpiName:GNT1
@@ -1521,8 +1503,6 @@ design: (work@fsm_using_function)
                 \_ref_obj: (work@fsm_using_function.fsm_function.future_state), line:28, col:11
                   |vpiName:future_state
                   |vpiFullName:work@fsm_using_function.fsm_function.future_state
-                  |vpiActual:
-                  \_logic_var: (future_state), line:21, col:87, parent:future_state
                 |vpiRhs:
                 \_ref_obj: (work@fsm_using_function.fsm_function.IDLE), line:28, col:26
                   |vpiName:IDLE
@@ -1547,7 +1527,7 @@ design: (work@fsm_using_function)
               |vpiName:req_0
               |vpiFullName:work@fsm_using_function.fsm_function.req_0
               |vpiActual:
-              \_bit_var: (req_0), line:21, col:53, parent:req_0
+              \_bit_var: (work@fsm_using_function.req_0), line:4, col:10, parent:work@fsm_using_function
             |vpiOperand:
             \_constant: , line:30, col:22
               |vpiConstType:3
@@ -1565,8 +1545,6 @@ design: (work@fsm_using_function)
               \_ref_obj: (work@fsm_using_function.fsm_function.future_state), line:31, col:11
                 |vpiName:future_state
                 |vpiFullName:work@fsm_using_function.fsm_function.future_state
-                |vpiActual:
-                \_logic_var: (future_state), line:21, col:87, parent:future_state
               |vpiRhs:
               \_ref_obj: (work@fsm_using_function.fsm_function.GNT0), line:31, col:26
                 |vpiName:GNT0
@@ -1584,8 +1562,6 @@ design: (work@fsm_using_function)
               \_ref_obj: (work@fsm_using_function.fsm_function.future_state), line:33, col:11
                 |vpiName:future_state
                 |vpiFullName:work@fsm_using_function.fsm_function.future_state
-                |vpiActual:
-                \_logic_var: (future_state), line:21, col:87, parent:future_state
               |vpiRhs:
               \_ref_obj: (work@fsm_using_function.fsm_function.IDLE), line:33, col:26
                 |vpiName:IDLE
@@ -1610,7 +1586,7 @@ design: (work@fsm_using_function)
               |vpiName:req_1
               |vpiFullName:work@fsm_using_function.fsm_function.req_1
               |vpiActual:
-              \_bit_var: (req_1), line:21, col:69, parent:req_1
+              \_bit_var: (work@fsm_using_function.req_1), line:5, col:10, parent:work@fsm_using_function
             |vpiOperand:
             \_constant: , line:35, col:22
               |vpiConstType:3
@@ -1628,8 +1604,6 @@ design: (work@fsm_using_function)
               \_ref_obj: (work@fsm_using_function.fsm_function.future_state), line:36, col:11
                 |vpiName:future_state
                 |vpiFullName:work@fsm_using_function.fsm_function.future_state
-                |vpiActual:
-                \_logic_var: (future_state), line:21, col:87, parent:future_state
               |vpiRhs:
               \_ref_obj: (work@fsm_using_function.fsm_function.GNT1), line:36, col:26
                 |vpiName:GNT1
@@ -1647,8 +1621,6 @@ design: (work@fsm_using_function)
               \_ref_obj: (work@fsm_using_function.fsm_function.future_state), line:38, col:11
                 |vpiName:future_state
                 |vpiFullName:work@fsm_using_function.fsm_function.future_state
-                |vpiActual:
-                \_logic_var: (future_state), line:21, col:87, parent:future_state
               |vpiRhs:
               \_ref_obj: (work@fsm_using_function.fsm_function.IDLE), line:38, col:26
                 |vpiName:IDLE
@@ -1665,8 +1637,6 @@ design: (work@fsm_using_function)
           \_ref_obj: (work@fsm_using_function.fsm_function.future_state), line:40, col:12
             |vpiName:future_state
             |vpiFullName:work@fsm_using_function.fsm_function.future_state
-            |vpiActual:
-            \_logic_var: (future_state), line:21, col:87, parent:future_state
           |vpiRhs:
           \_ref_obj: (work@fsm_using_function.fsm_function.IDLE), line:40, col:27
             |vpiName:IDLE

--- a/tests/FuncNoArgs/FuncNoArgs.log
+++ b/tests/FuncNoArgs/FuncNoArgs.log
@@ -319,9 +319,14 @@ design: (work@my_opt_reduce_or)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -513,9 +518,14 @@ design: (work@my_opt_reduce_or)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -526,9 +536,14 @@ design: (work@my_opt_reduce_or)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -539,9 +554,14 @@ design: (work@my_opt_reduce_or)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -554,9 +574,14 @@ design: (work@my_opt_reduce_or)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@my_opt_reduce_or (work@my_opt_reduce_or) dut.sv:1: , endline:31:9: , parent:work@my_opt_reduce_or
   |vpiDefName:work@my_opt_reduce_or

--- a/tests/GateLevel/GateLevel.log
+++ b/tests/GateLevel/GateLevel.log
@@ -556,9 +556,14 @@ design: (work@LogicGates)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -750,9 +755,14 @@ design: (work@LogicGates)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -763,9 +773,14 @@ design: (work@LogicGates)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -776,9 +791,14 @@ design: (work@LogicGates)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -791,9 +811,14 @@ design: (work@LogicGates)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@LogicGates (work@LogicGates) dut.sv:1: , endline:20:9: , parent:work@LogicGates
   |vpiDefName:work@LogicGates

--- a/tests/Gates/Gates.log
+++ b/tests/Gates/Gates.log
@@ -2884,9 +2884,14 @@ design: (work@gates)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -3078,9 +3083,14 @@ design: (work@gates)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -3091,9 +3101,14 @@ design: (work@gates)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -3104,9 +3119,14 @@ design: (work@gates)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -3119,9 +3139,14 @@ design: (work@gates)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@and_from_nand (work@and_from_nand) dut.sv:124: , endline:143:9: , parent:work@gates
   |vpiDefName:work@and_from_nand

--- a/tests/GenBlockVar/GenBlockVar.log
+++ b/tests/GenBlockVar/GenBlockVar.log
@@ -131,9 +131,14 @@ design: (work@top)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -325,9 +330,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -338,9 +348,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -351,9 +366,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -366,9 +386,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@top (work@top) dut.sv:1: , endline:12:9: , parent:work@top
   |vpiDefName:work@top

--- a/tests/GenIf/GenIf.log
+++ b/tests/GenIf/GenIf.log
@@ -175,9 +175,14 @@ design: (work@gen_test4)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -369,9 +374,14 @@ design: (work@gen_test4)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -382,9 +392,14 @@ design: (work@gen_test4)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -395,9 +410,14 @@ design: (work@gen_test4)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -410,9 +430,14 @@ design: (work@gen_test4)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@gen_test4 (work@gen_test4) dut.sv:1: , endline:14:9: , parent:work@gen_test4
   |vpiDefName:work@gen_test4

--- a/tests/GenerateAssigns/GenerateAssigns.log
+++ b/tests/GenerateAssigns/GenerateAssigns.log
@@ -341,9 +341,14 @@ design: (work@dut)
     \_io_decl: (bound)
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16
       |vpiExpr:
-      \_int_var: (bound), line:6, col:16, parent:bound
-        |vpiFullName:bound
+      \_constant: , line:6, col:28
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -514,9 +519,14 @@ design: (work@dut)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15
       |vpiExpr:
-      \_int_var: (keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:60, col:30
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -527,9 +537,14 @@ design: (work@dut)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11
       |vpiExpr:
-      \_int_var: (keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:63, col:26
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -540,9 +555,14 @@ design: (work@dut)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11
       |vpiExpr:
-      \_int_var: (keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:66, col:26
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -555,9 +575,14 @@ design: (work@dut)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23
       |vpiExpr:
-      \_int_var: (keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:69, col:38
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@dut (work@dut) top.v:1: , endline:43:9: , parent:work@dut
   |vpiDefName:work@dut

--- a/tests/GenerateInterface/GenerateInterface.log
+++ b/tests/GenerateInterface/GenerateInterface.log
@@ -564,9 +564,14 @@ design: (work@top)
     \_io_decl: (bound)
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16
       |vpiExpr:
-      \_int_var: (bound), line:6, col:16, parent:bound
-        |vpiFullName:bound
+      \_constant: , line:6, col:28
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -737,9 +742,14 @@ design: (work@top)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15
       |vpiExpr:
-      \_int_var: (keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:60, col:30
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -750,9 +760,14 @@ design: (work@top)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11
       |vpiExpr:
-      \_int_var: (keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:63, col:26
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -763,9 +778,14 @@ design: (work@top)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11
       |vpiExpr:
-      \_int_var: (keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:66, col:26
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -778,9 +798,14 @@ design: (work@top)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23
       |vpiExpr:
-      \_int_var: (keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:69, col:38
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallInterfaces:
 \_interface: work@abc_if (work@abc_if) top.sv:1: , parent:work@top
   |vpiDefName:work@abc_if

--- a/tests/GenerateModule/GenerateModule.log
+++ b/tests/GenerateModule/GenerateModule.log
@@ -549,9 +549,14 @@ design: (work@small_test)
     \_io_decl: (bound)
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16
       |vpiExpr:
-      \_int_var: (bound), line:6, col:16, parent:bound
-        |vpiFullName:bound
+      \_constant: , line:6, col:28
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -722,9 +727,14 @@ design: (work@small_test)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15
       |vpiExpr:
-      \_int_var: (keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:60, col:30
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -735,9 +745,14 @@ design: (work@small_test)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11
       |vpiExpr:
-      \_int_var: (keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:63, col:26
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -748,9 +763,14 @@ design: (work@small_test)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11
       |vpiExpr:
-      \_int_var: (keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:66, col:26
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -763,9 +783,14 @@ design: (work@small_test)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23
       |vpiExpr:
-      \_int_var: (keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:69, col:38
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@small_test (work@small_test) top.v:1: , endline:19:9: , parent:work@small_test
   |vpiDefName:work@small_test

--- a/tests/GenerateUnnamed/GenerateUnnamed.log
+++ b/tests/GenerateUnnamed/GenerateUnnamed.log
@@ -777,9 +777,14 @@ design: (work@test1)
     \_io_decl: (bound)
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16
       |vpiExpr:
-      \_int_var: (bound), line:6, col:16, parent:bound
-        |vpiFullName:bound
+      \_constant: , line:6, col:28
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -950,9 +955,14 @@ design: (work@test1)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15
       |vpiExpr:
-      \_int_var: (keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:60, col:30
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -963,9 +973,14 @@ design: (work@test1)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11
       |vpiExpr:
-      \_int_var: (keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:63, col:26
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -976,9 +991,14 @@ design: (work@test1)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11
       |vpiExpr:
-      \_int_var: (keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:66, col:26
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -991,9 +1011,14 @@ design: (work@test1)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23
       |vpiExpr:
-      \_int_var: (keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:69, col:38
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@test1 (work@test1) top.v:1: , endline:56:9: , parent:work@test1
   |vpiDefName:work@test1

--- a/tests/IfGenTypeBinding/IfGenTypeBinding.log
+++ b/tests/IfGenTypeBinding/IfGenTypeBinding.log
@@ -248,9 +248,14 @@ design: (work@top)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -442,9 +447,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -455,9 +465,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -468,9 +483,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -483,9 +503,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@top (work@top) dut.sv:13: , endline:24:9: , parent:work@top
   |vpiDefName:work@top

--- a/tests/ImplFuncArg/ImplFuncArg.log
+++ b/tests/ImplFuncArg/ImplFuncArg.log
@@ -124,9 +124,14 @@ design: (work@fsm_2_always_block)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -318,9 +323,14 @@ design: (work@fsm_2_always_block)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -331,9 +341,14 @@ design: (work@fsm_2_always_block)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -344,9 +359,14 @@ design: (work@fsm_2_always_block)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -359,9 +379,14 @@ design: (work@fsm_2_always_block)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@fsm_2_always_block (work@fsm_2_always_block) dut.sv:1: , endline:8:9: , parent:work@fsm_2_always_block
   |vpiDefName:work@fsm_2_always_block
@@ -377,9 +402,8 @@ design: (work@fsm_2_always_block)
     \_io_decl: (curr_state)
       |vpiName:curr_state
       |vpiDirection:1
-      |vpiExpr:
-      \_logic_var: (curr_state), line:4, col:19, parent:curr_state
-        |vpiFullName:curr_state
+      |vpiTypedef:
+      \_logic_typespec: , line:4, col:19
         |vpiRange:
         \_range: , line:4, col:24
           |vpiLeftRange:
@@ -398,23 +422,8 @@ design: (work@fsm_2_always_block)
     \_io_decl: (next_state)
       |vpiName:next_state
       |vpiDirection:1
-      |vpiExpr:
-      \_logic_var: (next_state), line:4, col:19, parent:next_state
-        |vpiFullName:next_state
-        |vpiRange:
-        \_range: , line:4, col:24, parent:next_state
-          |vpiLeftRange:
-          \_constant: , line:4, col:24
-            |vpiConstType:9
-            |vpiDecompile:1
-            |vpiSize:64
-            |UINT:1
-          |vpiRightRange:
-          \_constant: , line:4, col:26
-            |vpiConstType:9
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
+      |vpiTypedef:
+      \_logic_typespec: , line:4, col:19
     |vpiStmt:
     \_assignment: , line:5, col:5, parent:work@fsm_2_always_block.stateAsmt
       |vpiOpType:82
@@ -455,9 +464,8 @@ design: (work@fsm_2_always_block)
         \_io_decl: (curr_state)
           |vpiName:curr_state
           |vpiDirection:1
-          |vpiExpr:
-          \_logic_var: (curr_state), line:4, col:19, parent:curr_state
-            |vpiFullName:curr_state
+          |vpiTypedef:
+          \_logic_typespec: , line:4, col:19
             |vpiRange:
             \_range: , line:4, col:24
               |vpiLeftRange:
@@ -476,23 +484,8 @@ design: (work@fsm_2_always_block)
         \_io_decl: (next_state)
           |vpiName:next_state
           |vpiDirection:1
-          |vpiExpr:
-          \_logic_var: (next_state), line:4, col:19, parent:next_state
-            |vpiFullName:next_state
-            |vpiRange:
-            \_range: , line:4, col:24, parent:next_state
-              |vpiLeftRange:
-              \_constant: , line:4, col:24
-                |vpiConstType:9
-                |vpiDecompile:1
-                |vpiSize:64
-                |UINT:1
-              |vpiRightRange:
-              \_constant: , line:4, col:26
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
+          |vpiTypedef:
+          \_logic_typespec: , line:4, col:19
         |vpiStmt:
         \_assignment: , line:5, col:5, parent:work@fsm_2_always_block.stateAsmt
           |vpiOpType:82
@@ -513,11 +506,10 @@ design: (work@fsm_2_always_block)
     \_io_decl: (curr_state), parent:work@fsm_2_always_block.stateAsmt
       |vpiName:curr_state
       |vpiDirection:1
-      |vpiExpr:
-      \_logic_var: (work@fsm_2_always_block.stateAsmt.curr_state), line:4, col:19, parent:curr_state
-        |vpiFullName:work@fsm_2_always_block.stateAsmt.curr_state
+      |vpiTypedef:
+      \_logic_typespec: , line:4, col:19, parent:curr_state
         |vpiRange:
-        \_range: , line:4, col:24, parent:work@fsm_2_always_block.stateAsmt.curr_state
+        \_range: , line:4, col:24
           |vpiLeftRange:
           \_constant: , line:4, col:24
             |vpiConstType:9
@@ -534,11 +526,10 @@ design: (work@fsm_2_always_block)
     \_io_decl: (next_state), parent:work@fsm_2_always_block.stateAsmt
       |vpiName:next_state
       |vpiDirection:1
-      |vpiExpr:
-      \_logic_var: (work@fsm_2_always_block.stateAsmt.next_state), line:4, col:19, parent:next_state
-        |vpiFullName:work@fsm_2_always_block.stateAsmt.next_state
+      |vpiTypedef:
+      \_logic_typespec: , line:4, col:19, parent:next_state
         |vpiRange:
-        \_range: , line:4, col:24, parent:work@fsm_2_always_block.stateAsmt.next_state
+        \_range: , line:4, col:24
           |vpiLeftRange:
           \_constant: , line:4, col:24
             |vpiConstType:9
@@ -559,14 +550,10 @@ design: (work@fsm_2_always_block)
       \_ref_obj: (work@fsm_2_always_block.stateAsmt.curr_state), line:5, col:5
         |vpiName:curr_state
         |vpiFullName:work@fsm_2_always_block.stateAsmt.curr_state
-        |vpiActual:
-        \_logic_var: (curr_state), line:4, col:19, parent:curr_state
       |vpiRhs:
       \_ref_obj: (work@fsm_2_always_block.stateAsmt.next_state), line:5, col:18
         |vpiName:next_state
         |vpiFullName:work@fsm_2_always_block.stateAsmt.next_state
-        |vpiActual:
-        \_logic_var: (next_state), line:4, col:19, parent:next_state
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/ImplicitPort/ImplicitPort.log
+++ b/tests/ImplicitPort/ImplicitPort.log
@@ -139,9 +139,14 @@ design: (work@add)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -333,9 +338,14 @@ design: (work@add)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -346,9 +356,14 @@ design: (work@add)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -359,9 +374,14 @@ design: (work@add)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -374,9 +394,14 @@ design: (work@add)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@add (work@add) dut.sv:1: , endline:6:9: , parent:work@add
   |vpiDefName:work@add

--- a/tests/InterfaceModPort/InterfaceModPort.log
+++ b/tests/InterfaceModPort/InterfaceModPort.log
@@ -952,9 +952,14 @@ design: (work@interface_modports)
     \_io_decl: (bound)
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16
       |vpiExpr:
-      \_int_var: (bound), line:6, col:16, parent:bound
-        |vpiFullName:bound
+      \_constant: , line:6, col:28
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -1125,9 +1130,14 @@ design: (work@interface_modports)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15
       |vpiExpr:
-      \_int_var: (keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:60, col:30
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -1138,9 +1148,14 @@ design: (work@interface_modports)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11
       |vpiExpr:
-      \_int_var: (keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:63, col:26
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -1151,9 +1166,14 @@ design: (work@interface_modports)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11
       |vpiExpr:
-      \_int_var: (keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:66, col:26
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -1166,9 +1186,14 @@ design: (work@interface_modports)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23
       |vpiExpr:
-      \_int_var: (keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:69, col:38
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallInterfaces:
 \_interface: work@mem_if (work@mem_if) top.v:26: , parent:work@interface_modports
   |vpiDefName:work@mem_if

--- a/tests/InterpElab1/InterpElab1.log
+++ b/tests/InterpElab1/InterpElab1.log
@@ -77,9 +77,14 @@ design: (work@dut)
     \_io_decl: (bound)
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16
       |vpiExpr:
-      \_int_var: (bound), line:6, col:16, parent:bound
-        |vpiFullName:bound
+      \_constant: , line:6, col:28
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -250,9 +255,14 @@ design: (work@dut)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15
       |vpiExpr:
-      \_int_var: (keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:60, col:30
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -263,9 +273,14 @@ design: (work@dut)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11
       |vpiExpr:
-      \_int_var: (keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:63, col:26
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -276,9 +291,14 @@ design: (work@dut)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11
       |vpiExpr:
-      \_int_var: (keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:66, col:26
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -291,9 +311,14 @@ design: (work@dut)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23
       |vpiExpr:
-      \_int_var: (keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:69, col:38
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@dut (work@dut) dut.sv:1: , endline:21:9: , parent:work@dut
   |vpiDefName:work@dut

--- a/tests/JKFlipflop/JKFlipflop.log
+++ b/tests/JKFlipflop/JKFlipflop.log
@@ -75,9 +75,14 @@ design: (work@JKFlipflop)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -269,9 +274,14 @@ design: (work@JKFlipflop)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -282,9 +292,14 @@ design: (work@JKFlipflop)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -295,9 +310,14 @@ design: (work@JKFlipflop)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -310,9 +330,14 @@ design: (work@JKFlipflop)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@D_Flipflop (work@D_Flipflop) dut.sv:9: , endline:19:9: , parent:work@JKFlipflop
   |vpiDefName:work@D_Flipflop

--- a/tests/LargeHex/LargeHex.log
+++ b/tests/LargeHex/LargeHex.log
@@ -325,9 +325,14 @@ design: (work@tlul_socket_1n)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -519,9 +524,14 @@ design: (work@tlul_socket_1n)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -532,9 +542,14 @@ design: (work@tlul_socket_1n)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -545,9 +560,14 @@ design: (work@tlul_socket_1n)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -560,9 +580,14 @@ design: (work@tlul_socket_1n)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@tlul_fifo_sync (work@tlul_fifo_sync) dut.sv:1: , endline:3:9: , parent:work@tlul_socket_1n
   |vpiDefName:work@tlul_fifo_sync

--- a/tests/LocalParam/LocalParam.log
+++ b/tests/LocalParam/LocalParam.log
@@ -282,9 +282,14 @@ design: (work@top)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -476,9 +481,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -489,9 +499,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -502,9 +517,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -517,9 +537,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@assigner (work@assigner) dut.sv:6: , endline:12:9: , parent:work@top
   |vpiDefName:work@assigner

--- a/tests/LogicCast/LogicCast.log
+++ b/tests/LogicCast/LogicCast.log
@@ -131,9 +131,14 @@ design: (work@top)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -325,9 +330,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -338,9 +348,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -351,9 +366,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -366,9 +386,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@top (work@top) dut.sv:1: , endline:5:9: , parent:work@top
   |vpiDefName:work@top

--- a/tests/MBAdder/MBadder.log
+++ b/tests/MBAdder/MBadder.log
@@ -72,9 +72,14 @@ design: (work@MultibitAdder)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -266,9 +271,14 @@ design: (work@MultibitAdder)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -279,9 +289,14 @@ design: (work@MultibitAdder)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -292,9 +307,14 @@ design: (work@MultibitAdder)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -307,9 +327,14 @@ design: (work@MultibitAdder)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@MultibitAdder (work@MultibitAdder) dut.sv:1: , endline:7:9: , parent:work@MultibitAdder
   |vpiDefName:work@MultibitAdder

--- a/tests/PackDataType/PackDataType.log
+++ b/tests/PackDataType/PackDataType.log
@@ -327,9 +327,14 @@ design: (work@kmac_keymgr)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -521,9 +526,14 @@ design: (work@kmac_keymgr)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -534,9 +544,14 @@ design: (work@kmac_keymgr)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -547,9 +562,14 @@ design: (work@kmac_keymgr)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -562,9 +582,14 @@ design: (work@kmac_keymgr)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@OK (work@OK) dut.sv:13: , endline:14:9: , parent:work@kmac_keymgr
   |vpiDefName:work@OK

--- a/tests/PackageDpi/PackageDpi.log
+++ b/tests/PackageDpi/PackageDpi.log
@@ -47,9 +47,10 @@ design: (unnamed)
     \_io_decl: (path)
       |vpiName:path
       |vpiDirection:1
-      |vpiExpr:
-      \_string_var: (path), line:3, col:55, parent:path
-        |vpiFullName:path
+      |vpiTypedef:
+      \_string_typespec: , line:3, col:55
+        |vpiInstance:
+        \_package: pack (pack::) dut.sv:1: , parent:unnamed
   |vpiClassDefn:
   \_class_defn: (pack::toto) dut.sv:20: , parent:pack::
     |vpiName:toto

--- a/tests/PackageFuncCall/PackageFuncCall.log
+++ b/tests/PackageFuncCall/PackageFuncCall.log
@@ -572,9 +572,8 @@ design: (work@top)
     \_io_decl: (state_in)
       |vpiName:state_in
       |vpiDirection:1
-      |vpiExpr:
-      \_logic_var: (state_in), line:8, col:46, parent:state_in
-        |vpiFullName:state_in
+      |vpiTypedef:
+      \_logic_typespec: , line:8, col:46
         |vpiRange:
         \_range: , line:8, col:53
           |vpiLeftRange:
@@ -589,13 +588,14 @@ design: (work@top)
             |vpiDecompile:0
             |vpiSize:64
             |UINT:0
+        |vpiInstance:
+        \_package: prim_cipher_pkg (prim_cipher_pkg::) dut.sv:1: , parent:work@top
     |vpiIODecl:
     \_io_decl: (sbox4)
       |vpiName:sbox4
       |vpiDirection:1
-      |vpiExpr:
-      \_logic_var: (sbox4), line:8, col:69, parent:sbox4
-        |vpiFullName:sbox4
+      |vpiTypedef:
+      \_logic_typespec: , line:8, col:69
         |vpiRange:
         \_range: , line:8, col:76
           |vpiLeftRange:
@@ -624,6 +624,8 @@ design: (work@top)
             |vpiDecompile:0
             |vpiSize:64
             |UINT:0
+        |vpiInstance:
+        \_package: prim_cipher_pkg (prim_cipher_pkg::) dut.sv:1: , parent:work@top
     |vpiStmt:
     \_begin: (prim_cipher_pkg::sbox4_64bit), parent:prim_cipher_pkg::sbox4_64bit
       |vpiFullName:prim_cipher_pkg::sbox4_64bit
@@ -965,9 +967,14 @@ design: (work@top)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -1159,9 +1166,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -1172,9 +1184,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -1185,9 +1202,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -1200,9 +1222,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@top (work@top) dut.sv:26: , endline:42:9: , parent:work@top
   |vpiDefName:work@top
@@ -1387,9 +1414,8 @@ design: (work@top)
               \_io_decl: (state_in)
                 |vpiName:state_in
                 |vpiDirection:1
-                |vpiExpr:
-                \_logic_var: (state_in), line:8, col:46, parent:state_in
-                  |vpiFullName:state_in
+                |vpiTypedef:
+                \_logic_typespec: , line:8, col:46
                   |vpiRange:
                   \_range: , line:8, col:53
                     |vpiLeftRange:
@@ -1404,13 +1430,14 @@ design: (work@top)
                       |vpiDecompile:0
                       |vpiSize:64
                       |UINT:0
+                  |vpiInstance:
+                  \_package: prim_cipher_pkg (prim_cipher_pkg::) dut.sv:1: , parent:work@top
               |vpiIODecl:
               \_io_decl: (sbox4)
                 |vpiName:sbox4
                 |vpiDirection:1
-                |vpiExpr:
-                \_logic_var: (sbox4), line:8, col:69, parent:sbox4
-                  |vpiFullName:sbox4
+                |vpiTypedef:
+                \_logic_typespec: , line:8, col:69
                   |vpiRange:
                   \_range: , line:8, col:76
                     |vpiLeftRange:
@@ -1439,6 +1466,8 @@ design: (work@top)
                       |vpiDecompile:0
                       |vpiSize:64
                       |UINT:0
+                  |vpiInstance:
+                  \_package: prim_cipher_pkg (prim_cipher_pkg::) dut.sv:1: , parent:work@top
               |vpiStmt:
               \_begin: (prim_cipher_pkg::sbox4_64bit), parent:prim_cipher_pkg::sbox4_64bit
                 |vpiFullName:prim_cipher_pkg::sbox4_64bit
@@ -1915,9 +1944,8 @@ design: (work@top)
               \_io_decl: (state_in)
                 |vpiName:state_in
                 |vpiDirection:1
-                |vpiExpr:
-                \_logic_var: (state_in), line:8, col:46, parent:state_in
-                  |vpiFullName:state_in
+                |vpiTypedef:
+                \_logic_typespec: , line:8, col:46
                   |vpiRange:
                   \_range: , line:8, col:53
                     |vpiLeftRange:
@@ -1932,13 +1960,14 @@ design: (work@top)
                       |vpiDecompile:0
                       |vpiSize:64
                       |UINT:0
+                  |vpiInstance:
+                  \_package: prim_cipher_pkg (prim_cipher_pkg::) dut.sv:1: , parent:work@top
               |vpiIODecl:
               \_io_decl: (sbox4)
                 |vpiName:sbox4
                 |vpiDirection:1
-                |vpiExpr:
-                \_logic_var: (sbox4), line:8, col:69, parent:sbox4
-                  |vpiFullName:sbox4
+                |vpiTypedef:
+                \_logic_typespec: , line:8, col:69
                   |vpiRange:
                   \_range: , line:8, col:76
                     |vpiLeftRange:
@@ -1967,6 +1996,8 @@ design: (work@top)
                       |vpiDecompile:0
                       |vpiSize:64
                       |UINT:0
+                  |vpiInstance:
+                  \_package: prim_cipher_pkg (prim_cipher_pkg::) dut.sv:1: , parent:work@top
               |vpiStmt:
               \_begin: (prim_cipher_pkg::sbox4_64bit), parent:prim_cipher_pkg::sbox4_64bit
                 |vpiFullName:prim_cipher_pkg::sbox4_64bit

--- a/tests/PackageParam/PackageParam.log
+++ b/tests/PackageParam/PackageParam.log
@@ -590,9 +590,14 @@ design: (unnamed)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -784,9 +789,14 @@ design: (unnamed)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -797,9 +807,14 @@ design: (unnamed)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -810,9 +825,14 @@ design: (unnamed)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -825,9 +845,14 @@ design: (unnamed)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/PackageType/PackageType.log
+++ b/tests/PackageType/PackageType.log
@@ -300,9 +300,14 @@ design: (unnamed)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -494,9 +499,14 @@ design: (unnamed)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -507,9 +517,14 @@ design: (unnamed)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -520,9 +535,14 @@ design: (unnamed)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -535,9 +555,14 @@ design: (unnamed)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/PackageValue/PackageValue.log
+++ b/tests/PackageValue/PackageValue.log
@@ -1241,9 +1241,14 @@ design: (work@prim_diff_decode)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -1435,9 +1440,14 @@ design: (work@prim_diff_decode)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -1448,9 +1458,14 @@ design: (work@prim_diff_decode)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -1461,9 +1476,14 @@ design: (work@prim_diff_decode)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -1476,9 +1496,14 @@ design: (work@prim_diff_decode)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@prim_diff_decode (work@prim_diff_decode) top.sv:11: , endline:33:9: , parent:work@prim_diff_decode
   |vpiDefName:work@prim_diff_decode

--- a/tests/ParamArray/ParamArray.log
+++ b/tests/ParamArray/ParamArray.log
@@ -483,9 +483,14 @@ design: (work@top)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -677,9 +682,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -690,9 +700,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -703,9 +718,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -718,9 +738,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@otp_ctrl_lci (work@otp_ctrl_lci) dut.sv:29: , endline:40:9: , parent:work@top
   |vpiDefName:work@otp_ctrl_lci

--- a/tests/ParamArraySelect/ParamArraySelect.log
+++ b/tests/ParamArraySelect/ParamArraySelect.log
@@ -750,9 +750,14 @@ design: (work@top)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -944,9 +949,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -957,9 +967,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -970,9 +985,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -985,9 +1005,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@otp_ctrl_lci (work@otp_ctrl_lci) dut.sv:32: , endline:47:9: , parent:work@top
   |vpiDefName:work@otp_ctrl_lci

--- a/tests/ParamCast/ParamCast.log
+++ b/tests/ParamCast/ParamCast.log
@@ -204,9 +204,14 @@ design: (work@otp_ctrl)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -398,9 +403,14 @@ design: (work@otp_ctrl)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -411,9 +421,14 @@ design: (work@otp_ctrl)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -424,9 +439,14 @@ design: (work@otp_ctrl)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -439,9 +459,14 @@ design: (work@otp_ctrl)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@otp_ctrl (work@otp_ctrl) dut.sv:15: , endline:18:9: , parent:work@otp_ctrl
   |vpiDefName:work@otp_ctrl

--- a/tests/ParamComplex/ParamComplex.log
+++ b/tests/ParamComplex/ParamComplex.log
@@ -290,9 +290,14 @@ design: (work@top)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -484,9 +489,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -497,9 +507,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -510,9 +525,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -525,9 +545,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@dut (work@dut) dut.sv:17: , endline:22:9: , parent:work@top
   |vpiDefName:work@dut

--- a/tests/ParamComplexVerilator/ParamComplexVerilator.log
+++ b/tests/ParamComplexVerilator/ParamComplexVerilator.log
@@ -290,9 +290,14 @@ design: (work@top)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -484,9 +489,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -497,9 +507,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -510,9 +525,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -525,9 +545,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@dut (work@dut) dut.sv:17: , endline:22:9: , parent:work@top
   |vpiDefName:work@dut

--- a/tests/ParamConcat/ParamConcat.log
+++ b/tests/ParamConcat/ParamConcat.log
@@ -200,9 +200,14 @@ design: (work@top)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -394,9 +399,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -407,9 +417,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -420,9 +435,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -435,9 +455,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@ibex_csr (work@ibex_csr) dut.sv:1: , endline:4:9: , parent:work@top
   |vpiDefName:work@ibex_csr

--- a/tests/ParamElab/ParamElab.log
+++ b/tests/ParamElab/ParamElab.log
@@ -230,9 +230,14 @@ design: (work@dut)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -424,9 +429,14 @@ design: (work@dut)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -437,9 +447,14 @@ design: (work@dut)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -450,9 +465,14 @@ design: (work@dut)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -465,9 +485,14 @@ design: (work@dut)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@dut (work@dut) dut.sv:1: , endline:6:9: , parent:work@dut
   |vpiDefName:work@dut

--- a/tests/PatAssignOp/PatAssignOp.log
+++ b/tests/PatAssignOp/PatAssignOp.log
@@ -272,9 +272,14 @@ design: (work@top)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -466,9 +471,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -479,9 +489,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -492,9 +507,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -507,9 +527,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@top (work@top) dut.sv:2: , endline:14:9: , parent:work@top
   |vpiDefName:work@top

--- a/tests/PortRanges/PortRanges.log
+++ b/tests/PortRanges/PortRanges.log
@@ -258,9 +258,14 @@ design: (work@DFlipflop8Bit)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -452,9 +457,14 @@ design: (work@DFlipflop8Bit)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -465,9 +475,14 @@ design: (work@DFlipflop8Bit)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -478,9 +493,14 @@ design: (work@DFlipflop8Bit)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -493,9 +513,14 @@ design: (work@DFlipflop8Bit)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@DFlipflop8Bit (work@DFlipflop8Bit) dut.sv:1: , endline:9:9: , parent:work@DFlipflop8Bit
   |vpiDefName:work@DFlipflop8Bit

--- a/tests/PortWildcard/PortWildcard.log
+++ b/tests/PortWildcard/PortWildcard.log
@@ -233,9 +233,14 @@ design: (work@dut)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -427,9 +432,14 @@ design: (work@dut)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -440,9 +450,14 @@ design: (work@dut)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -453,9 +468,14 @@ design: (work@dut)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -468,9 +488,14 @@ design: (work@dut)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@dut (work@dut) dut.sv:15: , endline:21:9: , parent:work@dut
   |vpiDefName:work@dut

--- a/tests/PreprocFunc/PreprocFunc.log
+++ b/tests/PreprocFunc/PreprocFunc.log
@@ -438,9 +438,14 @@ design: (work@asym_ram)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -632,9 +637,14 @@ design: (work@asym_ram)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -645,9 +655,14 @@ design: (work@asym_ram)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -658,9 +673,14 @@ design: (work@asym_ram)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -673,9 +693,14 @@ design: (work@asym_ram)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@asym_ram (work@asym_ram) dut.sv:5: , endline:45:9: , parent:work@asym_ram
   |vpiDefName:work@asym_ram

--- a/tests/PreprocUhdmCov/PreprocUhdmCov.log
+++ b/tests/PreprocUhdmCov/PreprocUhdmCov.log
@@ -292,9 +292,14 @@ design: (work@top)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -486,9 +491,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -499,9 +509,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -512,9 +527,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -527,9 +547,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@top (work@top) dut.sv:4: , endline:50:16: , parent:work@top
   |vpiDefName:work@top
@@ -624,9 +649,8 @@ design: (work@top)
     \_io_decl: (state_in)
       |vpiName:state_in
       |vpiDirection:1
-      |vpiExpr:
-      \_logic_var: (state_in), line:45, col:58, parent:state_in
-        |vpiFullName:state_in
+      |vpiTypedef:
+      \_logic_typespec: , line:45, col:58
         |vpiRange:
         \_range: , line:45, col:65
           |vpiLeftRange:
@@ -645,9 +669,8 @@ design: (work@top)
     \_io_decl: (shifts)
       |vpiName:shifts
       |vpiDirection:1
-      |vpiExpr:
-      \_logic_var: (shifts), line:46, col:63, parent:shifts
-        |vpiFullName:shifts
+      |vpiTypedef:
+      \_logic_typespec: , line:46, col:63
         |vpiRange:
         \_range: , line:46, col:70
           |vpiLeftRange:
@@ -895,9 +918,8 @@ design: (work@top)
         \_io_decl: (state_in)
           |vpiName:state_in
           |vpiDirection:1
-          |vpiExpr:
-          \_logic_var: (state_in), line:45, col:58, parent:state_in
-            |vpiFullName:state_in
+          |vpiTypedef:
+          \_logic_typespec: , line:45, col:58
             |vpiRange:
             \_range: , line:45, col:65
               |vpiLeftRange:
@@ -916,9 +938,8 @@ design: (work@top)
         \_io_decl: (shifts)
           |vpiName:shifts
           |vpiDirection:1
-          |vpiExpr:
-          \_logic_var: (shifts), line:46, col:63, parent:shifts
-            |vpiFullName:shifts
+          |vpiTypedef:
+          \_logic_typespec: , line:46, col:63
             |vpiRange:
             \_range: , line:46, col:70
               |vpiLeftRange:
@@ -973,11 +994,10 @@ design: (work@top)
     \_io_decl: (state_in), parent:work@top.prince_shiftrows_32bit
       |vpiName:state_in
       |vpiDirection:1
-      |vpiExpr:
-      \_logic_var: (work@top.prince_shiftrows_32bit.state_in), line:45, col:58, parent:state_in
-        |vpiFullName:work@top.prince_shiftrows_32bit.state_in
+      |vpiTypedef:
+      \_logic_typespec: , line:45, col:58, parent:state_in
         |vpiRange:
-        \_range: , line:45, col:65, parent:work@top.prince_shiftrows_32bit.state_in
+        \_range: , line:45, col:65
           |vpiLeftRange:
           \_constant: , line:45, col:65
             |vpiConstType:9
@@ -994,11 +1014,10 @@ design: (work@top)
     \_io_decl: (shifts), parent:work@top.prince_shiftrows_32bit
       |vpiName:shifts
       |vpiDirection:1
-      |vpiExpr:
-      \_logic_var: (work@top.prince_shiftrows_32bit.shifts), line:46, col:63, parent:shifts
-        |vpiFullName:work@top.prince_shiftrows_32bit.shifts
+      |vpiTypedef:
+      \_logic_typespec: , line:46, col:63, parent:shifts
         |vpiRange:
-        \_range: , line:46, col:70, parent:work@top.prince_shiftrows_32bit.shifts
+        \_range: , line:46, col:70
           |vpiLeftRange:
           \_constant: , line:46, col:70
             |vpiConstType:9
@@ -1012,7 +1031,7 @@ design: (work@top)
             |vpiSize:64
             |UINT:0
         |vpiRange:
-        \_range: , line:46, col:76, parent:work@top.prince_shiftrows_32bit.shifts
+        \_range: , line:46, col:76
           |vpiLeftRange:
           \_constant: , line:46, col:76
             |vpiConstType:9

--- a/tests/ProcForLoop/ProcForLoop.log
+++ b/tests/ProcForLoop/ProcForLoop.log
@@ -206,9 +206,14 @@ design: (work@top)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -400,9 +405,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -413,9 +423,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -426,9 +441,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -441,9 +461,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@top (work@top) dut.sv:1: , endline:11:9: , parent:work@top
   |vpiDefName:work@top

--- a/tests/RangeInf/RangeInf.log
+++ b/tests/RangeInf/RangeInf.log
@@ -259,9 +259,14 @@ design: (work@FullAdder)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -453,9 +458,14 @@ design: (work@FullAdder)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -466,9 +476,14 @@ design: (work@FullAdder)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -479,9 +494,14 @@ design: (work@FullAdder)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -494,9 +514,14 @@ design: (work@FullAdder)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@FullAdder (work@FullAdder) dut.sv:1: , endline:10:9: , parent:work@FullAdder
   |vpiDefName:work@FullAdder

--- a/tests/Rom/Rom.log
+++ b/tests/Rom/Rom.log
@@ -226,9 +226,14 @@ design: (work@top)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -420,9 +425,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -433,9 +443,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -446,9 +461,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -461,9 +481,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@top (work@top) dut.sv:1: , endline:20:9: , parent:work@top
   |vpiDefName:work@top

--- a/tests/SignedParam/SignedParam.log
+++ b/tests/SignedParam/SignedParam.log
@@ -95,9 +95,14 @@ design: (work@prim_pad_wrapper)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -289,9 +294,14 @@ design: (work@prim_pad_wrapper)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -302,9 +312,14 @@ design: (work@prim_pad_wrapper)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -315,9 +330,14 @@ design: (work@prim_pad_wrapper)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -330,9 +350,14 @@ design: (work@prim_pad_wrapper)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@prim_pad_wrapper (work@prim_pad_wrapper) dut.sv:2: , endline:10:9: , parent:work@prim_pad_wrapper
   |vpiDefName:work@prim_pad_wrapper

--- a/tests/SignedPort/SignedPort.log
+++ b/tests/SignedPort/SignedPort.log
@@ -160,9 +160,14 @@ design: (work@dut)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -354,9 +359,14 @@ design: (work@dut)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -367,9 +377,14 @@ design: (work@dut)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -380,9 +395,14 @@ design: (work@dut)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -395,9 +415,14 @@ design: (work@dut)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@dut (work@dut) dut.sv:2: , endline:5:9: , parent:work@dut
   |vpiDefName:work@dut

--- a/tests/StructAccess/StructAccess.log
+++ b/tests/StructAccess/StructAccess.log
@@ -306,9 +306,14 @@ design: (work@top)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -500,9 +505,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -513,9 +523,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -526,9 +541,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -541,9 +561,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@top (work@top) dut.sv:1: , endline:30:9: , parent:work@top
   |vpiDefName:work@top

--- a/tests/StructTypedef/StructTypedef.log
+++ b/tests/StructTypedef/StructTypedef.log
@@ -246,9 +246,14 @@ design: (work@top)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -440,9 +445,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -453,9 +463,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -466,9 +481,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -481,9 +501,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@top (work@top) dut.sv:21: , endline:27:9: , parent:work@top
   |vpiDefName:work@top

--- a/tests/StructVarImp/StructVarImp.log
+++ b/tests/StructVarImp/StructVarImp.log
@@ -442,9 +442,14 @@ design: (work@top)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -636,9 +641,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -649,9 +659,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -662,9 +677,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -677,9 +697,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@top (work@top) dut.sv:33: , endline:38:9: , parent:work@top
   |vpiDefName:work@top

--- a/tests/TaggedPattern/TaggedPattern.log
+++ b/tests/TaggedPattern/TaggedPattern.log
@@ -193,9 +193,14 @@ design: (work@top)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -387,9 +392,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -400,9 +410,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -413,9 +428,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -428,9 +448,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@top (work@top) dut.sv:1: , endline:14:10: , parent:work@top
   |vpiDefName:work@top

--- a/tests/TaskDecls/TaskDecls.log
+++ b/tests/TaskDecls/TaskDecls.log
@@ -351,9 +351,14 @@ design: (work@gen_errors)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -545,9 +550,14 @@ design: (work@gen_errors)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -558,9 +568,14 @@ design: (work@gen_errors)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -571,9 +586,14 @@ design: (work@gen_errors)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -586,9 +606,14 @@ design: (work@gen_errors)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@gen_errors (work@gen_errors) dut.sv:18: , endline:38:9: , parent:work@gen_errors
   |vpiDefName:work@gen_errors

--- a/tests/Ternary/Ternary.log
+++ b/tests/Ternary/Ternary.log
@@ -940,9 +940,14 @@ design: (work@test)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -1134,9 +1139,14 @@ design: (work@test)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -1147,9 +1157,14 @@ design: (work@test)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -1160,9 +1175,14 @@ design: (work@test)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -1175,9 +1195,14 @@ design: (work@test)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@test (work@test) top.sv:3: , endline:85:9: , parent:work@test
   |vpiDefName:work@test

--- a/tests/TypeDefScope/TypeDefScope.log
+++ b/tests/TypeDefScope/TypeDefScope.log
@@ -168,9 +168,14 @@ design: (work@dut)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -362,9 +367,14 @@ design: (work@dut)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -375,9 +385,14 @@ design: (work@dut)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -388,9 +403,14 @@ design: (work@dut)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -403,9 +423,14 @@ design: (work@dut)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@dut (work@dut) dut.sv:1: , endline:18:10: , parent:work@dut
   |vpiDefName:work@dut
@@ -441,38 +466,33 @@ design: (work@dut)
     \_io_decl: (type_name)
       |vpiName:type_name
       |vpiDirection:1
-      |vpiExpr:
-      \_string_var: (type_name), line:3, col:41, parent:type_name
-        |vpiFullName:type_name
+      |vpiTypedef:
+      \_string_typespec: , line:3, col:41
     |vpiIODecl:
     \_io_decl: (contxt)
       |vpiName:contxt
       |vpiDirection:1
-      |vpiExpr:
-      \_string_var: (contxt), line:4, col:6, parent:contxt
-        |vpiFullName:contxt
+      |vpiTypedef:
+      \_string_typespec: , line:4, col:6
     |vpiIODecl:
     \_io_decl: (inst_name)
       |vpiName:inst_name
       |vpiDirection:1
-      |vpiExpr:
-      \_string_var: (inst_name), line:5, col:6, parent:inst_name
-        |vpiFullName:inst_name
+      |vpiTypedef:
+      \_string_typespec: , line:5, col:6
     |vpiIODecl:
     \_io_decl: (field_name)
       |vpiName:field_name
       |vpiDirection:1
-      |vpiExpr:
-      \_string_var: (field_name), line:6, col:6, parent:field_name
-        |vpiFullName:field_name
+      |vpiTypedef:
+      \_string_typespec: , line:6, col:6
     |vpiIODecl:
     \_io_decl: (value)
       |vpiName:value
       |vpiDirection:1
-      |vpiExpr:
-      \_chandle_var: (value.bits_t), line:7, col:6, parent:value
+      |vpiTypedef:
+      \_unsupported_typespec: (bits_t), line:7, col:6
         |vpiName:bits_t
-        |vpiFullName:value.bits_t
     |vpiStmt:
     \_begin: (work@dut.UVMC_set_config_object), parent:work@dut.UVMC_set_config_object
       |vpiFullName:work@dut.UVMC_set_config_object
@@ -555,38 +575,33 @@ design: (work@dut)
         \_io_decl: (type_name)
           |vpiName:type_name
           |vpiDirection:1
-          |vpiExpr:
-          \_string_var: (type_name), line:3, col:41, parent:type_name
-            |vpiFullName:type_name
+          |vpiTypedef:
+          \_string_typespec: , line:3, col:41
         |vpiIODecl:
         \_io_decl: (contxt)
           |vpiName:contxt
           |vpiDirection:1
-          |vpiExpr:
-          \_string_var: (contxt), line:4, col:6, parent:contxt
-            |vpiFullName:contxt
+          |vpiTypedef:
+          \_string_typespec: , line:4, col:6
         |vpiIODecl:
         \_io_decl: (inst_name)
           |vpiName:inst_name
           |vpiDirection:1
-          |vpiExpr:
-          \_string_var: (inst_name), line:5, col:6, parent:inst_name
-            |vpiFullName:inst_name
+          |vpiTypedef:
+          \_string_typespec: , line:5, col:6
         |vpiIODecl:
         \_io_decl: (field_name)
           |vpiName:field_name
           |vpiDirection:1
-          |vpiExpr:
-          \_string_var: (field_name), line:6, col:6, parent:field_name
-            |vpiFullName:field_name
+          |vpiTypedef:
+          \_string_typespec: , line:6, col:6
         |vpiIODecl:
         \_io_decl: (value)
           |vpiName:value
           |vpiDirection:1
-          |vpiExpr:
-          \_chandle_var: (value.bits_t), line:7, col:6, parent:value
+          |vpiTypedef:
+          \_unsupported_typespec: (bits_t), line:7, col:6
             |vpiName:bits_t
-            |vpiFullName:value.bits_t
         |vpiStmt:
         \_begin: (work@dut.UVMC_set_config_object), parent:work@dut.UVMC_set_config_object
           |vpiFullName:work@dut.UVMC_set_config_object
@@ -609,38 +624,33 @@ design: (work@dut)
     \_io_decl: (type_name), parent:work@dut.UVMC_set_config_object
       |vpiName:type_name
       |vpiDirection:1
-      |vpiExpr:
-      \_string_var: (work@dut.UVMC_set_config_object.type_name), line:3, col:41, parent:type_name
-        |vpiFullName:work@dut.UVMC_set_config_object.type_name
+      |vpiTypedef:
+      \_string_typespec: , line:3, col:41, parent:type_name
     |vpiIODecl:
     \_io_decl: (contxt), parent:work@dut.UVMC_set_config_object
       |vpiName:contxt
       |vpiDirection:1
-      |vpiExpr:
-      \_string_var: (work@dut.UVMC_set_config_object.contxt), line:4, col:6, parent:contxt
-        |vpiFullName:work@dut.UVMC_set_config_object.contxt
+      |vpiTypedef:
+      \_string_typespec: , line:4, col:6, parent:contxt
     |vpiIODecl:
     \_io_decl: (inst_name), parent:work@dut.UVMC_set_config_object
       |vpiName:inst_name
       |vpiDirection:1
-      |vpiExpr:
-      \_string_var: (work@dut.UVMC_set_config_object.inst_name), line:5, col:6, parent:inst_name
-        |vpiFullName:work@dut.UVMC_set_config_object.inst_name
+      |vpiTypedef:
+      \_string_typespec: , line:5, col:6, parent:inst_name
     |vpiIODecl:
     \_io_decl: (field_name), parent:work@dut.UVMC_set_config_object
       |vpiName:field_name
       |vpiDirection:1
-      |vpiExpr:
-      \_string_var: (work@dut.UVMC_set_config_object.field_name), line:6, col:6, parent:field_name
-        |vpiFullName:work@dut.UVMC_set_config_object.field_name
+      |vpiTypedef:
+      \_string_typespec: , line:6, col:6, parent:field_name
     |vpiIODecl:
     \_io_decl: (value), parent:work@dut.UVMC_set_config_object
       |vpiName:value
       |vpiDirection:1
-      |vpiExpr:
-      \_chandle_var: (work@dut.UVMC_set_config_object.value.bits_t), line:7, col:6, parent:value
+      |vpiTypedef:
+      \_unsupported_typespec: (bits_t), line:7, col:6, parent:value
         |vpiName:bits_t
-        |vpiFullName:work@dut.UVMC_set_config_object.value.bits_t
     |vpiStmt:
     \_begin: (work@dut.UVMC_set_config_object), parent:work@dut.UVMC_set_config_object
       |vpiFullName:work@dut.UVMC_set_config_object

--- a/tests/Typename/Typename.log
+++ b/tests/Typename/Typename.log
@@ -149,9 +149,14 @@ design: (work@top)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -343,9 +348,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -356,9 +366,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -369,9 +384,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -384,9 +404,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@top (work@top) dut.sv:1: , endline:9:9: , parent:work@top
   |vpiDefName:work@top

--- a/tests/Udp/Udp.log
+++ b/tests/Udp/Udp.log
@@ -727,9 +727,14 @@ design: (work@udp_body_tb)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -921,9 +926,14 @@ design: (work@udp_body_tb)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -934,9 +944,14 @@ design: (work@udp_body_tb)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -947,9 +962,14 @@ design: (work@udp_body_tb)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -962,9 +982,14 @@ design: (work@udp_body_tb)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallUdps:
 \_udp_defn: work@udp_body, line:1, parent:work@udp_body_tb
   |vpiDefName:work@udp_body

--- a/tests/UndersVal/UndersVal.log
+++ b/tests/UndersVal/UndersVal.log
@@ -137,9 +137,14 @@ design: (work@dut)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -331,9 +336,14 @@ design: (work@dut)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -344,9 +354,14 @@ design: (work@dut)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -357,9 +372,14 @@ design: (work@dut)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -372,9 +392,14 @@ design: (work@dut)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@dut (work@dut) dut.sv:1: , endline:12:9: , parent:work@dut
   |vpiDefName:work@dut

--- a/tests/UnitDefParam/UnitDefParam.log
+++ b/tests/UnitDefParam/UnitDefParam.log
@@ -950,9 +950,14 @@ design: (work@top_def)
     \_io_decl: (bound)
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16
       |vpiExpr:
-      \_int_var: (bound), line:6, col:16, parent:bound
-        |vpiFullName:bound
+      \_constant: , line:6, col:28
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -1123,9 +1128,14 @@ design: (work@top_def)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15
       |vpiExpr:
-      \_int_var: (keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:60, col:30
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -1136,9 +1146,14 @@ design: (work@top_def)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11
       |vpiExpr:
-      \_int_var: (keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:63, col:26
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -1149,9 +1164,14 @@ design: (work@top_def)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11
       |vpiExpr:
-      \_int_var: (keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:66, col:26
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -1164,9 +1184,14 @@ design: (work@top_def)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23
       |vpiExpr:
-      \_int_var: (keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:69, col:38
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@def (work@def) def.v:2: , endline:8:9: , parent:work@top_def
   |vpiDefName:work@def

--- a/tests/UnitElab/UnitElab.log
+++ b/tests/UnitElab/UnitElab.log
@@ -13303,9 +13303,14 @@ design: (work@bottom1)
     \_io_decl: (bound)
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16
       |vpiExpr:
-      \_int_var: (bound), line:6, col:16, parent:bound
-        |vpiFullName:bound
+      \_constant: , line:6, col:28
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -13476,9 +13481,14 @@ design: (work@bottom1)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15
       |vpiExpr:
-      \_int_var: (keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:60, col:30
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -13489,9 +13499,14 @@ design: (work@bottom1)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11
       |vpiExpr:
-      \_int_var: (keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:63, col:26
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -13502,9 +13517,14 @@ design: (work@bottom1)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11
       |vpiExpr:
-      \_int_var: (keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:66, col:26
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -13517,9 +13537,14 @@ design: (work@bottom1)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23
       |vpiExpr:
-      \_int_var: (keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:69, col:38
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@bottom1 (work@bottom1) top.v:1: , endline:4:9: , parent:work@bottom1
   |vpiDefName:work@bottom1

--- a/tests/UnitEnum/UnitEnum.log
+++ b/tests/UnitEnum/UnitEnum.log
@@ -227,9 +227,14 @@ design: (work@top)
     \_io_decl: (bound)
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16
       |vpiExpr:
-      \_int_var: (bound), line:6, col:16, parent:bound
-        |vpiFullName:bound
+      \_constant: , line:6, col:28
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -400,9 +405,14 @@ design: (work@top)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15
       |vpiExpr:
-      \_int_var: (keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:60, col:30
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -413,9 +423,14 @@ design: (work@top)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11
       |vpiExpr:
-      \_int_var: (keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:63, col:26
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -426,9 +441,14 @@ design: (work@top)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11
       |vpiExpr:
-      \_int_var: (keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:66, col:26
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -441,9 +461,14 @@ design: (work@top)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23
       |vpiExpr:
-      \_int_var: (keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:69, col:38
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@top (work@top) top.v:14: , endline:24:9: , parent:work@top
   |vpiDefName:work@top

--- a/tests/UnitForLoop/UnitForLoop.log
+++ b/tests/UnitForLoop/UnitForLoop.log
@@ -334,16 +334,14 @@ design: (unnamed)
     \_io_decl: (i)
       |vpiName:i
       |vpiDirection:1
-      |vpiExpr:
-      \_int_var: (i), line:3, col:13, parent:i
-        |vpiFullName:i
+      |vpiTypedef:
+      \_int_typespec: , line:3, col:13
     |vpiIODecl:
     \_io_decl: (j)
       |vpiName:j
       |vpiDirection:1
-      |vpiExpr:
-      \_int_var: (j), line:3, col:20, parent:j
-        |vpiFullName:j
+      |vpiTypedef:
+      \_int_typespec: , line:3, col:20
   |vpiMethod:
   \_function: (work@top::f1), line:7, parent:work@top
     |vpiMethod:1

--- a/tests/UnitForeach/UnitForeach.log
+++ b/tests/UnitForeach/UnitForeach.log
@@ -512,10 +512,11 @@ design: (unnamed)
     \_io_decl: (printer)
       |vpiName:printer
       |vpiDirection:1
-      |vpiExpr:
-      \_chandle_var: (printer.uvm_printer), line:5, col:46, parent:printer
+      |vpiTypedef:
+      \_unsupported_typespec: (uvm_printer), line:5, col:46
         |vpiName:uvm_printer
-        |vpiFullName:printer.uvm_printer
+        |vpiInstance:
+        \_package: uvm_pkg (uvm_pkg::) top2.v:3: , parent:unnamed
     |vpiStmt:
     \_begin: (uvm_pkg::uvm_sequencer_base::do_print), parent:uvm_pkg::uvm_sequencer_base::do_print
       |vpiFullName:uvm_pkg::uvm_sequencer_base::do_print
@@ -639,9 +640,14 @@ design: (unnamed)
     \_io_decl: (bound)
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16
       |vpiExpr:
-      \_int_var: (bound), line:6, col:16, parent:bound
-        |vpiFullName:bound
+      \_constant: , line:6, col:28
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -821,9 +827,14 @@ design: (unnamed)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15
       |vpiExpr:
-      \_int_var: (keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:60, col:30
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -834,9 +845,14 @@ design: (unnamed)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11
       |vpiExpr:
-      \_int_var: (keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:63, col:26
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -847,9 +863,14 @@ design: (unnamed)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11
       |vpiExpr:
-      \_int_var: (keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:66, col:26
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -862,9 +883,14 @@ design: (unnamed)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23
       |vpiExpr:
-      \_int_var: (keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:69, col:38
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallClasses:
 \_class_defn: (work@uvm_reg_map) top.v:7: , parent:unnamed
   |vpiName:work@uvm_reg_map

--- a/tests/UnitPackage/UnitPackage.log
+++ b/tests/UnitPackage/UnitPackage.log
@@ -874,17 +874,18 @@ design: (work@simple_package)
     \_io_decl: (mName)
       |vpiName:mName
       |vpiDirection:1
-      |vpiExpr:
-      \_string_var: (mName), line:12, col:19, parent:mName
-        |vpiFullName:mName
+      |vpiTypedef:
+      \_string_typespec: , line:12, col:19
+        |vpiInstance:
+        \_package: msgPkg (msgPkg::) msgPkg.pkg:4: , parent:work@simple_package
     |vpiIODecl:
     \_io_decl: (term)
       |vpiName:term
       |vpiDirection:1
-      |vpiExpr:
-      \_chandle_var: (term.bit), line:12, col:33, parent:term
-        |vpiName:bit
-        |vpiFullName:term.bit
+      |vpiTypedef:
+      \_bit_typespec: , line:12, col:33
+        |vpiInstance:
+        \_package: msgPkg (msgPkg::) msgPkg.pkg:4: , parent:work@simple_package
     |vpiStmt:
     \_begin: (msgPkg::initMsgPkg), parent:msgPkg::initMsgPkg
       |vpiFullName:msgPkg::initMsgPkg
@@ -927,9 +928,10 @@ design: (work@simple_package)
     \_io_decl: (msg)
       |vpiName:msg
       |vpiDirection:1
-      |vpiExpr:
-      \_string_var: (msg), line:19, col:18, parent:msg
-        |vpiFullName:msg
+      |vpiTypedef:
+      \_string_typespec: , line:19, col:18
+        |vpiInstance:
+        \_package: msgPkg (msgPkg::) msgPkg.pkg:4: , parent:work@simple_package
     |vpiStmt:
     \_sys_func_call: ($display), line:20, col:4, parent:msgPkg::msg_info
       |vpiName:$display
@@ -961,9 +963,10 @@ design: (work@simple_package)
     \_io_decl: (msg)
       |vpiName:msg
       |vpiDirection:1
-      |vpiExpr:
-      \_string_var: (msg), line:25, col:18, parent:msg
-        |vpiFullName:msg
+      |vpiTypedef:
+      \_string_typespec: , line:25, col:18
+        |vpiInstance:
+        \_package: msgPkg (msgPkg::) msgPkg.pkg:4: , parent:work@simple_package
     |vpiStmt:
     \_begin: (msgPkg::msg_warn), parent:msgPkg::msg_warn
       |vpiFullName:msgPkg::msg_warn
@@ -1005,9 +1008,10 @@ design: (work@simple_package)
     \_io_decl: (msg)
       |vpiName:msg
       |vpiDirection:1
-      |vpiExpr:
-      \_string_var: (msg), line:32, col:19, parent:msg
-        |vpiFullName:msg
+      |vpiTypedef:
+      \_string_typespec: , line:32, col:19
+        |vpiInstance:
+        \_package: msgPkg (msgPkg::) msgPkg.pkg:4: , parent:work@simple_package
     |vpiStmt:
     \_begin: (msgPkg::msg_error), parent:msgPkg::msg_error
       |vpiFullName:msgPkg::msg_error
@@ -1058,9 +1062,10 @@ design: (work@simple_package)
     \_io_decl: (msg)
       |vpiName:msg
       |vpiDirection:1
-      |vpiExpr:
-      \_string_var: (msg), line:40, col:19, parent:msg
-        |vpiFullName:msg
+      |vpiTypedef:
+      \_string_typespec: , line:40, col:19
+        |vpiInstance:
+        \_package: msgPkg (msgPkg::) msgPkg.pkg:4: , parent:work@simple_package
     |vpiStmt:
     \_begin: (msgPkg::msg_fatal), parent:msgPkg::msg_fatal
       |vpiFullName:msgPkg::msg_fatal
@@ -1199,9 +1204,14 @@ design: (work@simple_package)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -1393,9 +1403,14 @@ design: (work@simple_package)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -1406,9 +1421,14 @@ design: (work@simple_package)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -1419,9 +1439,14 @@ design: (work@simple_package)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -1434,9 +1459,14 @@ design: (work@simple_package)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@simple_package (work@simple_package) simple_pkg.sv:11: , endline:30:9: , parent:work@simple_package
   |vpiDefName:work@simple_package
@@ -1601,9 +1631,10 @@ design: (work@simple_package)
         \_io_decl: (msg)
           |vpiName:msg
           |vpiDirection:1
-          |vpiExpr:
-          \_string_var: (msg), line:19, col:18, parent:msg
-            |vpiFullName:msg
+          |vpiTypedef:
+          \_string_typespec: , line:19, col:18
+            |vpiInstance:
+            \_package: msgPkg (msgPkg::) msgPkg.pkg:4: , parent:work@simple_package
         |vpiStmt:
         \_sys_func_call: ($display), line:20, col:4, parent:msgPkg::msg_info
           |vpiName:$display
@@ -1635,9 +1666,10 @@ design: (work@simple_package)
         \_io_decl: (msg)
           |vpiName:msg
           |vpiDirection:1
-          |vpiExpr:
-          \_string_var: (msg), line:25, col:18, parent:msg
-            |vpiFullName:msg
+          |vpiTypedef:
+          \_string_typespec: , line:25, col:18
+            |vpiInstance:
+            \_package: msgPkg (msgPkg::) msgPkg.pkg:4: , parent:work@simple_package
         |vpiStmt:
         \_begin: (msgPkg::msg_warn), parent:msgPkg::msg_warn
           |vpiFullName:msgPkg::msg_warn
@@ -1679,9 +1711,10 @@ design: (work@simple_package)
         \_io_decl: (msg)
           |vpiName:msg
           |vpiDirection:1
-          |vpiExpr:
-          \_string_var: (msg), line:32, col:19, parent:msg
-            |vpiFullName:msg
+          |vpiTypedef:
+          \_string_typespec: , line:32, col:19
+            |vpiInstance:
+            \_package: msgPkg (msgPkg::) msgPkg.pkg:4: , parent:work@simple_package
         |vpiStmt:
         \_begin: (msgPkg::msg_error), parent:msgPkg::msg_error
           |vpiFullName:msgPkg::msg_error
@@ -1732,9 +1765,10 @@ design: (work@simple_package)
         \_io_decl: (msg)
           |vpiName:msg
           |vpiDirection:1
-          |vpiExpr:
-          \_string_var: (msg), line:40, col:19, parent:msg
-            |vpiFullName:msg
+          |vpiTypedef:
+          \_string_typespec: , line:40, col:19
+            |vpiInstance:
+            \_package: msgPkg (msgPkg::) msgPkg.pkg:4: , parent:work@simple_package
         |vpiStmt:
         \_begin: (msgPkg::msg_fatal), parent:msgPkg::msg_fatal
           |vpiFullName:msgPkg::msg_fatal
@@ -1859,17 +1893,18 @@ design: (work@simple_package)
     \_io_decl: (mName)
       |vpiName:mName
       |vpiDirection:1
-      |vpiExpr:
-      \_string_var: (mName), line:12, col:19, parent:mName
-        |vpiFullName:mName
+      |vpiTypedef:
+      \_string_typespec: , line:12, col:19
+        |vpiInstance:
+        \_package: msgPkg (msgPkg::) msgPkg.pkg:4: , parent:work@simple_package
     |vpiIODecl:
     \_io_decl: (term)
       |vpiName:term
       |vpiDirection:1
-      |vpiExpr:
-      \_chandle_var: (term.bit), line:12, col:33, parent:term
-        |vpiName:bit
-        |vpiFullName:term.bit
+      |vpiTypedef:
+      \_bit_typespec: , line:12, col:33
+        |vpiInstance:
+        \_package: msgPkg (msgPkg::) msgPkg.pkg:4: , parent:work@simple_package
     |vpiStmt:
     \_begin: (msgPkg::initMsgPkg), parent:msgPkg::initMsgPkg
       |vpiFullName:msgPkg::initMsgPkg
@@ -2279,17 +2314,18 @@ design: (work@simple_package)
         \_io_decl: (mName)
           |vpiName:mName
           |vpiDirection:1
-          |vpiExpr:
-          \_string_var: (mName), line:12, col:19, parent:mName
-            |vpiFullName:mName
+          |vpiTypedef:
+          \_string_typespec: , line:12, col:19
+            |vpiInstance:
+            \_package: msgPkg (msgPkg::) msgPkg.pkg:4: , parent:work@simple_package
         |vpiIODecl:
         \_io_decl: (term)
           |vpiName:term
           |vpiDirection:1
-          |vpiExpr:
-          \_chandle_var: (term.bit), line:12, col:33, parent:term
-            |vpiName:bit
-            |vpiFullName:term.bit
+          |vpiTypedef:
+          \_bit_typespec: , line:12, col:33
+            |vpiInstance:
+            \_package: msgPkg (msgPkg::) msgPkg.pkg:4: , parent:work@simple_package
         |vpiStmt:
         \_begin: (msgPkg::initMsgPkg), parent:msgPkg::initMsgPkg
           |vpiFullName:msgPkg::initMsgPkg
@@ -2332,9 +2368,10 @@ design: (work@simple_package)
         \_io_decl: (msg)
           |vpiName:msg
           |vpiDirection:1
-          |vpiExpr:
-          \_string_var: (msg), line:19, col:18, parent:msg
-            |vpiFullName:msg
+          |vpiTypedef:
+          \_string_typespec: , line:19, col:18
+            |vpiInstance:
+            \_package: msgPkg (msgPkg::) msgPkg.pkg:4: , parent:work@simple_package
         |vpiStmt:
         \_sys_func_call: ($display), line:20, col:4, parent:msgPkg::msg_info
           |vpiName:$display
@@ -2366,9 +2403,10 @@ design: (work@simple_package)
         \_io_decl: (msg)
           |vpiName:msg
           |vpiDirection:1
-          |vpiExpr:
-          \_string_var: (msg), line:25, col:18, parent:msg
-            |vpiFullName:msg
+          |vpiTypedef:
+          \_string_typespec: , line:25, col:18
+            |vpiInstance:
+            \_package: msgPkg (msgPkg::) msgPkg.pkg:4: , parent:work@simple_package
         |vpiStmt:
         \_begin: (msgPkg::msg_warn), parent:msgPkg::msg_warn
           |vpiFullName:msgPkg::msg_warn
@@ -2410,9 +2448,10 @@ design: (work@simple_package)
         \_io_decl: (msg)
           |vpiName:msg
           |vpiDirection:1
-          |vpiExpr:
-          \_string_var: (msg), line:32, col:19, parent:msg
-            |vpiFullName:msg
+          |vpiTypedef:
+          \_string_typespec: , line:32, col:19
+            |vpiInstance:
+            \_package: msgPkg (msgPkg::) msgPkg.pkg:4: , parent:work@simple_package
         |vpiStmt:
         \_begin: (msgPkg::msg_error), parent:msgPkg::msg_error
           |vpiFullName:msgPkg::msg_error
@@ -2463,9 +2502,10 @@ design: (work@simple_package)
         \_io_decl: (msg)
           |vpiName:msg
           |vpiDirection:1
-          |vpiExpr:
-          \_string_var: (msg), line:40, col:19, parent:msg
-            |vpiFullName:msg
+          |vpiTypedef:
+          \_string_typespec: , line:40, col:19
+            |vpiInstance:
+            \_package: msgPkg (msgPkg::) msgPkg.pkg:4: , parent:work@simple_package
         |vpiStmt:
         \_begin: (msgPkg::msg_fatal), parent:msgPkg::msg_fatal
           |vpiFullName:msgPkg::msg_fatal
@@ -2590,17 +2630,18 @@ design: (work@simple_package)
     \_io_decl: (mName), parent:msgPkg::initMsgPkg
       |vpiName:mName
       |vpiDirection:1
-      |vpiExpr:
-      \_string_var: (work@simple_package.initMsgPkg.mName), line:12, col:19, parent:mName
-        |vpiFullName:work@simple_package.initMsgPkg.mName
+      |vpiTypedef:
+      \_string_typespec: , line:12, col:19, parent:mName
+        |vpiInstance:
+        \_package: msgPkg (msgPkg::) msgPkg.pkg:4: , parent:work@simple_package
     |vpiIODecl:
     \_io_decl: (term), parent:msgPkg::initMsgPkg
       |vpiName:term
       |vpiDirection:1
-      |vpiExpr:
-      \_chandle_var: (work@simple_package.initMsgPkg.term.bit), line:12, col:33, parent:term
-        |vpiName:bit
-        |vpiFullName:work@simple_package.initMsgPkg.term.bit
+      |vpiTypedef:
+      \_bit_typespec: , line:12, col:33, parent:term
+        |vpiInstance:
+        \_package: msgPkg (msgPkg::) msgPkg.pkg:4: , parent:work@simple_package
     |vpiStmt:
     \_begin: (work@simple_package.initMsgPkg), parent:msgPkg::initMsgPkg
       |vpiFullName:work@simple_package.initMsgPkg
@@ -2616,8 +2657,6 @@ design: (work@simple_package)
         \_ref_obj: (work@simple_package.initMsgPkg.term), line:13, col:25
           |vpiName:term
           |vpiFullName:work@simple_package.initMsgPkg.term
-          |vpiActual:
-          \_chandle_var: (term.bit), line:12, col:33, parent:term
       |vpiStmt:
       \_assignment: , line:14, col:4, parent:work@simple_package.initMsgPkg
         |vpiOpType:82
@@ -2630,8 +2669,6 @@ design: (work@simple_package)
         \_ref_obj: (work@simple_package.initMsgPkg.mName), line:14, col:14
           |vpiName:mName
           |vpiFullName:work@simple_package.initMsgPkg.mName
-          |vpiActual:
-          \_string_var: (mName), line:12, col:19, parent:mName
   |vpiTaskFunc:
   \_task: (msgPkg::msg_info), line:19, col:2, parent:work@simple_package
     |vpiVisibility:1
@@ -2643,9 +2680,10 @@ design: (work@simple_package)
     \_io_decl: (msg), parent:msgPkg::msg_info
       |vpiName:msg
       |vpiDirection:1
-      |vpiExpr:
-      \_string_var: (work@simple_package.msg_info.msg), line:19, col:18, parent:msg
-        |vpiFullName:work@simple_package.msg_info.msg
+      |vpiTypedef:
+      \_string_typespec: , line:19, col:18, parent:msg
+        |vpiInstance:
+        \_package: msgPkg (msgPkg::) msgPkg.pkg:4: , parent:work@simple_package
     |vpiStmt:
     \_sys_func_call: ($display), line:20, col:4, parent:msgPkg::msg_info
       |vpiName:$display
@@ -2666,8 +2704,6 @@ design: (work@simple_package)
       \_ref_obj: (work@simple_package.msg_info.msg), line:20, col:50, parent:$display
         |vpiName:msg
         |vpiFullName:work@simple_package.msg_info.msg
-        |vpiActual:
-        \_string_var: (msg), line:19, col:18, parent:msg
   |vpiTaskFunc:
   \_task: (msgPkg::msg_warn), line:25, col:2, parent:work@simple_package
     |vpiVisibility:1
@@ -2679,9 +2715,10 @@ design: (work@simple_package)
     \_io_decl: (msg), parent:msgPkg::msg_warn
       |vpiName:msg
       |vpiDirection:1
-      |vpiExpr:
-      \_string_var: (work@simple_package.msg_warn.msg), line:25, col:18, parent:msg
-        |vpiFullName:work@simple_package.msg_warn.msg
+      |vpiTypedef:
+      \_string_typespec: , line:25, col:18, parent:msg
+        |vpiInstance:
+        \_package: msgPkg (msgPkg::) msgPkg.pkg:4: , parent:work@simple_package
     |vpiStmt:
     \_begin: (work@simple_package.msg_warn), parent:msgPkg::msg_warn
       |vpiFullName:work@simple_package.msg_warn
@@ -2705,8 +2742,6 @@ design: (work@simple_package)
         \_ref_obj: (work@simple_package.msg_warn.msg), line:26, col:50, parent:$display
           |vpiName:msg
           |vpiFullName:work@simple_package.msg_warn.msg
-          |vpiActual:
-          \_string_var: (msg), line:25, col:18, parent:msg
       |vpiStmt:
       \_operation: , line:27, col:4, parent:work@simple_package.msg_warn
         |vpiOpType:62
@@ -2725,9 +2760,10 @@ design: (work@simple_package)
     \_io_decl: (msg), parent:msgPkg::msg_error
       |vpiName:msg
       |vpiDirection:1
-      |vpiExpr:
-      \_string_var: (work@simple_package.msg_error.msg), line:32, col:19, parent:msg
-        |vpiFullName:work@simple_package.msg_error.msg
+      |vpiTypedef:
+      \_string_typespec: , line:32, col:19, parent:msg
+        |vpiInstance:
+        \_package: msgPkg (msgPkg::) msgPkg.pkg:4: , parent:work@simple_package
     |vpiStmt:
     \_begin: (work@simple_package.msg_error), parent:msgPkg::msg_error
       |vpiFullName:work@simple_package.msg_error
@@ -2751,8 +2787,6 @@ design: (work@simple_package)
         \_ref_obj: (work@simple_package.msg_error.msg), line:33, col:51, parent:$display
           |vpiName:msg
           |vpiFullName:work@simple_package.msg_error.msg
-          |vpiActual:
-          \_string_var: (msg), line:32, col:19, parent:msg
       |vpiStmt:
       \_operation: , line:34, col:4, parent:work@simple_package.msg_error
         |vpiOpType:62
@@ -2780,9 +2814,10 @@ design: (work@simple_package)
     \_io_decl: (msg), parent:msgPkg::msg_fatal
       |vpiName:msg
       |vpiDirection:1
-      |vpiExpr:
-      \_string_var: (work@simple_package.msg_fatal.msg), line:40, col:19, parent:msg
-        |vpiFullName:work@simple_package.msg_fatal.msg
+      |vpiTypedef:
+      \_string_typespec: , line:40, col:19, parent:msg
+        |vpiInstance:
+        \_package: msgPkg (msgPkg::) msgPkg.pkg:4: , parent:work@simple_package
     |vpiStmt:
     \_begin: (work@simple_package.msg_fatal), parent:msgPkg::msg_fatal
       |vpiFullName:work@simple_package.msg_fatal
@@ -2806,8 +2841,6 @@ design: (work@simple_package)
         \_ref_obj: (work@simple_package.msg_fatal.msg), line:41, col:51, parent:$display
           |vpiName:msg
           |vpiFullName:work@simple_package.msg_fatal.msg
-          |vpiActual:
-          \_string_var: (msg), line:40, col:19, parent:msg
       |vpiStmt:
       \_sys_func_call: ($finish), line:42, col:4, parent:work@simple_package.msg_fatal
         |vpiName:$finish

--- a/tests/UnitPartSelect/UnitPartSelect.log
+++ b/tests/UnitPartSelect/UnitPartSelect.log
@@ -612,9 +612,14 @@ design: (work@toto)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -806,9 +811,14 @@ design: (work@toto)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -819,9 +829,14 @@ design: (work@toto)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -832,9 +847,14 @@ design: (work@toto)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -847,9 +867,14 @@ design: (work@toto)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@dut (work@dut) top.sv:21: , endline:27:9: , parent:work@toto
   |vpiDefName:work@dut

--- a/tests/UnitThisNew/UnitThisNew.log
+++ b/tests/UnitThisNew/UnitThisNew.log
@@ -361,17 +361,19 @@ design: (unnamed)
     \_io_decl: (action_str)
       |vpiName:action_str
       |vpiDirection:1
-      |vpiExpr:
-      \_string_var: (action_str), line:3, col:48, parent:action_str
-        |vpiFullName:action_str
+      |vpiTypedef:
+      \_string_typespec: , line:3, col:48
+        |vpiInstance:
+        \_package: toto (toto::) dut.sv:1: , parent:unnamed
     |vpiIODecl:
     \_io_decl: (action)
       |vpiName:action
       |vpiDirection:2
-      |vpiExpr:
-      \_chandle_var: (action.uvm_action), line:3, col:74, parent:action
+      |vpiTypedef:
+      \_unsupported_typespec: (uvm_action), line:3, col:74
         |vpiName:uvm_action
-        |vpiFullName:action.uvm_action
+        |vpiInstance:
+        \_package: toto (toto::) dut.sv:1: , parent:unnamed
     |vpiVariables:
     \_array_var: (toto::uvm_string_to_action)
       |vpiFullName:toto::uvm_string_to_action
@@ -509,10 +511,11 @@ design: (unnamed)
     \_io_decl: (field)
       |vpiName:field
       |vpiDirection:1
-      |vpiExpr:
-      \_chandle_var: (field.uvm_reg_field), line:25, col:33, parent:field
+      |vpiTypedef:
+      \_unsupported_typespec: (uvm_reg_field), line:25, col:33
         |vpiName:uvm_reg_field
-        |vpiFullName:field.uvm_reg_field
+        |vpiInstance:
+        \_package: toto (toto::) dut.sv:1: , parent:unnamed
     |vpiStmt:
     \_if_stmt: , line:27, col:3, parent:toto::uvm_reg::add_field
       |vpiCondition:
@@ -561,10 +564,11 @@ design: (unnamed)
     \_io_decl: (element)
       |vpiName:element
       |vpiDirection:1
-      |vpiExpr:
-      \_chandle_var: (element.uvm_object), line:36, col:52, parent:element
+      |vpiTypedef:
+      \_unsupported_typespec: (uvm_object), line:36, col:52
         |vpiName:uvm_object
-        |vpiFullName:element.uvm_object
+        |vpiInstance:
+        \_package: toto (toto::) dut.sv:1: , parent:unnamed
     |vpiStmt:
     \_begin: (toto::uvm_reg_backdoor::start_update_thread), parent:toto::uvm_reg_backdoor::start_update_thread
       |vpiFullName:toto::uvm_reg_backdoor::start_update_thread
@@ -611,9 +615,14 @@ design: (unnamed)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -805,9 +814,14 @@ design: (unnamed)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -818,9 +832,14 @@ design: (unnamed)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -831,9 +850,14 @@ design: (unnamed)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -846,9 +870,14 @@ design: (unnamed)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/UnpackPort/UnpackPort.log
+++ b/tests/UnpackPort/UnpackPort.log
@@ -198,9 +198,14 @@ design: (work@dut)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -392,9 +397,14 @@ design: (work@dut)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -405,9 +415,14 @@ design: (work@dut)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -418,9 +433,14 @@ design: (work@dut)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -433,9 +453,14 @@ design: (work@dut)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@dut (work@dut) dut.sv:1: , endline:11:9: , parent:work@dut
   |vpiDefName:work@dut

--- a/tests/Values/Values.log
+++ b/tests/Values/Values.log
@@ -214,9 +214,14 @@ design: (work@top)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -408,9 +413,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -421,9 +431,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -434,9 +449,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -449,9 +469,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@top (work@top) dut.sv:1: , endline:7:9: , parent:work@top
   |vpiDefName:work@top

--- a/tests/VarInFunc/VarInFunc.log
+++ b/tests/VarInFunc/VarInFunc.log
@@ -185,9 +185,14 @@ design: (work@top)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -379,9 +384,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -392,9 +402,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -405,9 +420,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -420,9 +440,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@top (work@top) dut.sv:1: , endline:9:9: , parent:work@top
   |vpiDefName:work@top

--- a/tests/VarSelect/VarSelect.log
+++ b/tests/VarSelect/VarSelect.log
@@ -232,9 +232,14 @@ design: (work@top)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -426,9 +431,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -439,9 +449,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -452,9 +467,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -467,9 +487,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@top (work@top) dut.sv:3: , endline:14:9: , parent:work@top
   |vpiDefName:work@top

--- a/tests/WildConn/WildConn.log
+++ b/tests/WildConn/WildConn.log
@@ -124,9 +124,14 @@ design: (work@top)
     \_io_decl: (bound), parent:work@mailbox::new
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16, parent:bound
       |vpiExpr:
-      \_int_var: (work@mailbox::new::bound), line:6, col:16, parent:bound
-        |vpiFullName:work@mailbox::new::bound
+      \_constant: , line:6, col:28, parent:bound
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -318,9 +323,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::new
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::new::keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:work@semaphore::new::keyCount
+      \_constant: , line:60, col:30, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -331,9 +341,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::put
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::put::keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::put::keyCount
+      \_constant: , line:63, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -344,9 +359,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::get::keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:work@semaphore::get::keyCount
+      \_constant: , line:66, col:26, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -359,9 +379,14 @@ design: (work@top)
     \_io_decl: (keyCount), parent:work@semaphore::try_get
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23, parent:keyCount
       |vpiExpr:
-      \_int_var: (work@semaphore::try_get::keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:work@semaphore::try_get::keyCount
+      \_constant: , line:69, col:38, parent:keyCount
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallModules:
 \_module: work@MOD (work@MOD) dut.sv:1: , endline:5:9: , parent:work@top
   |vpiDefName:work@MOD

--- a/third_party/tests/CoresSweRV/CoresSweRV.log
+++ b/third_party/tests/CoresSweRV/CoresSweRV.log
@@ -4843,6 +4843,9 @@ UHDM HTML COVERAGE REPORT: ../../../build/tests/CoresSweRV/slpp_all//surelog.uhd
 [ERR:UH0703] Internal Error: adding wrong object type (type_parameter) in a actual_group group!
 .
 
+[ERR:UH0703] Internal Error: adding wrong object type (constant) in a actual_group group!
+.
+
 [ERR:UH0704] design/mem.sv:27: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] design/mem.sv:35: UHDM coverage pointing to empty source line.
@@ -5055,6 +5058,14 @@ UHDM HTML COVERAGE REPORT: ../../../build/tests/CoresSweRV/slpp_all//surelog.uhd
 
 [ERR:UH0704] design/ifu/ifu_aln_ctl.sv:1232: UHDM coverage pointing to empty source line.
 
+[ERR:UH0704] design/ifu/ifu_ic_mem.sv:27: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] design/ifu/ifu_ic_mem.sv:31: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] design/ifu/ifu_ic_mem.sv:40: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] design/ifu/ifu_ic_mem.sv:41: UHDM coverage pointing to empty source line.
+
 [ERR:UH0704] design/ifu/ifu_bp_ctl.sv:886: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] design/ifu/ifu_bp_ctl.sv:896: UHDM coverage pointing to empty source line.
@@ -5213,14 +5224,6 @@ UHDM HTML COVERAGE REPORT: ../../../build/tests/CoresSweRV/slpp_all//surelog.uhd
 
 [ERR:UH0704] design/ifu/ifu_bp_ctl.sv:1767: UHDM coverage pointing to empty source line.
 
-[ERR:UH0704] design/ifu/ifu_ic_mem.sv:27: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] design/ifu/ifu_ic_mem.sv:31: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] design/ifu/ifu_ic_mem.sv:40: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] design/ifu/ifu_ic_mem.sv:41: UHDM coverage pointing to empty source line.
-
 [ERR:UH0704] design/ifu/ifu_iccm_mem.sv:21: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] design/ifu/ifu_iccm_mem.sv:24: UHDM coverage pointing to empty source line.
@@ -5262,24 +5265,6 @@ UHDM HTML COVERAGE REPORT: ../../../build/tests/CoresSweRV/slpp_all//surelog.uhd
 [ERR:UH0704] design/dec/dec_ib_ctl.sv:36: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] design/dec/dec_ib_ctl.sv:42: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] design/lsu/lsu_addrcheck.sv:34: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] design/lsu/lsu_addrcheck.sv:40: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] design/lsu/lsu_addrcheck.sv:46: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] design/lsu/lsu_addrcheck.sv:49: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] design/lsu/lsu.sv:27: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] design/lsu/lsu.sv:31: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] design/lsu/lsu.sv:35: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] design/lsu/lsu.sv:42: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] design/lsu/lsu.sv:49: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] design/exu/exu.sv:633: UHDM coverage pointing to empty source line.
 
@@ -5357,6 +5342,24 @@ UHDM HTML COVERAGE REPORT: ../../../build/tests/CoresSweRV/slpp_all//surelog.uhd
 
 [ERR:UH0704] design/lsu/lsu_lsc_ctl.sv:33: UHDM coverage pointing to empty source line.
 
+[ERR:UH0704] design/lsu/lsu.sv:27: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] design/lsu/lsu.sv:31: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] design/lsu/lsu.sv:35: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] design/lsu/lsu.sv:42: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] design/lsu/lsu.sv:49: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] design/lsu/lsu_addrcheck.sv:34: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] design/lsu/lsu_addrcheck.sv:40: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] design/lsu/lsu_addrcheck.sv:46: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] design/lsu/lsu_addrcheck.sv:49: UHDM coverage pointing to empty source line.
+
 [ERR:UH0704] design/lsu/lsu_stbuf.sv:28: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] design/lsu/lsu_stbuf.sv:29: UHDM coverage pointing to empty source line.
@@ -5366,6 +5369,22 @@ UHDM HTML COVERAGE REPORT: ../../../build/tests/CoresSweRV/slpp_all//surelog.uhd
 [ERR:UH0704] design/lsu/lsu_stbuf.sv:40: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] design/lsu/lsu_stbuf.sv:45: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] design/lsu/lsu_ecc.sv:31: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] design/lsu/lsu_ecc.sv:37: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] design/lsu/lsu_ecc.sv:45: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] design/lsu/lsu_bus_buffer.sv:29: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] design/lsu/lsu_bus_buffer.sv:34: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] design/lsu/lsu_bus_buffer.sv:37: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] design/lsu/lsu_bus_buffer.sv:38: UHDM coverage pointing to empty source line.
+
+[ERR:UH0704] design/lsu/lsu_bus_buffer.sv:49: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] design/lsu/lsu_bus_intf.sv:35: UHDM coverage pointing to empty source line.
 
@@ -5378,22 +5397,6 @@ UHDM HTML COVERAGE REPORT: ../../../build/tests/CoresSweRV/slpp_all//surelog.uhd
 [ERR:UH0704] design/lsu/lsu_dccm_ctl.sv:28: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] design/lsu/lsu_dccm_ctl.sv:43: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] design/lsu/lsu_bus_buffer.sv:29: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] design/lsu/lsu_bus_buffer.sv:34: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] design/lsu/lsu_bus_buffer.sv:37: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] design/lsu/lsu_bus_buffer.sv:38: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] design/lsu/lsu_bus_buffer.sv:49: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] design/lsu/lsu_ecc.sv:31: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] design/lsu/lsu_ecc.sv:37: UHDM coverage pointing to empty source line.
-
-[ERR:UH0704] design/lsu/lsu_ecc.sv:45: UHDM coverage pointing to empty source line.
 
 [ERR:UH0704] design/dbg/dbg.sv:33: UHDM coverage pointing to empty source line.
 
@@ -5491,7 +5494,7 @@ UHDM HTML COVERAGE REPORT: ../../../build/tests/CoresSweRV/slpp_all//surelog.uhd
 
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 324
+[  ERROR] : 325
 [WARNING] : 120
 [   NOTE] : 15
 

--- a/third_party/tests/SimpleParserTest/SimpleParserTest.log
+++ b/third_party/tests/SimpleParserTest/SimpleParserTest.log
@@ -147,9 +147,14 @@ design: (work@dff_async_reset)
     \_io_decl: (bound)
       |vpiName:bound
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:6, col:16
       |vpiExpr:
-      \_int_var: (bound), line:6, col:16, parent:bound
-        |vpiFullName:bound
+      \_constant: , line:6, col:28
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_function: (work@mailbox::num), line:9, col:2, parent:work@mailbox
     |vpiMethod:1
@@ -320,9 +325,14 @@ design: (work@dff_async_reset)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:60, col:15
       |vpiExpr:
-      \_int_var: (keyCount), line:60, col:15, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:60, col:30
+        |vpiConstType:9
+        |vpiDecompile:0
+        |vpiSize:64
+        |UINT:0
   |vpiMethod:
   \_task: (work@semaphore::put), line:63, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -333,9 +343,14 @@ design: (work@dff_async_reset)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:63, col:11
       |vpiExpr:
-      \_int_var: (keyCount), line:63, col:11, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:63, col:26
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_task: (work@semaphore::get), line:66, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -346,9 +361,14 @@ design: (work@dff_async_reset)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:66, col:11
       |vpiExpr:
-      \_int_var: (keyCount), line:66, col:11, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:66, col:26
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
   |vpiMethod:
   \_function: (work@semaphore::try_get), line:69, col:2, parent:work@semaphore
     |vpiMethod:1
@@ -361,9 +381,14 @@ design: (work@dff_async_reset)
     \_io_decl: (keyCount)
       |vpiName:keyCount
       |vpiDirection:1
+      |vpiTypedef:
+      \_int_typespec: , line:69, col:23
       |vpiExpr:
-      \_int_var: (keyCount), line:69, col:23, parent:keyCount
-        |vpiFullName:keyCount
+      \_constant: , line:69, col:38
+        |vpiConstType:9
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
 |uhdmallUdps:
 \_udp_defn: work@jkff_udp, line:7, parent:work@dff_async_reset
   |vpiDefName:work@jkff_udp


### PR DESCRIPTION
Fixes #1166.
io_decl modeling has changed:
- vpiExpr is now used to model the default value of the func args
- vpiTypespec and vpiRanges model the io type.
