### PR TITLE
Fix setting string parameter with dot from command-line

### DIFF
--- a/src/Expression/ExprBuilder.cpp
+++ b/src/Expression/ExprBuilder.cpp
@@ -862,22 +862,26 @@ Value* ExprBuilder::fromString(const std::string& value) {
         break;
       }
     }
-  } else if (strstr(value_ptr, ".")) {
-    long double v = std::strtold(value_ptr, 0);
-    val = m_valueFactory.newLValue();
-    val->set((double) v);  
-  } else if (value.size() && value[0] == '-') {
-    int64_t v = std::strtoll(value_ptr, 0, 10);
-    val = m_valueFactory.newLValue();
-    val->set(v);  
   } else {
-    uint64_t v = std::strtoull(value_ptr, &end_parse_ptr, 10);
-    if (value_ptr != end_parse_ptr) {
+    long double v = std::strtold(value_ptr, &end_parse_ptr);
+    if (value_ptr != end_parse_ptr && strstr(value_ptr, ".")) {
       val = m_valueFactory.newLValue();
-      val->set(v);
+      val->set((double) v);
     } else {
-      val = m_valueFactory.newStValue();
-      val->set(value);
+      int64_t v = std::strtoll(value_ptr, &end_parse_ptr, 10);
+      if (value_ptr != end_parse_ptr && value.size() && value[0] == '-') {
+        val = m_valueFactory.newLValue();
+        val->set(v);
+      } else {
+        uint64_t v = std::strtoull(value_ptr, &end_parse_ptr, 10);
+        if (value_ptr != end_parse_ptr) {
+          val = m_valueFactory.newLValue();
+          val->set(v);
+        } else {
+          val = m_valueFactory.newStValue();
+          val->set(value);
+        }
+      }
     }
   }
   return val;

--- a/tests/ParamLine/ParamLine.log
+++ b/tests/ParamLine/ParamLine.log
@@ -36,7 +36,7 @@ UHDM HTML COVERAGE REPORT: ./slpp_all//surelog.uhdm.chk.html
 design: (work@top)
 |vpiName:work@top
 |uhdmallModules:
-\_module: work@top (work@top) dut.sv:1: , endline:27:9: , parent:work@top
+\_module: work@top (work@top) dut.sv:1: , endline:33:9: , parent:work@top
   |vpiDefName:work@top
   |vpiFullName:work@top
   |vpiParamAssign:
@@ -54,7 +54,7 @@ design: (work@top)
   |vpiParameter:
   \_parameter: (work@top.p), line:2, col:14, parent:work@top
 |uhdmtopModules:
-\_module: work@top (work@top) dut.sv:1: , endline:27:9: 
+\_module: work@top (work@top) dut.sv:1: , endline:33:9: 
   |vpiDefName:work@top
   |vpiName:work@top
   |vpiGenScopeArray:
@@ -136,7 +136,7 @@ UHDM HTML COVERAGE REPORT: ./slpp_all//surelog.uhdm.chk.html
 design: (work@top)
 |vpiName:work@top
 |uhdmallModules:
-\_module: work@top (work@top) dut.sv:1: , endline:27:9: , parent:work@top
+\_module: work@top (work@top) dut.sv:1: , endline:33:9: , parent:work@top
   |vpiDefName:work@top
   |vpiFullName:work@top
   |vpiParamAssign:
@@ -154,7 +154,7 @@ design: (work@top)
   |vpiParameter:
   \_parameter: (work@top.p), line:2, col:14, parent:work@top
 |uhdmtopModules:
-\_module: work@top (work@top) dut.sv:1: , endline:27:9: 
+\_module: work@top (work@top) dut.sv:1: , endline:33:9: 
   |vpiDefName:work@top
   |vpiName:work@top
   |vpiGenScopeArray:
@@ -216,7 +216,7 @@ UHDM HTML COVERAGE REPORT: ./slpp_all//surelog.uhdm.chk.html
 design: (work@top)
 |vpiName:work@top
 |uhdmallModules:
-\_module: work@top (work@top) dut.sv:1: , endline:27:9: , parent:work@top
+\_module: work@top (work@top) dut.sv:1: , endline:33:9: , parent:work@top
   |vpiDefName:work@top
   |vpiFullName:work@top
   |vpiParamAssign:
@@ -234,7 +234,7 @@ design: (work@top)
   |vpiParameter:
   \_parameter: (work@top.p), line:2, col:14, parent:work@top
 |uhdmtopModules:
-\_module: work@top (work@top) dut.sv:1: , endline:27:9: 
+\_module: work@top (work@top) dut.sv:1: , endline:33:9: 
   |vpiDefName:work@top
   |vpiName:work@top
   |vpiParamAssign:
@@ -291,7 +291,7 @@ UHDM HTML COVERAGE REPORT: ./slpp_all//surelog.uhdm.chk.html
 design: (work@top)
 |vpiName:work@top
 |uhdmallModules:
-\_module: work@top (work@top) dut.sv:1: , endline:27:9: , parent:work@top
+\_module: work@top (work@top) dut.sv:1: , endline:33:9: , parent:work@top
   |vpiDefName:work@top
   |vpiFullName:work@top
   |vpiParamAssign:
@@ -309,7 +309,7 @@ design: (work@top)
   |vpiParameter:
   \_parameter: (work@top.p), line:2, col:14, parent:work@top
 |uhdmtopModules:
-\_module: work@top (work@top) dut.sv:1: , endline:27:9: 
+\_module: work@top (work@top) dut.sv:1: , endline:33:9: 
   |vpiDefName:work@top
   |vpiName:work@top
   |vpiGenScopeArray:
@@ -378,7 +378,7 @@ UHDM HTML COVERAGE REPORT: ./slpp_all//surelog.uhdm.chk.html
 design: (work@top)
 |vpiName:work@top
 |uhdmallModules:
-\_module: work@top (work@top) dut.sv:1: , endline:27:9: , parent:work@top
+\_module: work@top (work@top) dut.sv:1: , endline:33:9: , parent:work@top
   |vpiDefName:work@top
   |vpiFullName:work@top
   |vpiParamAssign:
@@ -396,7 +396,7 @@ design: (work@top)
   |vpiParameter:
   \_parameter: (work@top.p), line:2, col:14, parent:work@top
 |uhdmtopModules:
-\_module: work@top (work@top) dut.sv:1: , endline:27:9: 
+\_module: work@top (work@top) dut.sv:1: , endline:33:9: 
   |vpiDefName:work@top
   |vpiName:work@top
   |vpiGenScopeArray:
@@ -466,7 +466,7 @@ UHDM HTML COVERAGE REPORT: ./slpp_all//surelog.uhdm.chk.html
 design: (work@top)
 |vpiName:work@top
 |uhdmallModules:
-\_module: work@top (work@top) dut.sv:1: , endline:27:9: , parent:work@top
+\_module: work@top (work@top) dut.sv:1: , endline:33:9: , parent:work@top
   |vpiDefName:work@top
   |vpiFullName:work@top
   |vpiParamAssign:
@@ -484,7 +484,7 @@ design: (work@top)
   |vpiParameter:
   \_parameter: (work@top.p), line:2, col:14, parent:work@top
 |uhdmtopModules:
-\_module: work@top (work@top) dut.sv:1: , endline:27:9: 
+\_module: work@top (work@top) dut.sv:1: , endline:33:9: 
   |vpiDefName:work@top
   |vpiName:work@top
   |vpiGenScopeArray:
@@ -554,7 +554,7 @@ UHDM HTML COVERAGE REPORT: ./slpp_all//surelog.uhdm.chk.html
 design: (work@top)
 |vpiName:work@top
 |uhdmallModules:
-\_module: work@top (work@top) dut.sv:1: , endline:27:9: , parent:work@top
+\_module: work@top (work@top) dut.sv:1: , endline:33:9: , parent:work@top
   |vpiDefName:work@top
   |vpiFullName:work@top
   |vpiParamAssign:
@@ -572,7 +572,7 @@ design: (work@top)
   |vpiParameter:
   \_parameter: (work@top.p), line:2, col:14, parent:work@top
 |uhdmtopModules:
-\_module: work@top (work@top) dut.sv:1: , endline:27:9: 
+\_module: work@top (work@top) dut.sv:1: , endline:33:9: 
   |vpiDefName:work@top
   |vpiName:work@top
   |vpiGenScopeArray:
@@ -623,30 +623,38 @@ Processing: -parse -d uhdm -elabuhdm dut.sv -nobuiltin -Pp=0
 
 [INF:CP0335] dut.sv:24: Compile generate block "work@top.genblk8".
 
+[INF:CP0335] dut.sv:27: Compile generate block "work@top.genblk9".
+
+[INF:CP0335] dut.sv:30: Compile generate block "work@top.genblk10".
+
 [NTE:EL0503] dut.sv:1: Top level module "work@top".
 
 [WRN:EL0500] dut.sv:4: Cannot find a module definition for "work@top.genblk1::GOOD_BLAH".
 
 [WRN:EL0500] dut.sv:25: Cannot find a module definition for "work@top.genblk8::GOOD_0".
 
+[WRN:EL0500] dut.sv:28: Cannot find a module definition for "work@top.genblk9::GOOD_STR_WITH_DOT".
+
+[WRN:EL0500] dut.sv:31: Cannot find a module definition for "work@top.genblk10::GOOD_MINUS_STR".
+
 [NTE:EL0508] Nb Top level modules: 1.
 
 [NTE:EL0509] Max instance depth: 3.
 
-[NTE:EL0510] Nb instances: 3.
+[NTE:EL0510] Nb instances: 5.
 
-[NTE:EL0511] Nb leaf instances: 2.
+[NTE:EL0511] Nb leaf instances: 4.
 
-[WRN:EL0512] Nb undefined modules: 2.
+[WRN:EL0512] Nb undefined modules: 4.
 
-[WRN:EL0513] Nb undefined instances: 2.
+[WRN:EL0513] Nb undefined instances: 4.
 
 UHDM HTML COVERAGE REPORT: ./slpp_all//surelog.uhdm.chk.html
 ====== UHDM =======
 design: (work@top)
 |vpiName:work@top
 |uhdmallModules:
-\_module: work@top (work@top) dut.sv:1: , endline:27:9: , parent:work@top
+\_module: work@top (work@top) dut.sv:1: , endline:33:9: , parent:work@top
   |vpiDefName:work@top
   |vpiFullName:work@top
   |vpiParamAssign:
@@ -664,7 +672,7 @@ design: (work@top)
   |vpiParameter:
   \_parameter: (work@top.p), line:2, col:14, parent:work@top
 |uhdmtopModules:
-\_module: work@top (work@top) dut.sv:1: , endline:27:9: 
+\_module: work@top (work@top) dut.sv:1: , endline:33:9: 
   |vpiDefName:work@top
   |vpiName:work@top
   |vpiGenScopeArray:
@@ -691,6 +699,30 @@ design: (work@top)
         |vpiDefName:work@top.genblk8::GOOD_0
         |vpiName:good
         |vpiFullName:work@top.genblk8.good
+  |vpiGenScopeArray:
+  \_gen_scope_array: (work@top.genblk9), line:27, parent:work@top
+    |vpiName:genblk9
+    |vpiFullName:work@top.genblk9
+    |vpiGenScope:
+    \_gen_scope: (work@top.genblk9), parent:work@top.genblk9
+      |vpiFullName:work@top.genblk9
+      |vpiModule:
+      \_module: work@top.genblk9::GOOD_STR_WITH_DOT (work@top.genblk9.good) dut.sv:28: , parent:work@top.genblk9
+        |vpiDefName:work@top.genblk9::GOOD_STR_WITH_DOT
+        |vpiName:good
+        |vpiFullName:work@top.genblk9.good
+  |vpiGenScopeArray:
+  \_gen_scope_array: (work@top.genblk10), line:30, parent:work@top
+    |vpiName:genblk10
+    |vpiFullName:work@top.genblk10
+    |vpiGenScope:
+    \_gen_scope: (work@top.genblk10), parent:work@top.genblk10
+      |vpiFullName:work@top.genblk10
+      |vpiModule:
+      \_module: work@top.genblk10::GOOD_MINUS_STR (work@top.genblk10.good) dut.sv:31: , parent:work@top.genblk10
+        |vpiDefName:work@top.genblk10::GOOD_MINUS_STR
+        |vpiName:good
+        |vpiFullName:work@top.genblk10.good
   |vpiParamAssign:
   \_param_assign: , line:2, col:14, parent:work@top
     |vpiRhs:
@@ -710,6 +742,214 @@ design: (work@top)
 [  FATAL] : 0
 [ SYNTAX] : 0
 [  ERROR] : 0
+[WARNING] : 7
+[   NOTE] : 5
+Processing: -parse -d uhdm -elabuhdm dut.sv -nobuiltin -Pp="STR.WITH.DOT"
+[INF:CM0023] Creating log file ./slpp_all/surelog.log.
+
+[WRN:PA0205] dut.sv:1: No timescale set for "top".
+
+[INF:CP0300] Compilation...
+
+[INF:CP0303] dut.sv:1: Compile module "work@top".
+
+[INF:EL0526] Design Elaboration...
+
+[INF:CP0335] dut.sv:24: Compile generate block "work@top.genblk8".
+
+[INF:CP0335] dut.sv:27: Compile generate block "work@top.genblk9".
+
+[NTE:EL0503] dut.sv:1: Top level module "work@top".
+
+[WRN:EL0500] dut.sv:25: Cannot find a module definition for "work@top.genblk8::GOOD_0".
+
+[WRN:EL0500] dut.sv:28: Cannot find a module definition for "work@top.genblk9::GOOD_STR_WITH_DOT".
+
+[NTE:EL0508] Nb Top level modules: 1.
+
+[NTE:EL0509] Max instance depth: 3.
+
+[NTE:EL0510] Nb instances: 3.
+
+[NTE:EL0511] Nb leaf instances: 2.
+
+[WRN:EL0512] Nb undefined modules: 2.
+
+[WRN:EL0513] Nb undefined instances: 2.
+
+UHDM HTML COVERAGE REPORT: ./slpp_all//surelog.uhdm.chk.html
+====== UHDM =======
+design: (work@top)
+|vpiName:work@top
+|uhdmallModules:
+\_module: work@top (work@top) dut.sv:1: , endline:33:9: , parent:work@top
+  |vpiDefName:work@top
+  |vpiFullName:work@top
+  |vpiParamAssign:
+  \_param_assign: , line:2, col:14, parent:work@top
+    |vpiRhs:
+    \_constant: , line:2, col:18
+      |vpiConstType:3
+      |vpiDecompile:1'b0
+      |vpiSize:1
+      |BIN:0
+    |vpiLhs:
+    \_parameter: (work@top.p), line:2, col:14, parent:work@top
+      |vpiName:p
+      |vpiFullName:work@top.p
+  |vpiParameter:
+  \_parameter: (work@top.p), line:2, col:14, parent:work@top
+|uhdmtopModules:
+\_module: work@top (work@top) dut.sv:1: , endline:33:9: 
+  |vpiDefName:work@top
+  |vpiName:work@top
+  |vpiGenScopeArray:
+  \_gen_scope_array: (work@top.genblk8), line:24, parent:work@top
+    |vpiName:genblk8
+    |vpiFullName:work@top.genblk8
+    |vpiGenScope:
+    \_gen_scope: (work@top.genblk8), parent:work@top.genblk8
+      |vpiFullName:work@top.genblk8
+      |vpiModule:
+      \_module: work@top.genblk8::GOOD_0 (work@top.genblk8.good) dut.sv:25: , parent:work@top.genblk8
+        |vpiDefName:work@top.genblk8::GOOD_0
+        |vpiName:good
+        |vpiFullName:work@top.genblk8.good
+  |vpiGenScopeArray:
+  \_gen_scope_array: (work@top.genblk9), line:27, parent:work@top
+    |vpiName:genblk9
+    |vpiFullName:work@top.genblk9
+    |vpiGenScope:
+    \_gen_scope: (work@top.genblk9), parent:work@top.genblk9
+      |vpiFullName:work@top.genblk9
+      |vpiModule:
+      \_module: work@top.genblk9::GOOD_STR_WITH_DOT (work@top.genblk9.good) dut.sv:28: , parent:work@top.genblk9
+        |vpiDefName:work@top.genblk9::GOOD_STR_WITH_DOT
+        |vpiName:good
+        |vpiFullName:work@top.genblk9.good
+  |vpiParamAssign:
+  \_param_assign: , line:2, col:14, parent:work@top
+    |vpiRhs:
+    \_constant: , line:2, col:18
+      |vpiConstType:6
+      |vpiDecompile:STR.WITH.DOT
+      |vpiSize:14
+      |STRING:STR.WITH.DOT
+    |vpiLhs:
+    \_parameter: (work@top.p), line:2, col:14, parent:work@top
+      |vpiName:p
+      |vpiFullName:work@top.p
+      |STRING:STR.WITH.DOT
+  |vpiParameter:
+  \_parameter: (work@top.p), line:2, col:14, parent:work@top
+===================
+[  FATAL] : 0
+[ SYNTAX] : 0
+[  ERROR] : 0
+[WARNING] : 5
+[   NOTE] : 5
+Processing: -parse -d uhdm -elabuhdm dut.sv -nobuiltin -Pp="-STR"
+[INF:CM0023] Creating log file ./slpp_all/surelog.log.
+
+[WRN:PA0205] dut.sv:1: No timescale set for "top".
+
+[INF:CP0300] Compilation...
+
+[INF:CP0303] dut.sv:1: Compile module "work@top".
+
+[INF:EL0526] Design Elaboration...
+
+[INF:CP0335] dut.sv:24: Compile generate block "work@top.genblk8".
+
+[INF:CP0335] dut.sv:30: Compile generate block "work@top.genblk10".
+
+[NTE:EL0503] dut.sv:1: Top level module "work@top".
+
+[WRN:EL0500] dut.sv:25: Cannot find a module definition for "work@top.genblk8::GOOD_0".
+
+[WRN:EL0500] dut.sv:31: Cannot find a module definition for "work@top.genblk10::GOOD_MINUS_STR".
+
+[NTE:EL0508] Nb Top level modules: 1.
+
+[NTE:EL0509] Max instance depth: 3.
+
+[NTE:EL0510] Nb instances: 3.
+
+[NTE:EL0511] Nb leaf instances: 2.
+
+[WRN:EL0512] Nb undefined modules: 2.
+
+[WRN:EL0513] Nb undefined instances: 2.
+
+UHDM HTML COVERAGE REPORT: ./slpp_all//surelog.uhdm.chk.html
+====== UHDM =======
+design: (work@top)
+|vpiName:work@top
+|uhdmallModules:
+\_module: work@top (work@top) dut.sv:1: , endline:33:9: , parent:work@top
+  |vpiDefName:work@top
+  |vpiFullName:work@top
+  |vpiParamAssign:
+  \_param_assign: , line:2, col:14, parent:work@top
+    |vpiRhs:
+    \_constant: , line:2, col:18
+      |vpiConstType:3
+      |vpiDecompile:1'b0
+      |vpiSize:1
+      |BIN:0
+    |vpiLhs:
+    \_parameter: (work@top.p), line:2, col:14, parent:work@top
+      |vpiName:p
+      |vpiFullName:work@top.p
+  |vpiParameter:
+  \_parameter: (work@top.p), line:2, col:14, parent:work@top
+|uhdmtopModules:
+\_module: work@top (work@top) dut.sv:1: , endline:33:9: 
+  |vpiDefName:work@top
+  |vpiName:work@top
+  |vpiGenScopeArray:
+  \_gen_scope_array: (work@top.genblk8), line:24, parent:work@top
+    |vpiName:genblk8
+    |vpiFullName:work@top.genblk8
+    |vpiGenScope:
+    \_gen_scope: (work@top.genblk8), parent:work@top.genblk8
+      |vpiFullName:work@top.genblk8
+      |vpiModule:
+      \_module: work@top.genblk8::GOOD_0 (work@top.genblk8.good) dut.sv:25: , parent:work@top.genblk8
+        |vpiDefName:work@top.genblk8::GOOD_0
+        |vpiName:good
+        |vpiFullName:work@top.genblk8.good
+  |vpiGenScopeArray:
+  \_gen_scope_array: (work@top.genblk10), line:30, parent:work@top
+    |vpiName:genblk10
+    |vpiFullName:work@top.genblk10
+    |vpiGenScope:
+    \_gen_scope: (work@top.genblk10), parent:work@top.genblk10
+      |vpiFullName:work@top.genblk10
+      |vpiModule:
+      \_module: work@top.genblk10::GOOD_MINUS_STR (work@top.genblk10.good) dut.sv:31: , parent:work@top.genblk10
+        |vpiDefName:work@top.genblk10::GOOD_MINUS_STR
+        |vpiName:good
+        |vpiFullName:work@top.genblk10.good
+  |vpiParamAssign:
+  \_param_assign: , line:2, col:14, parent:work@top
+    |vpiRhs:
+    \_constant: , line:2, col:18
+      |vpiConstType:6
+      |vpiDecompile:-STR
+      |vpiSize:6
+      |STRING:-STR
+    |vpiLhs:
+    \_parameter: (work@top.p), line:2, col:14, parent:work@top
+      |vpiName:p
+      |vpiFullName:work@top.p
+      |STRING:-STR
+  |vpiParameter:
+  \_parameter: (work@top.p), line:2, col:14, parent:work@top
+===================
+[  FATAL] : 0
+[ SYNTAX] : 0
+[  ERROR] : 0
 [WARNING] : 5
 [   NOTE] : 5
 Processing: 
@@ -720,10 +960,10 @@ Processing:
 [  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
-Processed 9 tests.
+Processed 11 tests.
 [  FATAL] : 0
 [ SYNTAX] : 0
 [  ERROR] : 0
-[WARNING] : 31
-[   NOTE] : 40
+[WARNING] : 43
+[   NOTE] : 50
 

--- a/tests/ParamLine/batch.txt
+++ b/tests/ParamLine/batch.txt
@@ -6,4 +6,6 @@
 -parse -d uhdm -elabuhdm dut.sv -nobuiltin -Pp=12
 -parse -d uhdm -elabuhdm dut.sv -nobuiltin -Pp=12.12
 -parse -d uhdm -elabuhdm dut.sv -nobuiltin -Pp=0
+-parse -d uhdm -elabuhdm dut.sv -nobuiltin -Pp="STR.WITH.DOT"
+-parse -d uhdm -elabuhdm dut.sv -nobuiltin -Pp="-STR"
 

--- a/tests/ParamLine/dut.sv
+++ b/tests/ParamLine/dut.sv
@@ -24,4 +24,10 @@ module top();
    if (p == 0) begin
       GOOD_0 good();
    end
+   if (p == "STR.WITH.DOT") begin
+      GOOD_STR_WITH_DOT good();
+   end
+   if (p == "-STR") begin
+      GOOD_MINUS_STR good();
+   end
 endmodule


### PR DESCRIPTION
Fixes setting string parameters (and starting with ``-``) from command-line.
Similar fix to: https://github.com/alainmarcel/Surelog/pull/1155

Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>