### PR TITLE
Test if component is not null

### DIFF
--- a/src/DesignCompile/CompileExpression.cpp
+++ b/src/DesignCompile/CompileExpression.cpp
@@ -259,12 +259,14 @@ UHDM::task_func* CompileHelper::getTaskFunc(const std::string& name, DesignCompo
     }
     comp = dynamic_cast<DesignComponent*> ((DesignComponent*) comp->getParentScope());
   }
-  for (const FileContent* cfC : component->getFileContents()) {
-    FileContent* fC = (FileContent*) cfC;
-    if (fC->getTask_funcs()) {
-      for (UHDM::task_func* tf : *fC->getTask_funcs()) {
-        if (tf->VpiName() == name) {
-          return tf;
+  if (component) {
+    for (const FileContent* cfC : component->getFileContents()) {
+      FileContent* fC = (FileContent*) cfC;
+      if (fC->getTask_funcs()) {
+        for (UHDM::task_func* tf : *fC->getTask_funcs()) {
+          if (tf->VpiName() == name) {
+            return tf;
+          }
         }
       }
     }


### PR DESCRIPTION
Segmentation Fault was occurring during parsing the following file:
```systemverilog
module top();
    a u_a (
	.b(c == d_pkg::e));
endmodule
```
It was when `component` was `nullptr`. I added `if` for that case. 