### PR TITLE
Remove redundant alternative from <cross_item>

### DIFF
--- a/grammar/SV3_1aParser.g4
+++ b/grammar/SV3_1aParser.g4
@@ -1503,8 +1503,7 @@ cover_cross : ( identifier COLUMN )? CROSS list_of_cross_items ( IFF OPEN_PARENS
 list_of_cross_items : cross_item COMMA cross_item ( COMMA cross_item )* ; 
 
 cross_item  
-    : identifier 
-    | identifier    
+    : identifier     
     ; 
 
 cross_body  


### PR DESCRIPTION
I am not sure what is the purpose of this duplicate alternative. But this seems to be safe to remove the duplicate alternative.