### PR TITLE
Leaf objects Consing in elaborator

### DIFF
--- a/src/CommandLine/CommandLineParser.cpp
+++ b/src/CommandLine/CommandLineParser.cpp
@@ -313,7 +313,8 @@ CommandLineParser::CommandLineParser(ErrorContainer* errors,
       m_elabUhdm(false),
       m_coverUhdm(false),
       m_showVpiIDs(false), 
-      m_replay(false) {
+      m_replay(false),
+      m_uhdmStats(false) {
   m_errors->regiterCmdLine(this);
   m_logFileId = m_symbolTable->registerSymbol(defaultLogFileName);
   m_compileUnitDirectory = m_symbolTable->registerSymbol("slpp_unit/");
@@ -596,6 +597,8 @@ bool CommandLineParser::parseCommandLine(int argc, const char** argv) {
         m_debugIncludeFileInfo = true;
       } else if (all_arguments[i] == "uhdm") {
         m_dumpUhdm = true;
+      } else if (all_arguments[i] == "uhdmstats") {
+        m_uhdmStats = true;
       } else if (all_arguments[i] == "coveruhdm") {
         m_coverUhdm = true;
       } else if (all_arguments[i] == "vpi_ids") {

--- a/src/CommandLine/CommandLineParser.h
+++ b/src/CommandLine/CommandLineParser.h
@@ -100,6 +100,7 @@ class CommandLineParser final {
   int  getDebugLevel() { return m_debugLevel; }
   bool getDebugAstModel() { return m_debugAstModel; }
   bool getDebugUhdm() { return m_dumpUhdm; }
+  bool getUhdmStats() { return m_uhdmStats; }
   bool getElabUhdm() { return m_elabUhdm; }
   bool getCoverUhdm() { return m_coverUhdm; }
   bool getParametersSubstitution() { return m_parametersubstitution; }
@@ -253,6 +254,7 @@ class CommandLineParser final {
   bool m_coverUhdm;
   bool m_showVpiIDs;
   bool m_replay;
+  bool m_uhdmStats;
 };
 
 }  // namespace SURELOG

--- a/src/DesignCompile/UhdmWriter.cpp
+++ b/src/DesignCompile/UhdmWriter.cpp
@@ -2014,7 +2014,8 @@ vpiHandle UhdmWriter::write(const std::string& uhdmFile) const {
     d->TopModules(uhdm_top_modules);
   }
 
-  //printUhdmStats(s); 
+  if (m_compileDesign->getCompiler()->getCommandLineParser()->getUhdmStats())
+    printUhdmStats(s); 
 
   // ----------------------------------
   // Fully elaborated model
@@ -2028,7 +2029,8 @@ vpiHandle UhdmWriter::write(const std::string& uhdmFile) const {
     listen_designs(designs,listener);
   }
 
-  //printUhdmStats(s); 
+  if (m_compileDesign->getCompiler()->getCommandLineParser()->getUhdmStats())
+    printUhdmStats(s); 
 
   {
     Error err(ErrorDefinition::UHDM_WRITE_DB, loc);

--- a/tests/AlwaysNoElab/AlwaysNoElab.log
+++ b/tests/AlwaysNoElab/AlwaysNoElab.log
@@ -227,9 +227,9 @@ design: (work@dut)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -446,9 +446,9 @@ design: (work@dut)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -464,9 +464,9 @@ design: (work@dut)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -482,9 +482,9 @@ design: (work@dut)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -502,9 +502,9 @@ design: (work@dut)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/Assignments/Assignments.log
+++ b/tests/Assignments/Assignments.log
@@ -399,9 +399,9 @@ design: (work@dut)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -618,9 +618,9 @@ design: (work@dut)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -636,9 +636,9 @@ design: (work@dut)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -654,9 +654,9 @@ design: (work@dut)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -674,9 +674,9 @@ design: (work@dut)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -1138,16 +1138,8 @@ design: (work@dut)
                 \_ref_obj: m_bits (work@dut.m_bits)
                 |vpiLeftRange:
                 \_constant: , line:15:11, endln:15:13
-                  |vpiConstType:9
-                  |vpiDecompile:31
-                  |vpiSize:64
-                  |UINT:31
                 |vpiRightRange:
                 \_constant: , line:15:14, endln:15:15
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
               |vpiRhs:
               \_ref_obj: (work@dut.m_pack_iter), line:15:20, endln:15:31, parent:work@dut
                 |vpiName:m_pack_iter
@@ -1164,10 +1156,6 @@ design: (work@dut)
                 \_logic_net: (work@dut.o), line:1:16, endln:1:17, parent:work@dut
               |vpiRhs:
               \_constant: , line:16:9, endln:16:10
-                |vpiConstType:9
-                |vpiDecompile:1
-                |vpiSize:64
-                |UINT:1
             |vpiStmt:
             \_assignment: , line:17:4, endln:17:16, parent:work@dut
               |vpiOpType:82
@@ -1405,7 +1393,7 @@ design: (work@dut)
       |vpiName:stream
       |vpiDirection:6
       |vpiTypedef:
-      \_bit_typespec: , line:5:48, endln:5:51, parent:stream
+      \_bit_typespec: , line:5:48, endln:5:51
     |vpiStmt:
     \_begin: (work@dut.uvm_packer::get_packed_bits), parent:work@dut.uvm_packer::get_packed_bits
       |vpiFullName:work@dut.uvm_packer::get_packed_bits
@@ -1434,10 +1422,6 @@ design: (work@dut)
                 |vpiName:size
             |vpiOperand:
             \_constant: , line:6:41, endln:6:42
-              |vpiConstType:9
-              |vpiDecompile:1
-              |vpiSize:64
-              |UINT:1
           |vpiArgument:
           \_ref_obj: (work@dut.uvm_packer::get_packed_bits.cover_info), line:6:45, endln:6:55, parent:new
             |vpiName:cover_info
@@ -1470,16 +1454,8 @@ design: (work@dut)
           \_ref_obj: (work@dut.uvm_packer::get_packed_bits.m_bits)
           |vpiLeftRange:
           \_constant: , line:8:11, endln:8:13
-            |vpiConstType:9
-            |vpiDecompile:31
-            |vpiSize:64
-            |UINT:31
           |vpiRightRange:
           \_constant: , line:8:14, endln:8:15
-            |vpiConstType:9
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
         |vpiRhs:
         \_ref_obj: (work@dut.uvm_packer::get_packed_bits.m_pack_iter), line:8:20, endln:8:31
           |vpiName:m_pack_iter
@@ -1495,16 +1471,8 @@ design: (work@dut)
           \_ref_obj: (work@dut.uvm_packer::get_packed_bits.m_bits)
           |vpiLeftRange:
           \_constant: , line:9:11, endln:9:13
-            |vpiConstType:9
-            |vpiDecompile:63
-            |vpiSize:64
-            |UINT:63
           |vpiRightRange:
           \_constant: , line:9:14, endln:9:16
-            |vpiConstType:9
-            |vpiDecompile:32
-            |vpiSize:64
-            |UINT:32
         |vpiRhs:
         \_ref_obj: (work@dut.uvm_packer::get_packed_bits.m_unpack_iter), line:9:20, endln:9:33
           |vpiName:m_unpack_iter
@@ -1527,10 +1495,6 @@ design: (work@dut)
         \_assign_stmt: , parent:work@dut.uvm_packer::get_packed_bits
           |vpiRhs:
           \_constant: , line:10:15, endln:10:16
-            |vpiConstType:9
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
           |vpiLhs:
           \_int_var: (work@dut.uvm_packer::get_packed_bits.i), line:10:9, endln:10:12
             |vpiName:i

--- a/tests/Attributes/Attributes.log
+++ b/tests/Attributes/Attributes.log
@@ -715,9 +715,9 @@ design: (work@foo)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -934,9 +934,9 @@ design: (work@foo)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -952,9 +952,9 @@ design: (work@foo)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -970,9 +970,9 @@ design: (work@foo)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -990,9 +990,9 @@ design: (work@foo)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/BiasValue/BiasValue.log
+++ b/tests/BiasValue/BiasValue.log
@@ -224,9 +224,9 @@ design: (work@bp_be_rec_to_fp)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -443,9 +443,9 @@ design: (work@bp_be_rec_to_fp)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -461,9 +461,9 @@ design: (work@bp_be_rec_to_fp)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -479,9 +479,9 @@ design: (work@bp_be_rec_to_fp)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -499,9 +499,9 @@ design: (work@bp_be_rec_to_fp)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/BindVarsAndEnum/BindVarsAndEnum.log
+++ b/tests/BindVarsAndEnum/BindVarsAndEnum.log
@@ -246,9 +246,9 @@ design: (work@conditional_Fsm)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -465,9 +465,9 @@ design: (work@conditional_Fsm)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -483,9 +483,9 @@ design: (work@conditional_Fsm)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -501,9 +501,9 @@ design: (work@conditional_Fsm)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -521,9 +521,9 @@ design: (work@conditional_Fsm)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/Bindings/Bindings.log
+++ b/tests/Bindings/Bindings.log
@@ -1262,9 +1262,9 @@ design: (work@dut1)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -1481,9 +1481,9 @@ design: (work@dut1)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -1499,9 +1499,9 @@ design: (work@dut1)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -1517,9 +1517,9 @@ design: (work@dut1)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -1537,9 +1537,9 @@ design: (work@dut1)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -2338,7 +2338,7 @@ design: (work@dut1)
                 |vpiName:lfsr_q
                 |vpiFullName:work@dut3.lfsr_q
                 |vpiIndex:
-                \_constant: , line:60:64, endln:60:65, parent:work@dut3.lfsr_q
+                \_constant: , line:60:64, endln:60:65, parent:lfsr_q
                   |vpiConstType:9
                   |vpiDecompile:0
                   |vpiSize:64
@@ -2530,7 +2530,6 @@ design: (work@dut1)
                     |UINT:0
                 |vpiTypespec:
                 \_integer_typespec: , line:75:21, endln:75:28
-                  |INT:-1
             |vpiElseStmt:
             \_assignment: , line:77:10, endln:77:26
               |vpiOpType:82

--- a/tests/BitSelect/BitSelect.log
+++ b/tests/BitSelect/BitSelect.log
@@ -355,7 +355,6 @@ design: (work@dut)
           |UINT:1
           |vpiTypespec:
           \_bit_typespec: (AsyncOn), line:3:12, endln:3:15, parent:work@dut.gen_alert_tx[0].i_alert_sender.AsyncOn
-            |vpiName:AsyncOn
       |vpiParameter:
       \_parameter: (work@dut.gen_alert_tx[0].i), line:10, parent:work@dut.gen_alert_tx[0]
         |vpiName:i
@@ -396,7 +395,6 @@ design: (work@dut)
           |UINT:1
           |vpiTypespec:
           \_bit_typespec: (AsyncOn), line:3:12, endln:3:15, parent:work@dut.gen_alert_tx[1].i_alert_sender.AsyncOn
-            |vpiName:AsyncOn
       |vpiParameter:
       \_parameter: (work@dut.gen_alert_tx[1].i), line:10, parent:work@dut.gen_alert_tx[1]
         |vpiName:i
@@ -437,7 +435,6 @@ design: (work@dut)
           |UINT:1
           |vpiTypespec:
           \_bit_typespec: (AsyncOn), line:3:12, endln:3:15, parent:work@dut.gen_alert_tx[2].i_alert_sender.AsyncOn
-            |vpiName:AsyncOn
       |vpiParameter:
       \_parameter: (work@dut.gen_alert_tx[2].i), line:10, parent:work@dut.gen_alert_tx[2]
         |vpiName:i

--- a/tests/BitsOp/BitsOp.log
+++ b/tests/BitsOp/BitsOp.log
@@ -1831,12 +1831,12 @@ design: (work@dut)
         |vpiPacked:1
         |vpiName:dmi_t
         |vpiTypespecMember:
-        \_typespec_member: (address), line:107:17, endln:107:24, parent:dmi_t
+        \_typespec_member: (address), line:107:17, endln:107:24
           |vpiName:address
           |vpiTypespec:
-          \_logic_typespec: , line:107:4, endln:107:9, parent:address
+          \_logic_typespec: , line:107:4, endln:107:9
             |vpiRange:
-            \_range: , line:107:11, endln:107:14
+            \_range: , line:107:11, endln:107:14, parent:dmi_t
               |vpiLeftRange:
               \_constant: , line:107:11, endln:107:12
                 |vpiConstType:9
@@ -1850,12 +1850,12 @@ design: (work@dut)
                 |vpiSize:64
                 |UINT:0
         |vpiTypespecMember:
-        \_typespec_member: (data), line:108:17, endln:108:21, parent:dmi_t
+        \_typespec_member: (data), line:108:17, endln:108:21
           |vpiName:data
           |vpiTypespec:
-          \_logic_typespec: , line:108:4, endln:108:9, parent:data
+          \_logic_typespec: , line:108:4, endln:108:9
             |vpiRange:
-            \_range: , line:108:11, endln:108:15
+            \_range: , line:108:11, endln:108:15, parent:dmi_t
               |vpiLeftRange:
               \_constant: , line:108:11, endln:108:13
                 |vpiConstType:9
@@ -1869,12 +1869,12 @@ design: (work@dut)
                 |vpiSize:64
                 |UINT:0
         |vpiTypespecMember:
-        \_typespec_member: (op), line:109:17, endln:109:19, parent:dmi_t
+        \_typespec_member: (op), line:109:17, endln:109:19
           |vpiName:op
           |vpiTypespec:
-          \_logic_typespec: , line:109:4, endln:109:9, parent:op
+          \_logic_typespec: , line:109:4, endln:109:9
             |vpiRange:
-            \_range: , line:109:11, endln:109:14
+            \_range: , line:109:11, endln:109:14, parent:dmi_t
               |vpiLeftRange:
               \_constant: , line:109:11, endln:109:12
                 |vpiConstType:9
@@ -1897,65 +1897,6 @@ design: (work@dut)
         |vpiFullName:work@dmi_jtag.dmi
         |vpiTypespec:
         \_struct_typespec: (dmi_t), line:106:10, endln:106:16
-          |vpiPacked:1
-          |vpiName:dmi_t
-          |vpiTypespecMember:
-          \_typespec_member: (address), line:107:17, endln:107:24
-            |vpiName:address
-            |vpiTypespec:
-            \_logic_typespec: , line:107:4, endln:107:9
-              |vpiRange:
-              \_range: , line:107:11, endln:107:14, parent:dmi_t
-                |vpiLeftRange:
-                \_constant: , line:107:11, endln:107:12
-                  |vpiConstType:9
-                  |vpiDecompile:6
-                  |vpiSize:64
-                  |UINT:6
-                |vpiRightRange:
-                \_constant: , line:107:13, endln:107:14
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (data), line:108:17, endln:108:21
-            |vpiName:data
-            |vpiTypespec:
-            \_logic_typespec: , line:108:4, endln:108:9
-              |vpiRange:
-              \_range: , line:108:11, endln:108:15, parent:dmi_t
-                |vpiLeftRange:
-                \_constant: , line:108:11, endln:108:13
-                  |vpiConstType:9
-                  |vpiDecompile:31
-                  |vpiSize:64
-                  |UINT:31
-                |vpiRightRange:
-                \_constant: , line:108:14, endln:108:15
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
-          |vpiTypespecMember:
-          \_typespec_member: (op), line:109:17, endln:109:19
-            |vpiName:op
-            |vpiTypespec:
-            \_logic_typespec: , line:109:4, endln:109:9
-              |vpiRange:
-              \_range: , line:109:11, endln:109:14, parent:dmi_t
-                |vpiLeftRange:
-                \_constant: , line:109:11, endln:109:12
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-                |vpiRightRange:
-                \_constant: , line:109:13, endln:109:14
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
   |vpiNet:
   \_logic_net: (work@dmi_jtag.dr_d), line:112:27, endln:112:31, parent:work@dmi_jtag
   |vpiNet:

--- a/tests/BlackParrotComplex/BlackParrotComplex.log
+++ b/tests/BlackParrotComplex/BlackParrotComplex.log
@@ -2964,9 +2964,9 @@ design: (work@top)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -3183,9 +3183,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -3201,9 +3201,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -3219,9 +3219,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -3239,9 +3239,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -6248,7 +6248,7 @@ design: (work@top)
       \_sys_func_call: ($display), line:57:2, endln:57:46, parent:work@top
         |vpiName:$display
         |vpiArgument:
-        \_constant: , line:57:12, endln:57:20, parent:$display
+        \_constant: , line:57:12, endln:57:20
           |vpiConstType:6
           |vpiDecompile:d = %d
           |vpiSize:6

--- a/tests/BlackParrotParam/BlackParrotParam.log
+++ b/tests/BlackParrotParam/BlackParrotParam.log
@@ -18571,9 +18571,9 @@ design: (work@bp_be_ptw)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -18790,9 +18790,9 @@ design: (work@bp_be_ptw)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -18808,9 +18808,9 @@ design: (work@bp_be_ptw)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -18826,9 +18826,9 @@ design: (work@bp_be_ptw)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -18846,9 +18846,9 @@ design: (work@bp_be_ptw)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/BlackParrotSkipParam/BlackParrotSkipParam.log
+++ b/tests/BlackParrotSkipParam/BlackParrotSkipParam.log
@@ -182,9 +182,9 @@ design: (work@top)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -401,9 +401,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -419,9 +419,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -437,9 +437,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -457,9 +457,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/BlackParrotStructParam/BlackParrotStructParam.log
+++ b/tests/BlackParrotStructParam/BlackParrotStructParam.log
@@ -655,9 +655,9 @@ design: (work@top)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -874,9 +874,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -892,9 +892,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -910,9 +910,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -930,9 +930,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/CarryTrans/CarryTrans.log
+++ b/tests/CarryTrans/CarryTrans.log
@@ -637,9 +637,9 @@ design: (work@carry_rtl)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -856,9 +856,9 @@ design: (work@carry_rtl)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -874,9 +874,9 @@ design: (work@carry_rtl)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -892,9 +892,9 @@ design: (work@carry_rtl)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -912,9 +912,9 @@ design: (work@carry_rtl)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/CaseFullElab/CaseFullElab.log
+++ b/tests/CaseFullElab/CaseFullElab.log
@@ -459,9 +459,9 @@ design: (work@FSM)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -678,9 +678,9 @@ design: (work@FSM)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -696,9 +696,9 @@ design: (work@FSM)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -714,9 +714,9 @@ design: (work@FSM)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -734,9 +734,9 @@ design: (work@FSM)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/CaseInside/CaseInside.log
+++ b/tests/CaseInside/CaseInside.log
@@ -290,9 +290,9 @@ design: (work@dm_csrs)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -509,9 +509,9 @@ design: (work@dm_csrs)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -527,9 +527,9 @@ design: (work@dm_csrs)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -545,9 +545,9 @@ design: (work@dm_csrs)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -565,9 +565,9 @@ design: (work@dm_csrs)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/CastEnum/CastEnum.log
+++ b/tests/CastEnum/CastEnum.log
@@ -224,9 +224,9 @@ design: (work@dm_csrs)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -443,9 +443,9 @@ design: (work@dm_csrs)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -461,9 +461,9 @@ design: (work@dm_csrs)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -479,9 +479,9 @@ design: (work@dm_csrs)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -499,9 +499,9 @@ design: (work@dm_csrs)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -598,7 +598,7 @@ design: (work@dm_csrs)
       \_enum_typespec: (dm::dtm_op_e), line:7:2, endln:7:10
         |vpiName:dm::dtm_op_e
         |vpiBaseTypespec:
-        \_logic_typespec: , line:3:13, endln:3:18, parent:dm::dtm_op_e
+        \_logic_typespec: , line:3:13, endln:3:18
           |vpiRange:
           \_range: , line:3:20, endln:3:23
             |vpiLeftRange:
@@ -620,57 +620,20 @@ design: (work@dm_csrs)
             |vpiFullName:dm::
             |vpiTypedef:
             \_enum_typespec: (dm::dtm_op_e), line:7:2, endln:7:10
-              |vpiName:dm::dtm_op_e
-              |vpiBaseTypespec:
-              \_logic_typespec: , line:3:13, endln:3:18
-                |vpiRange:
-                \_range: , line:3:20, endln:3:23
-                  |vpiLeftRange:
-                  \_constant: , line:3:20, endln:3:21
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                  |vpiRightRange:
-                  \_constant: , line:3:22, endln:3:23
-                    |vpiConstType:9
-                    |vpiDecompile:0
-                    |vpiSize:64
-                    |UINT:0
-                |vpiInstance:
-                \_package: dm (dm::) dut.sv:1: , endln:9:10, parent:work@dm_csrs
-              |vpiEnumConst:
-              \_enum_const: (DTM_NOP), line:4:2, endln:4:9
-                |vpiName:DTM_NOP
-                |vpiDecompile:2'h0
-                |UINT:0
-                |vpiSize:2
-              |vpiEnumConst:
-              \_enum_const: (DTM_READ), line:5:2, endln:5:10
-                |vpiName:DTM_READ
-                |vpiDecompile:2'h1
-                |UINT:1
-                |vpiSize:2
-              |vpiEnumConst:
-              \_enum_const: (DTM_WRITE), line:6:2, endln:6:11
-                |vpiName:DTM_WRITE
-                |vpiDecompile:2'h2
-                |UINT:2
-                |vpiSize:2
         |vpiEnumConst:
-        \_enum_const: (DTM_NOP), line:4:2, endln:4:9, parent:dm::dtm_op_e
+        \_enum_const: (DTM_NOP), line:4:2, endln:4:9
           |vpiName:DTM_NOP
           |vpiDecompile:2'h0
           |UINT:0
           |vpiSize:2
         |vpiEnumConst:
-        \_enum_const: (DTM_READ), line:5:2, endln:5:10, parent:dm::dtm_op_e
+        \_enum_const: (DTM_READ), line:5:2, endln:5:10
           |vpiName:DTM_READ
           |vpiDecompile:2'h1
           |UINT:1
           |vpiSize:2
         |vpiEnumConst:
-        \_enum_const: (DTM_WRITE), line:6:2, endln:6:11, parent:dm::dtm_op_e
+        \_enum_const: (DTM_WRITE), line:6:2, endln:6:11
           |vpiName:DTM_WRITE
           |vpiDecompile:2'h2
           |UINT:2

--- a/tests/CastPartSelect/CastPartSelect.log
+++ b/tests/CastPartSelect/CastPartSelect.log
@@ -174,9 +174,9 @@ design: (work@top)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -393,9 +393,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -411,9 +411,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -429,9 +429,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -449,9 +449,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/CastShift/CastShift.log
+++ b/tests/CastShift/CastShift.log
@@ -410,9 +410,9 @@ design: (work@dut)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -629,9 +629,9 @@ design: (work@dut)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -647,9 +647,9 @@ design: (work@dut)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -665,9 +665,9 @@ design: (work@dut)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -685,9 +685,9 @@ design: (work@dut)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/CastTypespec/CastTypespec.log
+++ b/tests/CastTypespec/CastTypespec.log
@@ -681,9 +681,9 @@ design: (work@tlul_adapter_host)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -900,9 +900,9 @@ design: (work@tlul_adapter_host)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -918,9 +918,9 @@ design: (work@tlul_adapter_host)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -936,9 +936,9 @@ design: (work@tlul_adapter_host)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -956,9 +956,9 @@ design: (work@tlul_adapter_host)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -1222,9 +1222,8 @@ design: (work@tlul_adapter_host)
         \_operation: , line:18:17, endln:18:43
           |vpiOpType:67
           |vpiOperand:
-          \_ref_obj: (work@tlul_adapter_host.WordSize), line:18:34, endln:18:42
+          \_ref_obj: (WordSize), line:18:34, endln:18:42
             |vpiName:WordSize
-            |vpiFullName:work@tlul_adapter_host.WordSize
           |vpiTypespec:
           \_int_typespec: 
             |UINT:2
@@ -1251,18 +1250,18 @@ design: (work@tlul_adapter_host)
             |vpiName:v1
             |vpiFullName:work@top.v1
             |vpiTypespec:
-            \_struct_typespec: (ab_t), line:27:12, endln:27:18, parent:work@top.v1
+            \_struct_typespec: (ab_t), line:27:12, endln:27:18
               |vpiName:ab_t
               |vpiTypespecMember:
-              \_typespec_member: (a), line:27:24, endln:27:25, parent:ab_t
+              \_typespec_member: (a), line:27:24, endln:27:25
                 |vpiName:a
                 |vpiTypespec:
-                \_int_typespec: , line:27:20, endln:27:23, parent:a
+                \_int_typespec: , line:27:20, endln:27:23
               |vpiTypespecMember:
-              \_typespec_member: (b), line:27:26, endln:27:27, parent:ab_t
+              \_typespec_member: (b), line:27:26, endln:27:27
                 |vpiName:b
                 |vpiTypespec:
-                \_int_typespec: , line:27:20, endln:27:23, parent:b
+                \_int_typespec: , line:27:20, endln:27:23
           |vpiRange:
           \_range: , line:31:14, endln:31:17, parent:work@top
             |vpiLeftRange:
@@ -1441,17 +1440,6 @@ design: (work@tlul_adapter_host)
     |vpiVisibility:1
   |vpiTypedef:
   \_struct_typespec: (ab_t), line:27:12, endln:27:18
-    |vpiName:ab_t
-    |vpiTypespecMember:
-    \_typespec_member: (a), line:27:24, endln:27:25
-      |vpiName:a
-      |vpiTypespec:
-      \_int_typespec: , line:27:20, endln:27:23
-    |vpiTypespecMember:
-    \_typespec_member: (b), line:27:26, endln:27:27
-      |vpiName:b
-      |vpiTypespec:
-      \_int_typespec: , line:27:20, endln:27:23
   |vpiParamAssign:
   \_param_assign: , line:35:13, endln:35:27, parent:work@top
     |vpiRhs:

--- a/tests/CastUnsigned/CastUnsigned.log
+++ b/tests/CastUnsigned/CastUnsigned.log
@@ -188,9 +188,9 @@ design: (work@top)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -407,9 +407,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -425,9 +425,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -443,9 +443,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -463,9 +463,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/ClassFsm/ClassFsm.log
+++ b/tests/ClassFsm/ClassFsm.log
@@ -141,7 +141,7 @@ design: (work@fsm_class)
         |vpiName:state_to_bit
         |vpiDirection:1
         |vpiTypedef:
-        \_int_typespec: , line:8:38, endln:8:41, parent:state_to_bit
+        \_int_typespec: , line:8:38, endln:8:41
       |vpiStmt:
       \_begin: (work@fsm_class::baseFsm::next_state_transition), line:10:6, endln:13:9, parent:work@fsm_class::baseFsm::next_state_transition
         |vpiFullName:work@fsm_class::baseFsm::next_state_transition
@@ -194,7 +194,7 @@ design: (work@fsm_class)
         |vpiName:reset
         |vpiDirection:1
         |vpiTypedef:
-        \_logic_typespec: , line:15:41, endln:15:46, parent:reset
+        \_logic_typespec: , line:15:41, endln:15:46
       |vpiStmt:
       \_begin: (work@fsm_class::baseFsm::current_state_transition), line:17:6, endln:22:9, parent:work@fsm_class::baseFsm::current_state_transition
         |vpiFullName:work@fsm_class::baseFsm::current_state_transition
@@ -891,7 +891,7 @@ design: (work@fsm_class)
                             |vpiName:state_to_bit
                             |vpiDirection:1
                             |vpiTypedef:
-                            \_int_typespec: , line:8:38, endln:8:41, parent:state_to_bit
+                            \_int_typespec: , line:8:38, endln:8:41
                           |vpiStmt:
                           \_begin: (work@fsm_class::baseFsm::next_state_transition), line:10:6, endln:13:9, parent:work@fsm_class::baseFsm::next_state_transition
                             |vpiFullName:work@fsm_class::baseFsm::next_state_transition
@@ -944,7 +944,7 @@ design: (work@fsm_class)
                             |vpiName:reset
                             |vpiDirection:1
                             |vpiTypedef:
-                            \_logic_typespec: , line:15:41, endln:15:46, parent:reset
+                            \_logic_typespec: , line:15:41, endln:15:46
                           |vpiStmt:
                           \_begin: (work@fsm_class::baseFsm::current_state_transition), line:17:6, endln:22:9, parent:work@fsm_class::baseFsm::current_state_transition
                             |vpiFullName:work@fsm_class::baseFsm::current_state_transition
@@ -1054,7 +1054,7 @@ design: (work@fsm_class)
           |vpiTask:
           \_task: (work@fsm_class::baseFsm::current_state_transition), line:15:4, endln:23:11, parent:work@fsm_class::baseFsm
           |vpiArgument:
-          \_constant: , line:83:31, endln:83:32, parent:current_state_transition
+          \_constant: , line:83:31, endln:83:32
             |vpiConstType:9
             |vpiDecompile:0
             |vpiSize:64
@@ -1122,7 +1122,7 @@ design: (work@fsm_class)
         |vpiName:state_to_bit
         |vpiDirection:1
         |vpiTypedef:
-        \_int_typespec: , line:8:38, endln:8:41, parent:state_to_bit
+        \_int_typespec: , line:8:38, endln:8:41
       |vpiStmt:
       \_begin: (work@fsm_class::baseFsm::next_state_transition), line:10:6, endln:13:9, parent:work@fsm_class::baseFsm::next_state_transition
         |vpiFullName:work@fsm_class::baseFsm::next_state_transition
@@ -1142,10 +1142,6 @@ design: (work@fsm_class)
               |vpiVisibility:1
           |vpiRhs:
           \_constant: , line:11:21, endln:11:22
-            |vpiConstType:9
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
         |vpiStmt:
         \_assignment: , line:12:8, endln:12:40, parent:work@fsm_class::baseFsm::next_state_transition
           |vpiOpType:82
@@ -1160,10 +1156,6 @@ design: (work@fsm_class)
               |vpiFullName:work@fsm_class::baseFsm::next_state_transition::next_state::state_to_bit
           |vpiRhs:
           \_constant: , line:12:36, endln:12:40
-            |vpiConstType:3
-            |vpiDecompile:1'b1
-            |vpiSize:1
-            |BIN:1
     |vpiMethod:
     \_task: (work@fsm_class::baseFsm::current_state_transition), line:15:4, endln:23:11, parent:work@fsm_class::baseFsm
       |vpiMethod:1
@@ -1175,7 +1167,7 @@ design: (work@fsm_class)
         |vpiName:reset
         |vpiDirection:1
         |vpiTypedef:
-        \_logic_typespec: , line:15:41, endln:15:46, parent:reset
+        \_logic_typespec: , line:15:41, endln:15:46
       |vpiStmt:
       \_begin: (work@fsm_class::baseFsm::current_state_transition), line:17:6, endln:22:9, parent:work@fsm_class::baseFsm::current_state_transition
         |vpiFullName:work@fsm_class::baseFsm::current_state_transition
@@ -1203,10 +1195,6 @@ design: (work@fsm_class)
                 |vpiVisibility:1
             |vpiRhs:
             \_constant: , line:19:24, endln:19:25
-              |vpiConstType:9
-              |vpiDecompile:0
-              |vpiSize:64
-              |UINT:0
           |vpiElseStmt:
           \_assignment: , line:21:8, endln:21:35
             |vpiOpType:82
@@ -1425,10 +1413,6 @@ design: (work@fsm_class)
           |vpiCaseType:1
           |vpiCondition:
           \_constant: , line:71:14, endln:71:18
-            |vpiConstType:3
-            |vpiDecompile:1'b1
-            |vpiSize:1
-            |BIN:1
           |vpiCaseItem:
           \_case_item: , line:72:10, endln:72:53
             |vpiExpr:
@@ -1507,40 +1491,24 @@ design: (work@fsm_class)
     \_param_assign: , line:28:16, endln:28:32, parent:work@fsm_class::specificFSM
       |vpiRhs:
       \_constant: , line:28:31, endln:28:32
-        |vpiConstType:9
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
       |vpiLhs:
       \_parameter: (work@fsm_class::specificFSM::STATE_00_BIT), line:28:16, endln:28:32, parent:work@fsm_class::specificFSM
     |vpiParamAssign:
     \_param_assign: , line:29:16, endln:29:32, parent:work@fsm_class::specificFSM
       |vpiRhs:
       \_constant: , line:29:31, endln:29:32
-        |vpiConstType:9
-        |vpiDecompile:1
-        |vpiSize:64
-        |UINT:1
       |vpiLhs:
       \_parameter: (work@fsm_class::specificFSM::STATE_01_BIT), line:29:16, endln:29:32, parent:work@fsm_class::specificFSM
     |vpiParamAssign:
     \_param_assign: , line:30:16, endln:30:32, parent:work@fsm_class::specificFSM
       |vpiRhs:
       \_constant: , line:30:31, endln:30:32
-        |vpiConstType:9
-        |vpiDecompile:2
-        |vpiSize:64
-        |UINT:2
       |vpiLhs:
       \_parameter: (work@fsm_class::specificFSM::STATE_10_BIT), line:30:16, endln:30:32, parent:work@fsm_class::specificFSM
     |vpiParamAssign:
     \_param_assign: , line:31:16, endln:31:32, parent:work@fsm_class::specificFSM
       |vpiRhs:
       \_constant: , line:31:31, endln:31:32
-        |vpiConstType:9
-        |vpiDecompile:3
-        |vpiSize:64
-        |UINT:3
       |vpiLhs:
       \_parameter: (work@fsm_class::specificFSM::STATE_11_BIT), line:31:16, endln:31:32, parent:work@fsm_class::specificFSM
     |vpiParameter:

--- a/tests/ClassFuncProto/ClassFuncProto.log
+++ b/tests/ClassFuncProto/ClassFuncProto.log
@@ -301,9 +301,9 @@ design: (work@toto)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -520,9 +520,9 @@ design: (work@toto)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -538,9 +538,9 @@ design: (work@toto)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -556,9 +556,9 @@ design: (work@toto)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -576,9 +576,9 @@ design: (work@toto)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -618,7 +618,7 @@ design: (work@toto)
         |vpiName:provider
         |vpiDirection:1
         |vpiTypedef:
-        \_unsupported_typespec: (this_type), line:35:23, endln:35:32, parent:provider
+        \_unsupported_typespec: (this_type), line:35:23, endln:35:32
           |vpiName:this_type
     |vpiMethod:
     \_function: (work@toto::c1::get_verbosity_level), line:38:3, endln:39:14, parent:work@toto::c1
@@ -633,10 +633,10 @@ design: (work@toto)
         |vpiName:severity
         |vpiDirection:1
         |vpiTypedef:
-        \_enum_typespec: (uvm_severity), line:27:2, endln:27:14, parent:severity
+        \_enum_typespec: (uvm_severity), line:27:2, endln:27:14
           |vpiName:uvm_severity
           |vpiBaseTypespec:
-          \_bit_typespec: , line:21:13, endln:21:16, parent:uvm_severity
+          \_bit_typespec: , line:21:13, endln:21:16
             |vpiRange:
             \_range: , line:21:18, endln:21:21
               |vpiLeftRange:
@@ -652,24 +652,24 @@ design: (work@toto)
                 |vpiSize:64
                 |UINT:0
           |vpiEnumConst:
-          \_enum_const: (UVM_INFO), line:23:2, endln:23:10, parent:uvm_severity
+          \_enum_const: (UVM_INFO), line:23:2, endln:23:10
             |vpiName:UVM_INFO
             |vpiDecompile:0
             |INT:0
             |vpiSize:64
           |vpiEnumConst:
-          \_enum_const: (UVM_WARNING), line:24:2, endln:24:13, parent:uvm_severity
+          \_enum_const: (UVM_WARNING), line:24:2, endln:24:13
             |vpiName:UVM_WARNING
             |vpiDecompile:1
             |INT:1
             |vpiSize:64
           |vpiEnumConst:
-          \_enum_const: (UVM_ERROR), line:25:2, endln:25:11, parent:uvm_severity
+          \_enum_const: (UVM_ERROR), line:25:2, endln:25:11
             |vpiName:UVM_ERROR
             |STRING:toto
             |vpiSize:4
           |vpiEnumConst:
-          \_enum_const: (UVM_FATAL), line:26:2, endln:26:11, parent:uvm_severity
+          \_enum_const: (UVM_FATAL), line:26:2, endln:26:11
             |vpiName:UVM_FATAL
             |vpiDecompile:3
             |INT:3
@@ -679,7 +679,7 @@ design: (work@toto)
         |vpiName:reg_a
         |vpiDirection:1
         |vpiTypedef:
-        \_unsupported_typespec: (uvm_reg), line:38:70, endln:38:77, parent:reg_a
+        \_unsupported_typespec: (uvm_reg), line:38:70, endln:38:77
           |vpiName:uvm_reg
     |vpiMethod:
     \_function: (work@toto::c1::set_verbosity_level), line:41:1, endln:42:14, parent:work@toto::c1
@@ -694,53 +694,13 @@ design: (work@toto)
         |vpiName:severity
         |vpiDirection:1
         |vpiTypedef:
-        \_enum_typespec: (uvm_severity), line:27:2, endln:27:14, parent:severity
-          |vpiName:uvm_severity
-          |vpiBaseTypespec:
-          \_bit_typespec: , line:21:13, endln:21:16, parent:uvm_severity
-            |vpiRange:
-            \_range: , line:21:18, endln:21:21
-              |vpiLeftRange:
-              \_constant: , line:21:18, endln:21:19
-                |vpiConstType:9
-                |vpiDecompile:1
-                |vpiSize:64
-                |UINT:1
-              |vpiRightRange:
-              \_constant: , line:21:20, endln:21:21
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-          |vpiEnumConst:
-          \_enum_const: (UVM_INFO), line:23:2, endln:23:10, parent:uvm_severity
-            |vpiName:UVM_INFO
-            |vpiDecompile:0
-            |INT:0
-            |vpiSize:64
-          |vpiEnumConst:
-          \_enum_const: (UVM_WARNING), line:24:2, endln:24:13, parent:uvm_severity
-            |vpiName:UVM_WARNING
-            |vpiDecompile:1
-            |INT:1
-            |vpiSize:64
-          |vpiEnumConst:
-          \_enum_const: (UVM_ERROR), line:25:2, endln:25:11, parent:uvm_severity
-            |vpiName:UVM_ERROR
-            |STRING:toto
-            |vpiSize:4
-          |vpiEnumConst:
-          \_enum_const: (UVM_FATAL), line:26:2, endln:26:11, parent:uvm_severity
-            |vpiName:UVM_FATAL
-            |vpiDecompile:3
-            |INT:3
-            |vpiSize:64
+        \_enum_typespec: (uvm_severity), line:27:2, endln:27:14
       |vpiIODecl:
       \_io_decl: (reg_a), parent:work@toto::c1::set_verbosity_level
         |vpiName:reg_a
         |vpiDirection:1
         |vpiTypedef:
-        \_unsupported_typespec: (uvm_reg), line:41:70, endln:41:77, parent:reg_a
+        \_unsupported_typespec: (uvm_reg), line:41:70, endln:41:77
           |vpiName:uvm_reg
     |vpiMethod:
     \_task: (work@toto::c1::wait_for_total_count), line:44:1, endln:46:9, parent:work@toto::c1
@@ -753,7 +713,7 @@ design: (work@toto)
         |vpiName:obj
         |vpiDirection:1
         |vpiTypedef:
-        \_class_typespec: (c2), line:44:27, endln:44:29, parent:obj
+        \_class_typespec: (c2), line:44:27, endln:44:29
           |vpiName:c2
           |vpiClassDefn:
           \_class_defn: (work@toto::c2) top.v:8: , endln:12:8, parent:work@toto
@@ -779,9 +739,9 @@ design: (work@toto)
         |vpiName:count
         |vpiDirection:1
         |vpiTypedef:
-        \_int_typespec: , line:44:40, endln:44:43, parent:count
+        \_int_typespec: , line:44:40, endln:44:43
         |vpiExpr:
-        \_constant: , line:44:50, endln:44:51, parent:count
+        \_constant: , line:44:50, endln:44:51
           |vpiConstType:9
           |vpiDecompile:0
           |vpiSize:64
@@ -801,16 +761,8 @@ design: (work@toto)
         \_range: , line:21:18, endln:21:21
           |vpiLeftRange:
           \_constant: , line:21:18, endln:21:19
-            |vpiConstType:9
-            |vpiDecompile:1
-            |vpiSize:64
-            |UINT:1
           |vpiRightRange:
           \_constant: , line:21:20, endln:21:21
-            |vpiConstType:9
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
       |vpiEnumConst:
       \_enum_const: (UVM_INFO), line:23:2, endln:23:10, parent:uvm_severity
         |vpiName:UVM_INFO
@@ -873,7 +825,7 @@ design: (work@toto)
         |vpiName:provider
         |vpiDirection:1
         |vpiTypedef:
-        \_unsupported_typespec: (this_type), line:35:23, endln:35:32, parent:provider
+        \_unsupported_typespec: (this_type), line:35:23, endln:35:32
           |vpiName:this_type
     |vpiMethod:
     \_function: (work@toto::c1::get_verbosity_level), line:38:3, endln:39:14, parent:work@toto::c1
@@ -888,10 +840,10 @@ design: (work@toto)
         |vpiName:severity
         |vpiDirection:1
         |vpiTypedef:
-        \_enum_typespec: (uvm_severity), line:27:2, endln:27:14, parent:severity
+        \_enum_typespec: (uvm_severity), line:27:2, endln:27:14
           |vpiName:uvm_severity
           |vpiBaseTypespec:
-          \_bit_typespec: , line:21:13, endln:21:16, parent:uvm_severity
+          \_bit_typespec: , line:21:13, endln:21:16
             |vpiRange:
             \_range: , line:21:18, endln:21:21
               |vpiLeftRange:
@@ -907,24 +859,24 @@ design: (work@toto)
                 |vpiSize:64
                 |UINT:0
           |vpiEnumConst:
-          \_enum_const: (UVM_INFO), line:23:2, endln:23:10, parent:uvm_severity
+          \_enum_const: (UVM_INFO), line:23:2, endln:23:10
             |vpiName:UVM_INFO
             |vpiDecompile:0
             |INT:0
             |vpiSize:64
           |vpiEnumConst:
-          \_enum_const: (UVM_WARNING), line:24:2, endln:24:13, parent:uvm_severity
+          \_enum_const: (UVM_WARNING), line:24:2, endln:24:13
             |vpiName:UVM_WARNING
             |vpiDecompile:1
             |INT:1
             |vpiSize:64
           |vpiEnumConst:
-          \_enum_const: (UVM_ERROR), line:25:2, endln:25:11, parent:uvm_severity
+          \_enum_const: (UVM_ERROR), line:25:2, endln:25:11
             |vpiName:UVM_ERROR
             |STRING:toto
             |vpiSize:4
           |vpiEnumConst:
-          \_enum_const: (UVM_FATAL), line:26:2, endln:26:11, parent:uvm_severity
+          \_enum_const: (UVM_FATAL), line:26:2, endln:26:11
             |vpiName:UVM_FATAL
             |vpiDecompile:3
             |INT:3
@@ -934,7 +886,7 @@ design: (work@toto)
         |vpiName:reg_a
         |vpiDirection:1
         |vpiTypedef:
-        \_unsupported_typespec: (uvm_reg), line:38:70, endln:38:77, parent:reg_a
+        \_unsupported_typespec: (uvm_reg), line:38:70, endln:38:77
           |vpiName:uvm_reg
     |vpiMethod:
     \_function: (work@toto::c1::set_verbosity_level), line:41:1, endln:42:14, parent:work@toto::c1
@@ -949,53 +901,13 @@ design: (work@toto)
         |vpiName:severity
         |vpiDirection:1
         |vpiTypedef:
-        \_enum_typespec: (uvm_severity), line:27:2, endln:27:14, parent:severity
-          |vpiName:uvm_severity
-          |vpiBaseTypespec:
-          \_bit_typespec: , line:21:13, endln:21:16, parent:uvm_severity
-            |vpiRange:
-            \_range: , line:21:18, endln:21:21
-              |vpiLeftRange:
-              \_constant: , line:21:18, endln:21:19
-                |vpiConstType:9
-                |vpiDecompile:1
-                |vpiSize:64
-                |UINT:1
-              |vpiRightRange:
-              \_constant: , line:21:20, endln:21:21
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-          |vpiEnumConst:
-          \_enum_const: (UVM_INFO), line:23:2, endln:23:10, parent:uvm_severity
-            |vpiName:UVM_INFO
-            |vpiDecompile:0
-            |INT:0
-            |vpiSize:64
-          |vpiEnumConst:
-          \_enum_const: (UVM_WARNING), line:24:2, endln:24:13, parent:uvm_severity
-            |vpiName:UVM_WARNING
-            |vpiDecompile:1
-            |INT:1
-            |vpiSize:64
-          |vpiEnumConst:
-          \_enum_const: (UVM_ERROR), line:25:2, endln:25:11, parent:uvm_severity
-            |vpiName:UVM_ERROR
-            |STRING:toto
-            |vpiSize:4
-          |vpiEnumConst:
-          \_enum_const: (UVM_FATAL), line:26:2, endln:26:11, parent:uvm_severity
-            |vpiName:UVM_FATAL
-            |vpiDecompile:3
-            |INT:3
-            |vpiSize:64
+        \_enum_typespec: (uvm_severity), line:27:2, endln:27:14
       |vpiIODecl:
       \_io_decl: (reg_a), parent:work@toto::c1::set_verbosity_level
         |vpiName:reg_a
         |vpiDirection:1
         |vpiTypedef:
-        \_unsupported_typespec: (uvm_reg), line:41:70, endln:41:77, parent:reg_a
+        \_unsupported_typespec: (uvm_reg), line:41:70, endln:41:77
           |vpiName:uvm_reg
     |vpiMethod:
     \_task: (work@toto::c1::wait_for_total_count), line:44:1, endln:46:9, parent:work@toto::c1
@@ -1008,7 +920,7 @@ design: (work@toto)
         |vpiName:obj
         |vpiDirection:1
         |vpiTypedef:
-        \_class_typespec: (c2), line:44:27, endln:44:29, parent:obj
+        \_class_typespec: (c2), line:44:27, endln:44:29
           |vpiName:c2
           |vpiClassDefn:
           \_class_defn: (work@toto::c2) top.v:8: , endln:12:8, parent:work@toto
@@ -1051,8 +963,7 @@ design: (work@toto)
                     |vpiName:provider
                     |vpiDirection:1
                     |vpiTypedef:
-                    \_unsupported_typespec: (this_type), line:35:23, endln:35:32, parent:provider
-                      |vpiName:this_type
+                    \_unsupported_typespec: (this_type), line:35:23, endln:35:32
                 |vpiMethod:
                 \_function: (work@toto::c1::get_verbosity_level), line:38:3, endln:39:14, parent:work@toto::c1
                   |vpiMethod:1
@@ -1066,54 +977,13 @@ design: (work@toto)
                     |vpiName:severity
                     |vpiDirection:1
                     |vpiTypedef:
-                    \_enum_typespec: (uvm_severity), line:27:2, endln:27:14, parent:severity
-                      |vpiName:uvm_severity
-                      |vpiBaseTypespec:
-                      \_bit_typespec: , line:21:13, endln:21:16, parent:uvm_severity
-                        |vpiRange:
-                        \_range: , line:21:18, endln:21:21
-                          |vpiLeftRange:
-                          \_constant: , line:21:18, endln:21:19
-                            |vpiConstType:9
-                            |vpiDecompile:1
-                            |vpiSize:64
-                            |UINT:1
-                          |vpiRightRange:
-                          \_constant: , line:21:20, endln:21:21
-                            |vpiConstType:9
-                            |vpiDecompile:0
-                            |vpiSize:64
-                            |UINT:0
-                      |vpiEnumConst:
-                      \_enum_const: (UVM_INFO), line:23:2, endln:23:10, parent:uvm_severity
-                        |vpiName:UVM_INFO
-                        |vpiDecompile:0
-                        |INT:0
-                        |vpiSize:64
-                      |vpiEnumConst:
-                      \_enum_const: (UVM_WARNING), line:24:2, endln:24:13, parent:uvm_severity
-                        |vpiName:UVM_WARNING
-                        |vpiDecompile:1
-                        |INT:1
-                        |vpiSize:64
-                      |vpiEnumConst:
-                      \_enum_const: (UVM_ERROR), line:25:2, endln:25:11, parent:uvm_severity
-                        |vpiName:UVM_ERROR
-                        |STRING:toto
-                        |vpiSize:4
-                      |vpiEnumConst:
-                      \_enum_const: (UVM_FATAL), line:26:2, endln:26:11, parent:uvm_severity
-                        |vpiName:UVM_FATAL
-                        |vpiDecompile:3
-                        |INT:3
-                        |vpiSize:64
+                    \_enum_typespec: (uvm_severity), line:27:2, endln:27:14
                   |vpiIODecl:
                   \_io_decl: (reg_a), parent:work@toto::c1::get_verbosity_level
                     |vpiName:reg_a
                     |vpiDirection:1
                     |vpiTypedef:
-                    \_unsupported_typespec: (uvm_reg), line:38:70, endln:38:77, parent:reg_a
-                      |vpiName:uvm_reg
+                    \_unsupported_typespec: (uvm_reg), line:38:70, endln:38:77
                 |vpiMethod:
                 \_function: (work@toto::c1::set_verbosity_level), line:41:1, endln:42:14, parent:work@toto::c1
                   |vpiMethod:1
@@ -1127,54 +997,13 @@ design: (work@toto)
                     |vpiName:severity
                     |vpiDirection:1
                     |vpiTypedef:
-                    \_enum_typespec: (uvm_severity), line:27:2, endln:27:14, parent:severity
-                      |vpiName:uvm_severity
-                      |vpiBaseTypespec:
-                      \_bit_typespec: , line:21:13, endln:21:16, parent:uvm_severity
-                        |vpiRange:
-                        \_range: , line:21:18, endln:21:21
-                          |vpiLeftRange:
-                          \_constant: , line:21:18, endln:21:19
-                            |vpiConstType:9
-                            |vpiDecompile:1
-                            |vpiSize:64
-                            |UINT:1
-                          |vpiRightRange:
-                          \_constant: , line:21:20, endln:21:21
-                            |vpiConstType:9
-                            |vpiDecompile:0
-                            |vpiSize:64
-                            |UINT:0
-                      |vpiEnumConst:
-                      \_enum_const: (UVM_INFO), line:23:2, endln:23:10, parent:uvm_severity
-                        |vpiName:UVM_INFO
-                        |vpiDecompile:0
-                        |INT:0
-                        |vpiSize:64
-                      |vpiEnumConst:
-                      \_enum_const: (UVM_WARNING), line:24:2, endln:24:13, parent:uvm_severity
-                        |vpiName:UVM_WARNING
-                        |vpiDecompile:1
-                        |INT:1
-                        |vpiSize:64
-                      |vpiEnumConst:
-                      \_enum_const: (UVM_ERROR), line:25:2, endln:25:11, parent:uvm_severity
-                        |vpiName:UVM_ERROR
-                        |STRING:toto
-                        |vpiSize:4
-                      |vpiEnumConst:
-                      \_enum_const: (UVM_FATAL), line:26:2, endln:26:11, parent:uvm_severity
-                        |vpiName:UVM_FATAL
-                        |vpiDecompile:3
-                        |INT:3
-                        |vpiSize:64
+                    \_enum_typespec: (uvm_severity), line:27:2, endln:27:14
                   |vpiIODecl:
                   \_io_decl: (reg_a), parent:work@toto::c1::set_verbosity_level
                     |vpiName:reg_a
                     |vpiDirection:1
                     |vpiTypedef:
-                    \_unsupported_typespec: (uvm_reg), line:41:70, endln:41:77, parent:reg_a
-                      |vpiName:uvm_reg
+                    \_unsupported_typespec: (uvm_reg), line:41:70, endln:41:77
                 |vpiMethod:
                 \_task: (work@toto::c1::wait_for_total_count), line:44:1, endln:46:9, parent:work@toto::c1
                   |vpiMethod:1
@@ -1186,18 +1015,15 @@ design: (work@toto)
                     |vpiName:obj
                     |vpiDirection:1
                     |vpiTypedef:
-                    \_class_typespec: (c2), line:44:27, endln:44:29, parent:obj
-                      |vpiName:c2
-                      |vpiClassDefn:
-                      \_class_defn: (work@toto::c2) top.v:8: , endln:12:8, parent:work@toto
+                    \_class_typespec: (c2), line:44:27, endln:44:29
                   |vpiIODecl:
                   \_io_decl: (count), parent:work@toto::c1::wait_for_total_count
                     |vpiName:count
                     |vpiDirection:1
                     |vpiTypedef:
-                    \_int_typespec: , line:44:40, endln:44:43, parent:count
+                    \_int_typespec: , line:44:40, endln:44:43
                     |vpiExpr:
-                    \_constant: , line:44:50, endln:44:51, parent:count
+                    \_constant: , line:44:50, endln:44:51
                       |vpiConstType:9
                       |vpiDecompile:0
                       |vpiSize:64
@@ -1217,16 +1043,8 @@ design: (work@toto)
                     \_range: , line:21:18, endln:21:21
                       |vpiLeftRange:
                       \_constant: , line:21:18, endln:21:19
-                        |vpiConstType:9
-                        |vpiDecompile:1
-                        |vpiSize:64
-                        |UINT:1
                       |vpiRightRange:
                       \_constant: , line:21:20, endln:21:21
-                        |vpiConstType:9
-                        |vpiDecompile:0
-                        |vpiSize:64
-                        |UINT:0
                   |vpiEnumConst:
                   \_enum_const: (UVM_INFO), line:23:2, endln:23:10, parent:uvm_severity
                     |vpiName:UVM_INFO
@@ -1258,13 +1076,9 @@ design: (work@toto)
         |vpiName:count
         |vpiDirection:1
         |vpiTypedef:
-        \_int_typespec: , line:44:40, endln:44:43, parent:count
+        \_int_typespec: , line:44:40, endln:44:43
         |vpiExpr:
-        \_constant: , line:44:50, endln:44:51, parent:count
-          |vpiConstType:9
-          |vpiDecompile:0
-          |vpiSize:64
-          |UINT:0
+        \_constant: , line:44:50, endln:44:51
     |vpiExtends:
     \_extends: , line:18:17, endln:18:19, parent:work@toto::c1
       |vpiClassTypespec:
@@ -1280,16 +1094,8 @@ design: (work@toto)
         \_range: , line:21:18, endln:21:21
           |vpiLeftRange:
           \_constant: , line:21:18, endln:21:19
-            |vpiConstType:9
-            |vpiDecompile:1
-            |vpiSize:64
-            |UINT:1
           |vpiRightRange:
           \_constant: , line:21:20, endln:21:21
-            |vpiConstType:9
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
       |vpiEnumConst:
       \_enum_const: (UVM_INFO), line:23:2, endln:23:10, parent:uvm_severity
         |vpiName:UVM_INFO

--- a/tests/ClassFuncTask/ClassFuncTask.log
+++ b/tests/ClassFuncTask/ClassFuncTask.log
@@ -67,9 +67,9 @@ design: (unnamed)
         |vpiName:bound
         |vpiDirection:1
         |vpiTypedef:
-        \_int_typespec: , line:15:16, endln:15:19, parent:bound
+        \_int_typespec: , line:15:16, endln:15:19
         |vpiExpr:
-        \_constant: , line:15:28, endln:15:29, parent:bound
+        \_constant: , line:15:28, endln:15:29
           |vpiConstType:9
           |vpiDecompile:0
           |vpiSize:64
@@ -108,7 +108,7 @@ design: (unnamed)
         |vpiName:i
         |vpiDirection:1
         |vpiTypedef:
-        \_int_typespec: , line:19:12, endln:19:15, parent:i
+        \_int_typespec: , line:19:12, endln:19:15
       |vpiStmt:
       \_assignment: , line:20:4, endln:20:9, parent:pack::C::set
         |vpiOpType:82

--- a/tests/ClassMethodCall/ClassMethodCall.log
+++ b/tests/ClassMethodCall/ClassMethodCall.log
@@ -103,7 +103,7 @@ design: (work@door_mod)
           |vpiName:a
           |vpiDirection:1
           |vpiTypedef:
-          \_int_typespec: , line:23:25, endln:23:28, parent:a
+          \_int_typespec: , line:23:25, endln:23:28
         |vpiStmt:
         \_begin: (pack::doorOpen::new), parent:pack::doorOpen::new
           |vpiFullName:pack::doorOpen::new
@@ -134,7 +134,7 @@ design: (work@door_mod)
           |vpiName:b
           |vpiDirection:1
           |vpiTypedef:
-          \_int_typespec: , line:29:18, endln:29:21, parent:b
+          \_int_typespec: , line:29:18, endln:29:21
         |vpiStmt:
         \_begin: (pack::doorOpen::new), parent:pack::doorOpen::new
           |vpiFullName:pack::doorOpen::new
@@ -302,7 +302,7 @@ design: (work@door_mod)
                     |vpiName:a
                     |vpiDirection:1
                     |vpiTypedef:
-                    \_int_typespec: , line:23:25, endln:23:28, parent:a
+                    \_int_typespec: , line:23:25, endln:23:28
                   |vpiStmt:
                   \_begin: (pack::doorOpen::new), parent:pack::doorOpen::new
                     |vpiFullName:pack::doorOpen::new
@@ -333,7 +333,7 @@ design: (work@door_mod)
                     |vpiName:b
                     |vpiDirection:1
                     |vpiTypedef:
-                    \_int_typespec: , line:29:18, endln:29:21, parent:b
+                    \_int_typespec: , line:29:18, endln:29:21
                   |vpiStmt:
                   \_begin: (pack::doorOpen::new), parent:pack::doorOpen::new
                     |vpiFullName:pack::doorOpen::new
@@ -543,7 +543,7 @@ design: (work@door_mod)
                     |vpiName:a
                     |vpiDirection:1
                     |vpiTypedef:
-                    \_int_typespec: , line:23:25, endln:23:28, parent:a
+                    \_int_typespec: , line:23:25, endln:23:28
                   |vpiStmt:
                   \_begin: (pack::doorOpen::new), parent:pack::doorOpen::new
                     |vpiFullName:pack::doorOpen::new
@@ -574,7 +574,7 @@ design: (work@door_mod)
                     |vpiName:b
                     |vpiDirection:1
                     |vpiTypedef:
-                    \_int_typespec: , line:29:18, endln:29:21, parent:b
+                    \_int_typespec: , line:29:18, endln:29:21
                   |vpiStmt:
                   \_begin: (pack::doorOpen::new), parent:pack::doorOpen::new
                     |vpiFullName:pack::doorOpen::new

--- a/tests/ClassParam/ClassParam.log
+++ b/tests/ClassParam/ClassParam.log
@@ -89,13 +89,9 @@ design: (unnamed)
           |vpiName:bound
           |vpiDirection:1
           |vpiTypedef:
-          \_int_typespec: , line:8:19, endln:8:22, parent:bound
+          \_int_typespec: , line:8:19, endln:8:22
           |vpiExpr:
-          \_constant: , line:8:31, endln:8:32, parent:bound
-            |vpiConstType:9
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
+          \_constant: , line:8:31, endln:8:32
     |vpiParamAssign:
     \_param_assign: , line:4:10, endln:4:17, parent:pack::uvm_port_base
       |vpiRhs:

--- a/tests/ClassParamAsParam/ClassParamAsParam.log
+++ b/tests/ClassParamAsParam/ClassParamAsParam.log
@@ -75,38 +75,30 @@ design: (work@top)
                   |vpiFullName:work@top.misc2.config_db.T
                   |vpiName:T
                   |vpiTypespec:
-                  \_class_typespec: (object), line:18:13, endln:18:19, parent:work@top.misc2.config_db.T
+                  \_class_typespec: (object), line:18:13, endln:18:19, parent:config_db.T
                     |vpiName:object
                     |vpiParamAssign:
-                    \_param_assign: , parent:object
+                    \_param_assign: 
                       |vpiRhs:
-                      \_type_parameter: (work@top.misc2.config_db.T.object.T)
-                        |vpiFullName:work@top.misc2.config_db.T.object.T
+                      \_type_parameter: (config_db.T.object.T), parent:object
+                        |vpiFullName:config_db.T.object.T
                         |vpiName:T
                         |vpiTypespec:
-                        \_long_int_typespec: , line:18:21, endln:18:28, parent:work@top.misc2.config_db.T.object.T
+                        \_long_int_typespec: , line:18:21, endln:18:28, parent:config_db.T.object.T
                       |vpiLhs:
-                      \_type_parameter: (work@top.misc2.config_db.T.object.T), line:1:27, endln:1:27
-                        |vpiFullName:work@top.misc2.config_db.T.object.T
+                      \_type_parameter: (work@object::T), line:1:27, endln:1:27, parent:work@object
+                        |vpiFullName:work@object::T
                         |vpiName:T
                         |vpiTypespec:
-                        \_int_typespec: , line:1:29, endln:1:32, parent:work@top.misc2.config_db.T.object.T
+                        \_int_typespec: , line:1:29, endln:1:32, parent:work@object::T
                     |vpiClassDefn:
                     \_class_defn: (work@object) dut.sv:1: , endln:2:8, parent:work@top
                       |vpiVirtual:1
                       |vpiName:work@object
                       |vpiParameter:
                       \_type_parameter: (work@object::T), line:1:27, endln:1:27, parent:work@object
-                        |vpiFullName:work@object::T
-                        |vpiName:T
-                        |vpiTypespec:
-                        \_int_typespec: , line:1:29, endln:1:32, parent:work@object::T
                     |vpiParameter:
-                    \_type_parameter: (work@top.misc2.config_db.T.object.T), parent:object
-                      |vpiFullName:work@top.misc2.config_db.T.object.T
-                      |vpiName:T
-                      |vpiTypespec:
-                      \_long_int_typespec: , line:18:21, endln:18:28, parent:work@top.misc2.config_db.T.object.T
+                    \_type_parameter: (config_db.T.object.T), parent:object
                 |vpiLhs:
                 \_type_parameter: (work@resource::T), line:4:22, endln:4:22, parent:work@resource
                   |vpiFullName:work@resource::T
@@ -181,44 +173,36 @@ design: (work@top)
           |vpiFullName:work@top.misc2.config_db.T
           |vpiName:T
           |vpiTypespec:
-          \_class_typespec: (object), line:18:13, endln:18:19, parent:work@top.misc2.config_db.T
+          \_class_typespec: (object), line:18:13, endln:18:19, parent:config_db.T
             |vpiName:object
             |vpiParamAssign:
-            \_param_assign: , parent:object
+            \_param_assign: 
               |vpiRhs:
-              \_type_parameter: (work@top.misc2.config_db.T.object.T)
-                |vpiFullName:work@top.misc2.config_db.T.object.T
+              \_type_parameter: (config_db.T.object.T), parent:object
+                |vpiFullName:config_db.T.object.T
                 |vpiName:T
                 |vpiTypespec:
-                \_long_int_typespec: , line:18:21, endln:18:28, parent:work@top.misc2.config_db.T.object.T
+                \_long_int_typespec: , line:18:21, endln:18:28, parent:config_db.T.object.T
               |vpiLhs:
-              \_type_parameter: (work@top.misc2.config_db.T.object.T), line:1:27, endln:1:27
-                |vpiFullName:work@top.misc2.config_db.T.object.T
+              \_type_parameter: (work@object::T), line:1:27, endln:1:27, parent:work@object
+                |vpiFullName:work@object::T
                 |vpiName:T
                 |vpiTypespec:
-                \_int_typespec: , line:1:29, endln:1:32, parent:work@top.misc2.config_db.T.object.T
+                \_int_typespec: , line:1:29, endln:1:32, parent:work@object::T
             |vpiClassDefn:
             \_class_defn: (work@object) dut.sv:1: , endln:2:8, parent:work@top
               |vpiVirtual:1
               |vpiName:work@object
               |vpiParameter:
               \_type_parameter: (work@object::T), line:1:27, endln:1:27, parent:work@object
-                |vpiFullName:work@object::T
-                |vpiName:T
-                |vpiTypespec:
-                \_int_typespec: , line:1:29, endln:1:32, parent:work@object::T
             |vpiParameter:
-            \_type_parameter: (work@top.misc2.config_db.T.object.T), parent:object
-              |vpiFullName:work@top.misc2.config_db.T.object.T
-              |vpiName:T
-              |vpiTypespec:
-              \_long_int_typespec: , line:18:21, endln:18:28, parent:work@top.misc2.config_db.T.object.T
+            \_type_parameter: (config_db.T.object.T), parent:object
         |vpiLhs:
         \_type_parameter: (work@top.misc2.config_db.T), line:14:22, endln:14:22
           |vpiFullName:work@top.misc2.config_db.T
           |vpiName:T
           |vpiTypespec:
-          \_int_typespec: , line:14:24, endln:14:27, parent:work@top.misc2.config_db.T
+          \_int_typespec: , line:14:24, endln:14:27, parent:work@config_db::T
       |vpiClassDefn:
       \_class_defn: (work@config_db) dut.sv:14: , endln:15:8, parent:work@top
         |vpiName:work@config_db
@@ -289,30 +273,7 @@ design: (work@top)
         |vpiFullName:work@top.misc2.config_db.T
         |vpiName:T
         |vpiTypespec:
-        \_class_typespec: (object), line:18:13, endln:18:19, parent:work@top.misc2.config_db.T
-          |vpiName:object
-          |vpiParamAssign:
-          \_param_assign: , parent:object
-            |vpiRhs:
-            \_type_parameter: (work@top.misc2.config_db.T.object.T)
-              |vpiFullName:work@top.misc2.config_db.T.object.T
-              |vpiName:T
-              |vpiTypespec:
-              \_long_int_typespec: , line:18:21, endln:18:28, parent:work@top.misc2.config_db.T.object.T
-            |vpiLhs:
-            \_type_parameter: (work@top.misc2.config_db.T.object.T), line:1:27, endln:1:27
-              |vpiFullName:work@top.misc2.config_db.T.object.T
-              |vpiName:T
-              |vpiTypespec:
-              \_int_typespec: , line:1:29, endln:1:32, parent:work@top.misc2.config_db.T.object.T
-          |vpiClassDefn:
-          \_class_defn: (work@object) dut.sv:1: , endln:2:8, parent:work@top
-          |vpiParameter:
-          \_type_parameter: (work@top.misc2.config_db.T.object.T), parent:object
-            |vpiFullName:work@top.misc2.config_db.T.object.T
-            |vpiName:T
-            |vpiTypespec:
-            \_long_int_typespec: , line:18:21, endln:18:28, parent:work@top.misc2.config_db.T.object.T
+        \_class_typespec: (object), line:18:13, endln:18:19, parent:config_db.T
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/ClassTypeParam/ClassTypeParam.log
+++ b/tests/ClassTypeParam/ClassTypeParam.log
@@ -102,7 +102,7 @@ design: (work@top)
               |vpiName:a_error_msg
               |vpiDirection:1
               |vpiTypedef:
-              \_string_typespec: , line:11:44, endln:11:50, parent:a_error_msg
+              \_string_typespec: , line:11:44, endln:11:50
           |vpiDerivedClasses:
           \_class_defn: (work@uvm_config_db) dut.sv:16: , endln:17:8, parent:work@top
           |vpiVariables:
@@ -124,7 +124,7 @@ design: (work@top)
                     |vpiFullName:work@top.misc1.m_uvm_config_obj_misc.T
                     |vpiName:T
                     |vpiTypespec:
-                    \_class_typespec: (uvm_object), line:20:21, endln:20:42, parent:work@top.misc1.m_uvm_config_obj_misc.T
+                    \_class_typespec: (uvm_object), line:20:21, endln:20:42, parent:m_uvm_config_obj_misc.T
                       |vpiName:uvm_object
                       |vpiClassDefn:
                       \_class_defn: (work@uvm_object) dut.sv:1: , endln:2:8, parent:work@top
@@ -141,7 +141,7 @@ design: (work@top)
                     |vpiFullName:work@top.misc2.uvm_config_db.T
                     |vpiName:T
                     |vpiTypespec:
-                    \_class_typespec: (uvm_object), line:26:15, endln:26:36, parent:work@top.misc2.uvm_config_db.T
+                    \_class_typespec: (uvm_object), line:26:15, endln:26:36, parent:uvm_config_db.T
                       |vpiName:uvm_object
                       |vpiClassDefn:
                       \_class_defn: (work@uvm_object) dut.sv:1: , endln:2:8, parent:work@top
@@ -185,7 +185,7 @@ design: (work@top)
         |vpiFullName:work@top.misc1.m_uvm_config_obj_misc.T2
         |vpiName:T2
         |vpiTypespec:
-        \_string_typespec: , line:20:35, endln:20:41, parent:work@top.misc1.m_uvm_config_obj_misc.T2
+        \_string_typespec: , line:20:35, endln:20:41, parent:m_uvm_config_obj_misc.T2
       |vpiLhs:
       \_type_parameter: (work@uvm_config_db::T2), line:16:38, endln:16:38, parent:work@uvm_config_db
     |vpiParamAssign:
@@ -201,7 +201,7 @@ design: (work@top)
         |vpiFullName:work@top.misc2.uvm_config_db.T2
         |vpiName:T2
         |vpiTypespec:
-        \_string_typespec: , line:26:29, endln:26:35, parent:work@top.misc2.uvm_config_db.T2
+        \_string_typespec: , line:26:29, endln:26:35, parent:uvm_config_db.T2
       |vpiLhs:
       \_type_parameter: (work@uvm_config_db::T2), line:16:38, endln:16:38, parent:work@uvm_config_db
     |vpiParameter:
@@ -234,7 +234,7 @@ design: (work@top)
             |vpiName:a_error_msg
             |vpiDirection:1
             |vpiTypedef:
-            \_string_typespec: , line:11:44, endln:11:50, parent:a_error_msg
+            \_string_typespec: , line:11:44, endln:11:50
         |vpiDerivedClasses:
         \_class_defn: (work@uvm_config_db) dut.sv:16: , endln:17:8, parent:work@top
         |vpiVariables:
@@ -256,7 +256,7 @@ design: (work@top)
                   |vpiFullName:work@top.misc1.m_uvm_config_obj_misc.T
                   |vpiName:T
                   |vpiTypespec:
-                  \_class_typespec: (uvm_object), line:20:21, endln:20:42, parent:work@top.misc1.m_uvm_config_obj_misc.T
+                  \_class_typespec: (uvm_object), line:20:21, endln:20:42, parent:m_uvm_config_obj_misc.T
                     |vpiName:uvm_object
                     |vpiClassDefn:
                     \_class_defn: (work@uvm_object) dut.sv:1: , endln:2:8, parent:work@top
@@ -275,7 +275,7 @@ design: (work@top)
                   |vpiFullName:work@top.misc2.uvm_config_db.T
                   |vpiName:T
                   |vpiTypespec:
-                  \_class_typespec: (uvm_object), line:26:15, endln:26:36, parent:work@top.misc2.uvm_config_db.T
+                  \_class_typespec: (uvm_object), line:26:15, endln:26:36, parent:uvm_config_db.T
                     |vpiName:uvm_object
                     |vpiClassDefn:
                     \_class_defn: (work@uvm_object) dut.sv:1: , endln:2:8, parent:work@top
@@ -323,7 +323,7 @@ design: (work@top)
       |vpiFullName:work@top.misc1.m_uvm_config_obj_misc.T2
       |vpiName:T2
       |vpiTypespec:
-      \_string_typespec: , line:20:35, endln:20:41, parent:work@top.misc1.m_uvm_config_obj_misc.T2
+      \_string_typespec: , line:20:35, endln:20:41, parent:m_uvm_config_obj_misc.T2
     |vpiLhs:
     \_type_parameter: (work@uvm_config_db::T2), line:16:38, endln:16:38, parent:work@uvm_config_db
       |vpiFullName:work@uvm_config_db::T2
@@ -343,7 +343,7 @@ design: (work@top)
       |vpiFullName:work@top.misc2.uvm_config_db.T2
       |vpiName:T2
       |vpiTypespec:
-      \_string_typespec: , line:26:29, endln:26:35, parent:work@top.misc2.uvm_config_db.T2
+      \_string_typespec: , line:26:29, endln:26:35, parent:uvm_config_db.T2
     |vpiLhs:
     \_type_parameter: (work@uvm_config_db::T2), line:16:38, endln:16:38, parent:work@uvm_config_db
   |vpiParameter:
@@ -391,7 +391,7 @@ design: (work@top)
           |vpiFullName:work@top.misc1.m_uvm_config_obj_misc.T
           |vpiName:T
           |vpiTypespec:
-          \_class_typespec: (uvm_object), line:20:21, endln:20:42, parent:work@top.misc1.m_uvm_config_obj_misc.T
+          \_class_typespec: (uvm_object), line:20:21, endln:20:42, parent:m_uvm_config_obj_misc.T
             |vpiName:uvm_object
             |vpiClassDefn:
             \_class_defn: (work@uvm_object) dut.sv:1: , endln:2:8, parent:work@top
@@ -402,7 +402,7 @@ design: (work@top)
           |vpiFullName:work@top.misc1.m_uvm_config_obj_misc.T
           |vpiName:T
           |vpiTypespec:
-          \_int_typespec: , line:16:28, endln:16:31, parent:work@top.misc1.m_uvm_config_obj_misc.T
+          \_int_typespec: , line:16:28, endln:16:31, parent:work@uvm_config_db::T
       |vpiParamAssign:
       \_param_assign: , parent:m_uvm_config_obj_misc
         |vpiRhs:
@@ -410,13 +410,13 @@ design: (work@top)
           |vpiFullName:work@top.misc1.m_uvm_config_obj_misc.T2
           |vpiName:T2
           |vpiTypespec:
-          \_string_typespec: , line:20:35, endln:20:41, parent:work@top.misc1.m_uvm_config_obj_misc.T2
+          \_string_typespec: , line:20:35, endln:20:41, parent:m_uvm_config_obj_misc.T2
         |vpiLhs:
         \_type_parameter: (work@top.misc1.m_uvm_config_obj_misc.T2), line:16:38, endln:16:38
           |vpiFullName:work@top.misc1.m_uvm_config_obj_misc.T2
           |vpiName:T2
           |vpiTypespec:
-          \_int_typespec: , line:16:41, endln:16:44, parent:work@top.misc1.m_uvm_config_obj_misc.T2
+          \_int_typespec: , line:16:41, endln:16:44, parent:work@uvm_config_db::T2
       |vpiClassDefn:
       \_class_defn: (work@uvm_config_db) dut.sv:16: , endln:17:8, parent:work@top
         |vpiName:work@uvm_config_db
@@ -439,7 +439,7 @@ design: (work@top)
                   |vpiName:a_error_msg
                   |vpiDirection:1
                   |vpiTypedef:
-                  \_string_typespec: , line:11:44, endln:11:50, parent:a_error_msg
+                  \_string_typespec: , line:11:44, endln:11:50
               |vpiDerivedClasses:
               \_class_defn: (work@uvm_config_db) dut.sv:16: , endln:17:8, parent:work@top
               |vpiVariables:
@@ -471,7 +471,7 @@ design: (work@top)
                         |vpiFullName:work@top.misc2.uvm_config_db.T
                         |vpiName:T
                         |vpiTypespec:
-                        \_class_typespec: (uvm_object), line:26:15, endln:26:36, parent:work@top.misc2.uvm_config_db.T
+                        \_class_typespec: (uvm_object), line:26:15, endln:26:36, parent:uvm_config_db.T
                           |vpiName:uvm_object
                           |vpiClassDefn:
                           \_class_defn: (work@uvm_object) dut.sv:1: , endln:2:8, parent:work@top
@@ -535,7 +535,7 @@ design: (work@top)
             |vpiFullName:work@top.misc2.uvm_config_db.T2
             |vpiName:T2
             |vpiTypespec:
-            \_string_typespec: , line:26:29, endln:26:35, parent:work@top.misc2.uvm_config_db.T2
+            \_string_typespec: , line:26:29, endln:26:35, parent:uvm_config_db.T2
           |vpiLhs:
           \_type_parameter: (work@uvm_config_db::T2), line:16:38, endln:16:38, parent:work@uvm_config_db
         |vpiParameter:
@@ -547,16 +547,13 @@ design: (work@top)
         |vpiFullName:work@top.misc1.m_uvm_config_obj_misc.T
         |vpiName:T
         |vpiTypespec:
-        \_class_typespec: (uvm_object), line:20:21, endln:20:42, parent:work@top.misc1.m_uvm_config_obj_misc.T
-          |vpiName:uvm_object
-          |vpiClassDefn:
-          \_class_defn: (work@uvm_object) dut.sv:1: , endln:2:8, parent:work@top
+        \_class_typespec: (uvm_object), line:20:21, endln:20:42, parent:m_uvm_config_obj_misc.T
       |vpiParameter:
       \_type_parameter: (work@top.misc1.m_uvm_config_obj_misc.T2), parent:m_uvm_config_obj_misc
         |vpiFullName:work@top.misc1.m_uvm_config_obj_misc.T2
         |vpiName:T2
         |vpiTypespec:
-        \_string_typespec: , line:20:35, endln:20:41, parent:work@top.misc1.m_uvm_config_obj_misc.T2
+        \_string_typespec: , line:20:35, endln:20:41, parent:m_uvm_config_obj_misc.T2
   |vpiVariables:
   \_class_var: (work@top.misc2), line:26:37, endln:26:42, parent:work@top
     |vpiName:misc2
@@ -578,7 +575,7 @@ design: (work@top)
           |vpiFullName:work@top.misc2.uvm_config_db.T
           |vpiName:T
           |vpiTypespec:
-          \_int_typespec: , line:16:28, endln:16:31, parent:work@top.misc2.uvm_config_db.T
+          \_int_typespec: , line:16:28, endln:16:31, parent:work@uvm_config_db::T
       |vpiParamAssign:
       \_param_assign: , parent:uvm_config_db
         |vpiRhs:
@@ -588,7 +585,7 @@ design: (work@top)
           |vpiFullName:work@top.misc2.uvm_config_db.T2
           |vpiName:T2
           |vpiTypespec:
-          \_int_typespec: , line:16:41, endln:16:44, parent:work@top.misc2.uvm_config_db.T2
+          \_int_typespec: , line:16:41, endln:16:44, parent:work@uvm_config_db::T2
       |vpiClassDefn:
       \_class_defn: (work@uvm_config_db) dut.sv:16: , endln:17:8, parent:work@top
       |vpiParameter:
@@ -596,16 +593,13 @@ design: (work@top)
         |vpiFullName:work@top.misc2.uvm_config_db.T
         |vpiName:T
         |vpiTypespec:
-        \_class_typespec: (uvm_object), line:26:15, endln:26:36, parent:work@top.misc2.uvm_config_db.T
-          |vpiName:uvm_object
-          |vpiClassDefn:
-          \_class_defn: (work@uvm_object) dut.sv:1: , endln:2:8, parent:work@top
+        \_class_typespec: (uvm_object), line:26:15, endln:26:36, parent:uvm_config_db.T
       |vpiParameter:
       \_type_parameter: (work@top.misc2.uvm_config_db.T2), parent:uvm_config_db
         |vpiFullName:work@top.misc2.uvm_config_db.T2
         |vpiName:T2
         |vpiTypespec:
-        \_string_typespec: , line:26:29, endln:26:35, parent:work@top.misc2.uvm_config_db.T2
+        \_string_typespec: , line:26:29, endln:26:35, parent:uvm_config_db.T2
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/ClassTypeParamAlias/ClassTypeParamAlias.log
+++ b/tests/ClassTypeParamAlias/ClassTypeParamAlias.log
@@ -178,9 +178,9 @@ design: (unnamed)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -275,7 +275,7 @@ design: (unnamed)
     \_logic_typespec: (BrickType), line:5:10, endln:5:15, parent:work@param_types_as_class_item::BT
       |vpiName:BrickType
       |vpiTypedefAlias:
-      \_logic_typespec: (BrickType), line:5:10, endln:5:15, parent:BrickType
+      \_logic_typespec: (BrickType), line:5:10, endln:5:15
         |vpiName:BrickType
   |vpiParameter:
   \_type_parameter: (work@param_types_as_class_item::CT1), line:7:17, endln:7:20, parent:work@param_types_as_class_item
@@ -457,9 +457,9 @@ design: (unnamed)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -475,9 +475,9 @@ design: (unnamed)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -493,9 +493,9 @@ design: (unnamed)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -513,9 +513,9 @@ design: (unnamed)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/ClockingBlock/ClockingBlock.log
+++ b/tests/ClockingBlock/ClockingBlock.log
@@ -175,9 +175,9 @@ design: (work@top)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -394,9 +394,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -412,9 +412,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -430,9 +430,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -450,9 +450,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/ClogCast/ClogCast.log
+++ b/tests/ClogCast/ClogCast.log
@@ -472,9 +472,9 @@ design: (work@debug_rom)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -691,9 +691,9 @@ design: (work@debug_rom)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -709,9 +709,9 @@ design: (work@debug_rom)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -727,9 +727,9 @@ design: (work@debug_rom)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -747,9 +747,9 @@ design: (work@debug_rom)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/ComplexBitSelect/ComplexBitSelect.log
+++ b/tests/ComplexBitSelect/ComplexBitSelect.log
@@ -388,9 +388,9 @@ design: (work@flash_ctrl_info_cfg)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -607,9 +607,9 @@ design: (work@flash_ctrl_info_cfg)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -625,9 +625,9 @@ design: (work@flash_ctrl_info_cfg)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -643,9 +643,9 @@ design: (work@flash_ctrl_info_cfg)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -663,9 +663,9 @@ design: (work@flash_ctrl_info_cfg)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/ConcatVal/ConcatVal.log
+++ b/tests/ConcatVal/ConcatVal.log
@@ -291,9 +291,9 @@ design: (work@dut)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -510,9 +510,9 @@ design: (work@dut)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -528,9 +528,9 @@ design: (work@dut)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -546,9 +546,9 @@ design: (work@dut)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -566,9 +566,9 @@ design: (work@dut)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -1071,55 +1071,13 @@ design: (work@dut)
       |vpiName:state_in
       |vpiDirection:1
       |vpiTypedef:
-      \_logic_typespec: , line:4:45, endln:4:50, parent:state_in
-        |vpiRange:
-        \_range: , line:4:52, endln:4:56
-          |vpiLeftRange:
-          \_constant: , line:4:52, endln:4:54
-            |vpiConstType:9
-            |vpiDecompile:63
-            |vpiSize:64
-            |UINT:63
-          |vpiRightRange:
-          \_constant: , line:4:55, endln:4:56
-            |vpiConstType:9
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
+      \_logic_typespec: , line:4:45, endln:4:50
     |vpiIODecl:
     \_io_decl: (sbox4), parent:work@dut.sbox4_64bit
       |vpiName:sbox4
       |vpiDirection:1
       |vpiTypedef:
-      \_logic_typespec: , line:4:68, endln:4:73, parent:sbox4
-        |vpiRange:
-        \_range: , line:4:75, endln:4:79
-          |vpiLeftRange:
-          \_constant: , line:4:75, endln:4:77
-            |vpiConstType:9
-            |vpiDecompile:15
-            |vpiSize:64
-            |UINT:15
-          |vpiRightRange:
-          \_constant: , line:4:78, endln:4:79
-            |vpiConstType:9
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
-        |vpiRange:
-        \_range: , line:4:81, endln:4:84
-          |vpiLeftRange:
-          \_constant: , line:4:81, endln:4:82
-            |vpiConstType:9
-            |vpiDecompile:3
-            |vpiSize:64
-            |UINT:3
-          |vpiRightRange:
-          \_constant: , line:4:83, endln:4:84
-            |vpiConstType:9
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
+      \_logic_typespec: , line:4:68, endln:4:73
     |vpiStmt:
     \_begin: (work@dut.sbox4_64bit), parent:work@dut.sbox4_64bit
       |vpiFullName:work@dut.sbox4_64bit

--- a/tests/ConcatWidth/ConcatWidth.log
+++ b/tests/ConcatWidth/ConcatWidth.log
@@ -303,9 +303,9 @@ design: (work@top)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -522,9 +522,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -540,9 +540,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -558,9 +558,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -578,9 +578,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/ConditionalOp/ConditionalOp.log
+++ b/tests/ConditionalOp/ConditionalOp.log
@@ -471,9 +471,9 @@ design: (work@top)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -690,9 +690,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -708,9 +708,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -726,9 +726,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -746,9 +746,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/ContAssign/ContAssign.log
+++ b/tests/ContAssign/ContAssign.log
@@ -175,9 +175,9 @@ design: (work@top)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -394,9 +394,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -412,9 +412,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -430,9 +430,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -450,9 +450,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/DelayAssign/DelayAssign.log
+++ b/tests/DelayAssign/DelayAssign.log
@@ -767,9 +767,9 @@ design: (work@SimDTM)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -986,9 +986,9 @@ design: (work@SimDTM)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -1004,9 +1004,9 @@ design: (work@SimDTM)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -1022,9 +1022,9 @@ design: (work@SimDTM)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -1042,9 +1042,9 @@ design: (work@SimDTM)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/DoWhile/DoWhile.log
+++ b/tests/DoWhile/DoWhile.log
@@ -212,9 +212,9 @@ design: (unnamed)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -431,9 +431,9 @@ design: (unnamed)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -449,9 +449,9 @@ design: (unnamed)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -467,9 +467,9 @@ design: (unnamed)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -487,9 +487,9 @@ design: (unnamed)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/DollarRoot/DollarRoot.log
+++ b/tests/DollarRoot/DollarRoot.log
@@ -6452,9 +6452,9 @@ design: (work@top)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -6671,9 +6671,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -6689,9 +6689,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -6707,9 +6707,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -6727,9 +6727,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -12550,33 +12550,33 @@ design: (work@top)
             |vpiName:cmd
             |vpiFullName:work@test_program.cmd
             |vpiTypespec:
-            \_struct_typespec: (Command), line:45:11, endln:45:17, parent:work@test_program.cmd
+            \_struct_typespec: (Command), line:45:11, endln:45:17
               |vpiName:Command
               |vpiTypespecMember:
-              \_typespec_member: (trans), line:47:36, endln:47:41, parent:Command
+              \_typespec_member: (trans), line:47:36, endln:47:41
                 |vpiName:trans
                 |vpiTypespec:
-                \_enum_typespec: (Transaction), line:37:5, endln:37:16, parent:trans
+                \_enum_typespec: (Transaction), line:37:5, endln:37:16
                   |vpiName:Transaction
                   |vpiBaseTypespec:
-                  \_bit_typespec: , line:33:16, endln:33:19, parent:Transaction
+                  \_bit_typespec: , line:33:16, endln:33:19
                   |vpiEnumConst:
-                  \_enum_const: (WRITE), line:35:7, endln:35:12, parent:Transaction
+                  \_enum_const: (WRITE), line:35:7, endln:35:12
                     |vpiName:WRITE
                     |vpiDecompile:0
                     |UINT:0
                     |vpiSize:64
                   |vpiEnumConst:
-                  \_enum_const: (READ), line:36:7, endln:36:11, parent:Transaction
+                  \_enum_const: (READ), line:36:7, endln:36:11
                     |vpiName:READ
                     |vpiDecompile:1
                     |UINT:1
                     |vpiSize:64
               |vpiTypespecMember:
-              \_typespec_member: (burstcount), line:48:36, endln:48:46, parent:Command
+              \_typespec_member: (burstcount), line:48:36, endln:48:46
                 |vpiName:burstcount
                 |vpiTypespec:
-                \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:burstcount
+                \_logic_typespec: (Burstcount), line:31:11, endln:31:16
                   |vpiName:Burstcount
                   |vpiRange:
                   \_range: , line:31:18, endln:31:29, parent:Burstcount
@@ -12584,15 +12584,9 @@ design: (work@top)
                     \_operation: , line:31:18, endln:31:25
                       |vpiOpType:11
                       |vpiOperand:
-                      \_ref_obj: (work@test_program.cmd.Command.burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
+                      \_ref_obj: (Burstcount.BURST_W), line:31:18, endln:31:25
                         |vpiName:BURST_W
-                        |vpiFullName:work@test_program.cmd.Command.burstcount.Burstcount.BURST_W
-                        |vpiActual:
-                        \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                          |vpiName:BURST_W
-                          |vpiFullName:work@test_program.BURST_W
-                          |vpiLocalParam:1
-                          |UINT:4
+                        |vpiFullName:Burstcount.BURST_W
                       |vpiOperand:
                       \_constant: , line:31:26, endln:31:27
                         |vpiConstType:9
@@ -12606,19 +12600,16 @@ design: (work@top)
                       |vpiSize:64
                       |UINT:0
                   |vpiTypedefAlias:
-                  \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:Burstcount
+                  \_logic_typespec: (Burstcount), line:31:11, endln:31:16
                     |vpiName:Burstcount
                     |vpiRange:
-                    \_range: , line:31:18, endln:31:29, parent:Burstcount
+                    \_range: , line:31:18, endln:31:29
                       |vpiLeftRange:
                       \_operation: , line:31:18, endln:31:25
                         |vpiOpType:11
                         |vpiOperand:
-                        \_ref_obj: (work@test_program.cmd.Command.burstcount.Burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
+                        \_ref_obj: (BURST_W), line:31:18, endln:31:25
                           |vpiName:BURST_W
-                          |vpiFullName:work@test_program.cmd.Command.burstcount.Burstcount.Burstcount.BURST_W
-                          |vpiActual:
-                          \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
                         |vpiOperand:
                         \_constant: , line:31:26, endln:31:27
                           |vpiConstType:9
@@ -12632,19 +12623,19 @@ design: (work@top)
                         |vpiSize:64
                         |UINT:0
               |vpiTypespecMember:
-              \_typespec_member: (addr), line:49:36, endln:49:40, parent:Command
+              \_typespec_member: (addr), line:49:36, endln:49:40
                 |vpiName:addr
                 |vpiTypespec:
-                \_logic_typespec: , line:49:7, endln:49:12, parent:addr
+                \_logic_typespec: , line:49:7, endln:49:12
                   |vpiRange:
-                  \_range: , line:49:14, endln:49:25
+                  \_range: , line:49:14, endln:49:25, parent:Command
                     |vpiLeftRange:
                     \_operation: , line:49:14, endln:49:20
                       |vpiOpType:11
                       |vpiOperand:
-                      \_ref_obj: (work@test_program.cmd.Command.addr.ADDR_W), line:49:14, endln:49:20
+                      \_ref_obj: (Command.ADDR_W), line:49:14, endln:49:20, parent:Command
                         |vpiName:ADDR_W
-                        |vpiFullName:work@test_program.cmd.Command.addr.ADDR_W
+                        |vpiFullName:Command.ADDR_W
                         |vpiActual:
                         \_parameter: (work@test_program.ADDR_W), line:13:14, endln:13:43, parent:work@test_program
                           |vpiName:ADDR_W
@@ -12664,19 +12655,19 @@ design: (work@top)
                       |vpiSize:64
                       |UINT:0
               |vpiTypespecMember:
-              \_typespec_member: (data), line:50:36, endln:50:40, parent:Command
+              \_typespec_member: (data), line:50:36, endln:50:40
                 |vpiName:data
                 |vpiTypespec:
-                \_logic_typespec: , line:50:7, endln:50:12, parent:data
+                \_logic_typespec: , line:50:7, endln:50:12
                   |vpiRange:
-                  \_range: , line:50:14, endln:50:24
+                  \_range: , line:50:14, endln:50:24, parent:Command
                     |vpiLeftRange:
                     \_operation: , line:50:14, endln:50:20
                       |vpiOpType:11
                       |vpiOperand:
-                      \_ref_obj: (work@test_program.cmd.Command.data.DATA_W), line:50:14, endln:50:20
+                      \_ref_obj: (Command.DATA_W), line:50:14, endln:50:20, parent:Command
                         |vpiName:DATA_W
-                        |vpiFullName:work@test_program.cmd.Command.data.DATA_W
+                        |vpiFullName:Command.DATA_W
                         |vpiActual:
                         \_parameter: (work@test_program.DATA_W), line:17:14, endln:17:63, parent:work@test_program
                           |vpiName:DATA_W
@@ -12696,19 +12687,19 @@ design: (work@top)
                       |vpiSize:64
                       |UINT:0
               |vpiTypespecMember:
-              \_typespec_member: (byteenable), line:51:36, endln:51:46, parent:Command
+              \_typespec_member: (byteenable), line:51:36, endln:51:46
                 |vpiName:byteenable
                 |vpiTypespec:
-                \_logic_typespec: , line:51:7, endln:51:12, parent:byteenable
+                \_logic_typespec: , line:51:7, endln:51:12
                   |vpiRange:
-                  \_range: , line:51:14, endln:51:29
+                  \_range: , line:51:14, endln:51:29, parent:Command
                     |vpiLeftRange:
                     \_operation: , line:51:14, endln:51:25
                       |vpiOpType:11
                       |vpiOperand:
-                      \_ref_obj: (work@test_program.cmd.Command.byteenable.NUM_SYMBOLS), line:51:14, endln:51:25
+                      \_ref_obj: (Command.NUM_SYMBOLS), line:51:14, endln:51:25, parent:Command
                         |vpiName:NUM_SYMBOLS
-                        |vpiFullName:work@test_program.cmd.Command.byteenable.NUM_SYMBOLS
+                        |vpiFullName:Command.NUM_SYMBOLS
                         |vpiActual:
                         \_parameter: (work@test_program.NUM_SYMBOLS), line:16:14, endln:16:42, parent:work@test_program
                           |vpiName:NUM_SYMBOLS
@@ -12728,12 +12719,12 @@ design: (work@top)
                       |vpiSize:64
                       |UINT:0
               |vpiTypespecMember:
-              \_typespec_member: (cmd_delay), line:52:36, endln:52:45, parent:Command
+              \_typespec_member: (cmd_delay), line:52:36, endln:52:45
                 |vpiName:cmd_delay
                 |vpiTypespec:
-                \_bit_typespec: , line:52:7, endln:52:10, parent:cmd_delay
+                \_bit_typespec: , line:52:7, endln:52:10
                   |vpiRange:
-                  \_range: , line:52:12, endln:52:16
+                  \_range: , line:52:12, endln:52:16, parent:Command
                     |vpiLeftRange:
                     \_constant: , line:52:12, endln:52:14
                       |vpiConstType:9
@@ -12747,12 +12738,12 @@ design: (work@top)
                       |vpiSize:64
                       |UINT:0
               |vpiTypespecMember:
-              \_typespec_member: (data_idles), line:53:36, endln:53:46, parent:Command
+              \_typespec_member: (data_idles), line:53:36, endln:53:46
                 |vpiName:data_idles
                 |vpiTypespec:
-                \_bit_typespec: , line:53:7, endln:53:10, parent:data_idles
+                \_bit_typespec: , line:53:7, endln:53:10
                   |vpiRange:
-                  \_range: , line:53:12, endln:53:16
+                  \_range: , line:53:12, endln:53:16, parent:Command
                     |vpiLeftRange:
                     \_constant: , line:53:12, endln:53:14
                       |vpiConstType:9
@@ -12772,13 +12763,13 @@ design: (work@top)
             |vpiName:actual_rsp
             |vpiFullName:work@test_program.actual_rsp
             |vpiTypespec:
-            \_struct_typespec: (Response), line:56:11, endln:56:17, parent:work@test_program.actual_rsp
+            \_struct_typespec: (Response), line:56:11, endln:56:17
               |vpiName:Response
               |vpiTypespecMember:
-              \_typespec_member: (burstcount), line:58:36, endln:58:46, parent:Response
+              \_typespec_member: (burstcount), line:58:36, endln:58:46
                 |vpiName:burstcount
                 |vpiTypespec:
-                \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:burstcount
+                \_logic_typespec: (Burstcount), line:31:11, endln:31:16
                   |vpiName:Burstcount
                   |vpiRange:
                   \_range: , line:31:18, endln:31:29, parent:Burstcount
@@ -12786,11 +12777,9 @@ design: (work@top)
                     \_operation: , line:31:18, endln:31:25
                       |vpiOpType:11
                       |vpiOperand:
-                      \_ref_obj: (work@test_program.actual_rsp.Response.burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
+                      \_ref_obj: (Burstcount.BURST_W), line:31:18, endln:31:25
                         |vpiName:BURST_W
-                        |vpiFullName:work@test_program.actual_rsp.Response.burstcount.Burstcount.BURST_W
-                        |vpiActual:
-                        \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
+                        |vpiFullName:Burstcount.BURST_W
                       |vpiOperand:
                       \_constant: , line:31:26, endln:31:27
                         |vpiConstType:9
@@ -12804,45 +12793,21 @@ design: (work@top)
                       |vpiSize:64
                       |UINT:0
                   |vpiTypedefAlias:
-                  \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:Burstcount
-                    |vpiName:Burstcount
-                    |vpiRange:
-                    \_range: , line:31:18, endln:31:29, parent:Burstcount
-                      |vpiLeftRange:
-                      \_operation: , line:31:18, endln:31:25
-                        |vpiOpType:11
-                        |vpiOperand:
-                        \_ref_obj: (work@test_program.actual_rsp.Response.burstcount.Burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                          |vpiName:BURST_W
-                          |vpiFullName:work@test_program.actual_rsp.Response.burstcount.Burstcount.Burstcount.BURST_W
-                          |vpiActual:
-                          \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                        |vpiOperand:
-                        \_constant: , line:31:26, endln:31:27
-                          |vpiConstType:9
-                          |vpiDecompile:1
-                          |vpiSize:64
-                          |UINT:1
-                      |vpiRightRange:
-                      \_constant: , line:31:28, endln:31:29
-                        |vpiConstType:9
-                        |vpiDecompile:0
-                        |vpiSize:64
-                        |UINT:0
+                  \_logic_typespec: (Burstcount), line:31:11, endln:31:16
               |vpiTypespecMember:
-              \_typespec_member: (data), line:59:36, endln:59:40, parent:Response
+              \_typespec_member: (data), line:59:36, endln:59:40
                 |vpiName:data
                 |vpiTypespec:
-                \_logic_typespec: , line:59:6, endln:59:11, parent:data
+                \_logic_typespec: , line:59:6, endln:59:11
                   |vpiRange:
-                  \_range: , line:59:13, endln:59:23
+                  \_range: , line:59:13, endln:59:23, parent:Response
                     |vpiLeftRange:
                     \_operation: , line:59:13, endln:59:19
                       |vpiOpType:11
                       |vpiOperand:
-                      \_ref_obj: (work@test_program.actual_rsp.Response.data.DATA_W), line:59:13, endln:59:19
+                      \_ref_obj: (Response.DATA_W), line:59:13, endln:59:19, parent:Response
                         |vpiName:DATA_W
-                        |vpiFullName:work@test_program.actual_rsp.Response.data.DATA_W
+                        |vpiFullName:Response.DATA_W
                         |vpiActual:
                         \_parameter: (work@test_program.DATA_W), line:17:14, endln:17:63, parent:work@test_program
                       |vpiOperand:
@@ -12858,12 +12823,12 @@ design: (work@top)
                       |vpiSize:64
                       |UINT:0
               |vpiTypespecMember:
-              \_typespec_member: (latency), line:60:36, endln:60:43, parent:Response
+              \_typespec_member: (latency), line:60:36, endln:60:43
                 |vpiName:latency
                 |vpiTypespec:
-                \_bit_typespec: , line:60:6, endln:60:9, parent:latency
+                \_bit_typespec: , line:60:6, endln:60:9
                   |vpiRange:
-                  \_range: , line:60:11, endln:60:15
+                  \_range: , line:60:11, endln:60:15, parent:Response
                     |vpiLeftRange:
                     \_constant: , line:60:11, endln:60:13
                       |vpiConstType:9
@@ -12883,110 +12848,7 @@ design: (work@top)
             |vpiName:exp_rsp
             |vpiFullName:work@test_program.exp_rsp
             |vpiTypespec:
-            \_struct_typespec: (Response), line:56:11, endln:56:17, parent:work@test_program.exp_rsp
-              |vpiName:Response
-              |vpiTypespecMember:
-              \_typespec_member: (burstcount), line:58:36, endln:58:46, parent:Response
-                |vpiName:burstcount
-                |vpiTypespec:
-                \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:burstcount
-                  |vpiName:Burstcount
-                  |vpiRange:
-                  \_range: , line:31:18, endln:31:29, parent:Burstcount
-                    |vpiLeftRange:
-                    \_operation: , line:31:18, endln:31:25
-                      |vpiOpType:11
-                      |vpiOperand:
-                      \_ref_obj: (work@test_program.exp_rsp.Response.burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                        |vpiName:BURST_W
-                        |vpiFullName:work@test_program.exp_rsp.Response.burstcount.Burstcount.BURST_W
-                        |vpiActual:
-                        \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                      |vpiOperand:
-                      \_constant: , line:31:26, endln:31:27
-                        |vpiConstType:9
-                        |vpiDecompile:1
-                        |vpiSize:64
-                        |UINT:1
-                    |vpiRightRange:
-                    \_constant: , line:31:28, endln:31:29
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-                  |vpiTypedefAlias:
-                  \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:Burstcount
-                    |vpiName:Burstcount
-                    |vpiRange:
-                    \_range: , line:31:18, endln:31:29, parent:Burstcount
-                      |vpiLeftRange:
-                      \_operation: , line:31:18, endln:31:25
-                        |vpiOpType:11
-                        |vpiOperand:
-                        \_ref_obj: (work@test_program.exp_rsp.Response.burstcount.Burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                          |vpiName:BURST_W
-                          |vpiFullName:work@test_program.exp_rsp.Response.burstcount.Burstcount.Burstcount.BURST_W
-                          |vpiActual:
-                          \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                        |vpiOperand:
-                        \_constant: , line:31:26, endln:31:27
-                          |vpiConstType:9
-                          |vpiDecompile:1
-                          |vpiSize:64
-                          |UINT:1
-                      |vpiRightRange:
-                      \_constant: , line:31:28, endln:31:29
-                        |vpiConstType:9
-                        |vpiDecompile:0
-                        |vpiSize:64
-                        |UINT:0
-              |vpiTypespecMember:
-              \_typespec_member: (data), line:59:36, endln:59:40, parent:Response
-                |vpiName:data
-                |vpiTypespec:
-                \_logic_typespec: , line:59:6, endln:59:11, parent:data
-                  |vpiRange:
-                  \_range: , line:59:13, endln:59:23
-                    |vpiLeftRange:
-                    \_operation: , line:59:13, endln:59:19
-                      |vpiOpType:11
-                      |vpiOperand:
-                      \_ref_obj: (work@test_program.exp_rsp.Response.data.DATA_W), line:59:13, endln:59:19
-                        |vpiName:DATA_W
-                        |vpiFullName:work@test_program.exp_rsp.Response.data.DATA_W
-                        |vpiActual:
-                        \_parameter: (work@test_program.DATA_W), line:17:14, endln:17:63, parent:work@test_program
-                      |vpiOperand:
-                      \_constant: , line:59:20, endln:59:21
-                        |vpiConstType:9
-                        |vpiDecompile:1
-                        |vpiSize:64
-                        |UINT:1
-                    |vpiRightRange:
-                    \_constant: , line:59:22, endln:59:23
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-              |vpiTypespecMember:
-              \_typespec_member: (latency), line:60:36, endln:60:43, parent:Response
-                |vpiName:latency
-                |vpiTypespec:
-                \_bit_typespec: , line:60:6, endln:60:9, parent:latency
-                  |vpiRange:
-                  \_range: , line:60:11, endln:60:15
-                    |vpiLeftRange:
-                    \_constant: , line:60:11, endln:60:13
-                      |vpiConstType:9
-                      |vpiDecompile:31
-                      |vpiSize:64
-                      |UINT:31
-                    |vpiRightRange:
-                    \_constant: , line:60:14, endln:60:15
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
+            \_struct_typespec: (Response), line:56:11, endln:56:17
         |vpiStmt:
         \_assignment: , line:254:6, endln:254:52, parent:work@test_program
           |vpiOpType:82
@@ -13002,7 +12864,7 @@ design: (work@top)
             \_bit_select: (read_command_queue_master), parent:read_command_queue_master[0].pop_front
               |vpiName:read_command_queue_master
               |vpiIndex:
-              \_constant: , line:254:38, endln:254:39, parent:read_command_queue_master
+              \_constant: , line:254:38, endln:254:39
                 |vpiConstType:9
                 |vpiDecompile:0
                 |vpiSize:64
@@ -13117,205 +12979,7 @@ design: (work@top)
             |vpiName:actual_cmd
             |vpiFullName:work@test_program.actual_cmd
             |vpiTypespec:
-            \_struct_typespec: (Command), line:45:11, endln:45:17, parent:work@test_program.actual_cmd
-              |vpiName:Command
-              |vpiTypespecMember:
-              \_typespec_member: (trans), line:47:36, endln:47:41, parent:Command
-                |vpiName:trans
-                |vpiTypespec:
-                \_enum_typespec: (Transaction), line:37:5, endln:37:16, parent:trans
-                  |vpiName:Transaction
-                  |vpiBaseTypespec:
-                  \_bit_typespec: , line:33:16, endln:33:19, parent:Transaction
-                  |vpiEnumConst:
-                  \_enum_const: (WRITE), line:35:7, endln:35:12, parent:Transaction
-                    |vpiName:WRITE
-                    |vpiDecompile:0
-                    |UINT:0
-                    |vpiSize:64
-                  |vpiEnumConst:
-                  \_enum_const: (READ), line:36:7, endln:36:11, parent:Transaction
-                    |vpiName:READ
-                    |vpiDecompile:1
-                    |UINT:1
-                    |vpiSize:64
-              |vpiTypespecMember:
-              \_typespec_member: (burstcount), line:48:36, endln:48:46, parent:Command
-                |vpiName:burstcount
-                |vpiTypespec:
-                \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:burstcount
-                  |vpiName:Burstcount
-                  |vpiRange:
-                  \_range: , line:31:18, endln:31:29, parent:Burstcount
-                    |vpiLeftRange:
-                    \_operation: , line:31:18, endln:31:25
-                      |vpiOpType:11
-                      |vpiOperand:
-                      \_ref_obj: (work@test_program.actual_cmd.Command.burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                        |vpiName:BURST_W
-                        |vpiFullName:work@test_program.actual_cmd.Command.burstcount.Burstcount.BURST_W
-                        |vpiActual:
-                        \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                      |vpiOperand:
-                      \_constant: , line:31:26, endln:31:27
-                        |vpiConstType:9
-                        |vpiDecompile:1
-                        |vpiSize:64
-                        |UINT:1
-                    |vpiRightRange:
-                    \_constant: , line:31:28, endln:31:29
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-                  |vpiTypedefAlias:
-                  \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:Burstcount
-                    |vpiName:Burstcount
-                    |vpiRange:
-                    \_range: , line:31:18, endln:31:29, parent:Burstcount
-                      |vpiLeftRange:
-                      \_operation: , line:31:18, endln:31:25
-                        |vpiOpType:11
-                        |vpiOperand:
-                        \_ref_obj: (work@test_program.actual_cmd.Command.burstcount.Burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                          |vpiName:BURST_W
-                          |vpiFullName:work@test_program.actual_cmd.Command.burstcount.Burstcount.Burstcount.BURST_W
-                          |vpiActual:
-                          \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                        |vpiOperand:
-                        \_constant: , line:31:26, endln:31:27
-                          |vpiConstType:9
-                          |vpiDecompile:1
-                          |vpiSize:64
-                          |UINT:1
-                      |vpiRightRange:
-                      \_constant: , line:31:28, endln:31:29
-                        |vpiConstType:9
-                        |vpiDecompile:0
-                        |vpiSize:64
-                        |UINT:0
-              |vpiTypespecMember:
-              \_typespec_member: (addr), line:49:36, endln:49:40, parent:Command
-                |vpiName:addr
-                |vpiTypespec:
-                \_logic_typespec: , line:49:7, endln:49:12, parent:addr
-                  |vpiRange:
-                  \_range: , line:49:14, endln:49:25
-                    |vpiLeftRange:
-                    \_operation: , line:49:14, endln:49:20
-                      |vpiOpType:11
-                      |vpiOperand:
-                      \_ref_obj: (work@test_program.actual_cmd.Command.addr.ADDR_W), line:49:14, endln:49:20
-                        |vpiName:ADDR_W
-                        |vpiFullName:work@test_program.actual_cmd.Command.addr.ADDR_W
-                        |vpiActual:
-                        \_parameter: (work@test_program.ADDR_W), line:13:14, endln:13:43, parent:work@test_program
-                      |vpiOperand:
-                      \_constant: , line:49:21, endln:49:22
-                        |vpiConstType:9
-                        |vpiDecompile:1
-                        |vpiSize:64
-                        |UINT:1
-                    |vpiRightRange:
-                    \_constant: , line:49:24, endln:49:25
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-              |vpiTypespecMember:
-              \_typespec_member: (data), line:50:36, endln:50:40, parent:Command
-                |vpiName:data
-                |vpiTypespec:
-                \_logic_typespec: , line:50:7, endln:50:12, parent:data
-                  |vpiRange:
-                  \_range: , line:50:14, endln:50:24
-                    |vpiLeftRange:
-                    \_operation: , line:50:14, endln:50:20
-                      |vpiOpType:11
-                      |vpiOperand:
-                      \_ref_obj: (work@test_program.actual_cmd.Command.data.DATA_W), line:50:14, endln:50:20
-                        |vpiName:DATA_W
-                        |vpiFullName:work@test_program.actual_cmd.Command.data.DATA_W
-                        |vpiActual:
-                        \_parameter: (work@test_program.DATA_W), line:17:14, endln:17:63, parent:work@test_program
-                      |vpiOperand:
-                      \_constant: , line:50:21, endln:50:22
-                        |vpiConstType:9
-                        |vpiDecompile:1
-                        |vpiSize:64
-                        |UINT:1
-                    |vpiRightRange:
-                    \_constant: , line:50:23, endln:50:24
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-              |vpiTypespecMember:
-              \_typespec_member: (byteenable), line:51:36, endln:51:46, parent:Command
-                |vpiName:byteenable
-                |vpiTypespec:
-                \_logic_typespec: , line:51:7, endln:51:12, parent:byteenable
-                  |vpiRange:
-                  \_range: , line:51:14, endln:51:29
-                    |vpiLeftRange:
-                    \_operation: , line:51:14, endln:51:25
-                      |vpiOpType:11
-                      |vpiOperand:
-                      \_ref_obj: (work@test_program.actual_cmd.Command.byteenable.NUM_SYMBOLS), line:51:14, endln:51:25
-                        |vpiName:NUM_SYMBOLS
-                        |vpiFullName:work@test_program.actual_cmd.Command.byteenable.NUM_SYMBOLS
-                        |vpiActual:
-                        \_parameter: (work@test_program.NUM_SYMBOLS), line:16:14, endln:16:42, parent:work@test_program
-                      |vpiOperand:
-                      \_constant: , line:51:26, endln:51:27
-                        |vpiConstType:9
-                        |vpiDecompile:1
-                        |vpiSize:64
-                        |UINT:1
-                    |vpiRightRange:
-                    \_constant: , line:51:28, endln:51:29
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-              |vpiTypespecMember:
-              \_typespec_member: (cmd_delay), line:52:36, endln:52:45, parent:Command
-                |vpiName:cmd_delay
-                |vpiTypespec:
-                \_bit_typespec: , line:52:7, endln:52:10, parent:cmd_delay
-                  |vpiRange:
-                  \_range: , line:52:12, endln:52:16
-                    |vpiLeftRange:
-                    \_constant: , line:52:12, endln:52:14
-                      |vpiConstType:9
-                      |vpiDecompile:31
-                      |vpiSize:64
-                      |UINT:31
-                    |vpiRightRange:
-                    \_constant: , line:52:15, endln:52:16
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-              |vpiTypespecMember:
-              \_typespec_member: (data_idles), line:53:36, endln:53:46, parent:Command
-                |vpiName:data_idles
-                |vpiTypespec:
-                \_bit_typespec: , line:53:7, endln:53:10, parent:data_idles
-                  |vpiRange:
-                  \_range: , line:53:12, endln:53:16
-                    |vpiLeftRange:
-                    \_constant: , line:53:12, endln:53:14
-                      |vpiConstType:9
-                      |vpiDecompile:31
-                      |vpiSize:64
-                      |UINT:31
-                    |vpiRightRange:
-                    \_constant: , line:53:15, endln:53:16
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
+            \_struct_typespec: (Command), line:45:11, endln:45:17
         |vpiStmt:
         \_assign_stmt: , parent:work@test_program
           |vpiLhs:
@@ -13323,205 +12987,7 @@ design: (work@top)
             |vpiName:exp_cmd
             |vpiFullName:work@test_program.exp_cmd
             |vpiTypespec:
-            \_struct_typespec: (Command), line:45:11, endln:45:17, parent:work@test_program.exp_cmd
-              |vpiName:Command
-              |vpiTypespecMember:
-              \_typespec_member: (trans), line:47:36, endln:47:41, parent:Command
-                |vpiName:trans
-                |vpiTypespec:
-                \_enum_typespec: (Transaction), line:37:5, endln:37:16, parent:trans
-                  |vpiName:Transaction
-                  |vpiBaseTypespec:
-                  \_bit_typespec: , line:33:16, endln:33:19, parent:Transaction
-                  |vpiEnumConst:
-                  \_enum_const: (WRITE), line:35:7, endln:35:12, parent:Transaction
-                    |vpiName:WRITE
-                    |vpiDecompile:0
-                    |UINT:0
-                    |vpiSize:64
-                  |vpiEnumConst:
-                  \_enum_const: (READ), line:36:7, endln:36:11, parent:Transaction
-                    |vpiName:READ
-                    |vpiDecompile:1
-                    |UINT:1
-                    |vpiSize:64
-              |vpiTypespecMember:
-              \_typespec_member: (burstcount), line:48:36, endln:48:46, parent:Command
-                |vpiName:burstcount
-                |vpiTypespec:
-                \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:burstcount
-                  |vpiName:Burstcount
-                  |vpiRange:
-                  \_range: , line:31:18, endln:31:29, parent:Burstcount
-                    |vpiLeftRange:
-                    \_operation: , line:31:18, endln:31:25
-                      |vpiOpType:11
-                      |vpiOperand:
-                      \_ref_obj: (work@test_program.exp_cmd.Command.burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                        |vpiName:BURST_W
-                        |vpiFullName:work@test_program.exp_cmd.Command.burstcount.Burstcount.BURST_W
-                        |vpiActual:
-                        \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                      |vpiOperand:
-                      \_constant: , line:31:26, endln:31:27
-                        |vpiConstType:9
-                        |vpiDecompile:1
-                        |vpiSize:64
-                        |UINT:1
-                    |vpiRightRange:
-                    \_constant: , line:31:28, endln:31:29
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-                  |vpiTypedefAlias:
-                  \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:Burstcount
-                    |vpiName:Burstcount
-                    |vpiRange:
-                    \_range: , line:31:18, endln:31:29, parent:Burstcount
-                      |vpiLeftRange:
-                      \_operation: , line:31:18, endln:31:25
-                        |vpiOpType:11
-                        |vpiOperand:
-                        \_ref_obj: (work@test_program.exp_cmd.Command.burstcount.Burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                          |vpiName:BURST_W
-                          |vpiFullName:work@test_program.exp_cmd.Command.burstcount.Burstcount.Burstcount.BURST_W
-                          |vpiActual:
-                          \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                        |vpiOperand:
-                        \_constant: , line:31:26, endln:31:27
-                          |vpiConstType:9
-                          |vpiDecompile:1
-                          |vpiSize:64
-                          |UINT:1
-                      |vpiRightRange:
-                      \_constant: , line:31:28, endln:31:29
-                        |vpiConstType:9
-                        |vpiDecompile:0
-                        |vpiSize:64
-                        |UINT:0
-              |vpiTypespecMember:
-              \_typespec_member: (addr), line:49:36, endln:49:40, parent:Command
-                |vpiName:addr
-                |vpiTypespec:
-                \_logic_typespec: , line:49:7, endln:49:12, parent:addr
-                  |vpiRange:
-                  \_range: , line:49:14, endln:49:25
-                    |vpiLeftRange:
-                    \_operation: , line:49:14, endln:49:20
-                      |vpiOpType:11
-                      |vpiOperand:
-                      \_ref_obj: (work@test_program.exp_cmd.Command.addr.ADDR_W), line:49:14, endln:49:20
-                        |vpiName:ADDR_W
-                        |vpiFullName:work@test_program.exp_cmd.Command.addr.ADDR_W
-                        |vpiActual:
-                        \_parameter: (work@test_program.ADDR_W), line:13:14, endln:13:43, parent:work@test_program
-                      |vpiOperand:
-                      \_constant: , line:49:21, endln:49:22
-                        |vpiConstType:9
-                        |vpiDecompile:1
-                        |vpiSize:64
-                        |UINT:1
-                    |vpiRightRange:
-                    \_constant: , line:49:24, endln:49:25
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-              |vpiTypespecMember:
-              \_typespec_member: (data), line:50:36, endln:50:40, parent:Command
-                |vpiName:data
-                |vpiTypespec:
-                \_logic_typespec: , line:50:7, endln:50:12, parent:data
-                  |vpiRange:
-                  \_range: , line:50:14, endln:50:24
-                    |vpiLeftRange:
-                    \_operation: , line:50:14, endln:50:20
-                      |vpiOpType:11
-                      |vpiOperand:
-                      \_ref_obj: (work@test_program.exp_cmd.Command.data.DATA_W), line:50:14, endln:50:20
-                        |vpiName:DATA_W
-                        |vpiFullName:work@test_program.exp_cmd.Command.data.DATA_W
-                        |vpiActual:
-                        \_parameter: (work@test_program.DATA_W), line:17:14, endln:17:63, parent:work@test_program
-                      |vpiOperand:
-                      \_constant: , line:50:21, endln:50:22
-                        |vpiConstType:9
-                        |vpiDecompile:1
-                        |vpiSize:64
-                        |UINT:1
-                    |vpiRightRange:
-                    \_constant: , line:50:23, endln:50:24
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-              |vpiTypespecMember:
-              \_typespec_member: (byteenable), line:51:36, endln:51:46, parent:Command
-                |vpiName:byteenable
-                |vpiTypespec:
-                \_logic_typespec: , line:51:7, endln:51:12, parent:byteenable
-                  |vpiRange:
-                  \_range: , line:51:14, endln:51:29
-                    |vpiLeftRange:
-                    \_operation: , line:51:14, endln:51:25
-                      |vpiOpType:11
-                      |vpiOperand:
-                      \_ref_obj: (work@test_program.exp_cmd.Command.byteenable.NUM_SYMBOLS), line:51:14, endln:51:25
-                        |vpiName:NUM_SYMBOLS
-                        |vpiFullName:work@test_program.exp_cmd.Command.byteenable.NUM_SYMBOLS
-                        |vpiActual:
-                        \_parameter: (work@test_program.NUM_SYMBOLS), line:16:14, endln:16:42, parent:work@test_program
-                      |vpiOperand:
-                      \_constant: , line:51:26, endln:51:27
-                        |vpiConstType:9
-                        |vpiDecompile:1
-                        |vpiSize:64
-                        |UINT:1
-                    |vpiRightRange:
-                    \_constant: , line:51:28, endln:51:29
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-              |vpiTypespecMember:
-              \_typespec_member: (cmd_delay), line:52:36, endln:52:45, parent:Command
-                |vpiName:cmd_delay
-                |vpiTypespec:
-                \_bit_typespec: , line:52:7, endln:52:10, parent:cmd_delay
-                  |vpiRange:
-                  \_range: , line:52:12, endln:52:16
-                    |vpiLeftRange:
-                    \_constant: , line:52:12, endln:52:14
-                      |vpiConstType:9
-                      |vpiDecompile:31
-                      |vpiSize:64
-                      |UINT:31
-                    |vpiRightRange:
-                    \_constant: , line:52:15, endln:52:16
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-              |vpiTypespecMember:
-              \_typespec_member: (data_idles), line:53:36, endln:53:46, parent:Command
-                |vpiName:data_idles
-                |vpiTypespec:
-                \_bit_typespec: , line:53:7, endln:53:10, parent:data_idles
-                  |vpiRange:
-                  \_range: , line:53:12, endln:53:16
-                    |vpiLeftRange:
-                    \_constant: , line:53:12, endln:53:14
-                      |vpiConstType:9
-                      |vpiDecompile:31
-                      |vpiSize:64
-                      |UINT:31
-                    |vpiRightRange:
-                    \_constant: , line:53:15, endln:53:16
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
+            \_struct_typespec: (Command), line:45:11, endln:45:17
         |vpiStmt:
         \_assign_stmt: , parent:work@test_program
           |vpiLhs:
@@ -13529,110 +12995,7 @@ design: (work@top)
             |vpiName:rsp
             |vpiFullName:work@test_program.rsp
             |vpiTypespec:
-            \_struct_typespec: (Response), line:56:11, endln:56:17, parent:work@test_program.rsp
-              |vpiName:Response
-              |vpiTypespecMember:
-              \_typespec_member: (burstcount), line:58:36, endln:58:46, parent:Response
-                |vpiName:burstcount
-                |vpiTypespec:
-                \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:burstcount
-                  |vpiName:Burstcount
-                  |vpiRange:
-                  \_range: , line:31:18, endln:31:29, parent:Burstcount
-                    |vpiLeftRange:
-                    \_operation: , line:31:18, endln:31:25
-                      |vpiOpType:11
-                      |vpiOperand:
-                      \_ref_obj: (work@test_program.rsp.Response.burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                        |vpiName:BURST_W
-                        |vpiFullName:work@test_program.rsp.Response.burstcount.Burstcount.BURST_W
-                        |vpiActual:
-                        \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                      |vpiOperand:
-                      \_constant: , line:31:26, endln:31:27
-                        |vpiConstType:9
-                        |vpiDecompile:1
-                        |vpiSize:64
-                        |UINT:1
-                    |vpiRightRange:
-                    \_constant: , line:31:28, endln:31:29
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-                  |vpiTypedefAlias:
-                  \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:Burstcount
-                    |vpiName:Burstcount
-                    |vpiRange:
-                    \_range: , line:31:18, endln:31:29, parent:Burstcount
-                      |vpiLeftRange:
-                      \_operation: , line:31:18, endln:31:25
-                        |vpiOpType:11
-                        |vpiOperand:
-                        \_ref_obj: (work@test_program.rsp.Response.burstcount.Burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                          |vpiName:BURST_W
-                          |vpiFullName:work@test_program.rsp.Response.burstcount.Burstcount.Burstcount.BURST_W
-                          |vpiActual:
-                          \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                        |vpiOperand:
-                        \_constant: , line:31:26, endln:31:27
-                          |vpiConstType:9
-                          |vpiDecompile:1
-                          |vpiSize:64
-                          |UINT:1
-                      |vpiRightRange:
-                      \_constant: , line:31:28, endln:31:29
-                        |vpiConstType:9
-                        |vpiDecompile:0
-                        |vpiSize:64
-                        |UINT:0
-              |vpiTypespecMember:
-              \_typespec_member: (data), line:59:36, endln:59:40, parent:Response
-                |vpiName:data
-                |vpiTypespec:
-                \_logic_typespec: , line:59:6, endln:59:11, parent:data
-                  |vpiRange:
-                  \_range: , line:59:13, endln:59:23
-                    |vpiLeftRange:
-                    \_operation: , line:59:13, endln:59:19
-                      |vpiOpType:11
-                      |vpiOperand:
-                      \_ref_obj: (work@test_program.rsp.Response.data.DATA_W), line:59:13, endln:59:19
-                        |vpiName:DATA_W
-                        |vpiFullName:work@test_program.rsp.Response.data.DATA_W
-                        |vpiActual:
-                        \_parameter: (work@test_program.DATA_W), line:17:14, endln:17:63, parent:work@test_program
-                      |vpiOperand:
-                      \_constant: , line:59:20, endln:59:21
-                        |vpiConstType:9
-                        |vpiDecompile:1
-                        |vpiSize:64
-                        |UINT:1
-                    |vpiRightRange:
-                    \_constant: , line:59:22, endln:59:23
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-              |vpiTypespecMember:
-              \_typespec_member: (latency), line:60:36, endln:60:43, parent:Response
-                |vpiName:latency
-                |vpiTypespec:
-                \_bit_typespec: , line:60:6, endln:60:9, parent:latency
-                  |vpiRange:
-                  \_range: , line:60:11, endln:60:15
-                    |vpiLeftRange:
-                    \_constant: , line:60:11, endln:60:13
-                      |vpiConstType:9
-                      |vpiDecompile:31
-                      |vpiSize:64
-                      |UINT:31
-                    |vpiRightRange:
-                    \_constant: , line:60:14, endln:60:15
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
+            \_struct_typespec: (Response), line:56:11, endln:56:17
         |vpiStmt:
         \_assign_stmt: , parent:work@test_program
           |vpiLhs:
@@ -13694,7 +13057,7 @@ design: (work@top)
               \_sys_func_call: ($urandom_range), line:291:31, endln:291:74
                 |vpiName:$urandom_range
                 |vpiArgument:
-                \_constant: , line:291:46, endln:291:47, parent:$urandom_range
+                \_constant: , line:291:46, endln:291:47
                   |vpiConstType:9
                   |vpiDecompile:0
                   |vpiSize:64
@@ -13751,7 +13114,7 @@ design: (work@top)
               |vpiName:actual_cmd
               |vpiFullName:work@test_program.actual_cmd
             |vpiArgument:
-            \_constant: , line:296:59, endln:296:60, parent:get_expected_command_for_slave
+            \_constant: , line:296:59, endln:296:60
               |vpiConstType:9
               |vpiDecompile:0
               |vpiSize:64
@@ -13789,10 +13152,6 @@ design: (work@top)
               |vpiFullName:work@test_program.READ
               |vpiActual:
               \_enum_const: (READ), line:36:7, endln:36:11
-                |vpiName:READ
-                |vpiDecompile:1
-                |UINT:1
-                |vpiSize:64
           |vpiStmt:
           \_begin: (work@test_program), line:300:36, endln:304:9
             |vpiFullName:work@test_program
@@ -13849,104 +13208,6 @@ design: (work@top)
                     |vpiVisibility:1
                     |vpiTypespec:
                     \_struct_typespec: (Response), line:56:11, endln:56:17
-                      |vpiName:Response
-                      |vpiTypespecMember:
-                      \_typespec_member: (burstcount), line:58:36, endln:58:46
-                        |vpiName:burstcount
-                        |vpiTypespec:
-                        \_logic_typespec: (Burstcount), line:31:11, endln:31:16
-                          |vpiName:Burstcount
-                          |vpiRange:
-                          \_range: , line:31:18, endln:31:29, parent:Burstcount
-                            |vpiLeftRange:
-                            \_operation: , line:31:18, endln:31:25
-                              |vpiOpType:11
-                              |vpiOperand:
-                              \_ref_obj: (Burstcount.BURST_W), line:31:18, endln:31:25
-                                |vpiName:BURST_W
-                                |vpiFullName:Burstcount.BURST_W
-                              |vpiOperand:
-                              \_constant: , line:31:26, endln:31:27
-                                |vpiConstType:9
-                                |vpiDecompile:1
-                                |vpiSize:64
-                                |UINT:1
-                            |vpiRightRange:
-                            \_constant: , line:31:28, endln:31:29
-                              |vpiConstType:9
-                              |vpiDecompile:0
-                              |vpiSize:64
-                              |UINT:0
-                          |vpiTypedefAlias:
-                          \_logic_typespec: (Burstcount), line:31:11, endln:31:16
-                            |vpiName:Burstcount
-                            |vpiRange:
-                            \_range: , line:31:18, endln:31:29
-                              |vpiLeftRange:
-                              \_operation: , line:31:18, endln:31:25
-                                |vpiOpType:11
-                                |vpiOperand:
-                                \_ref_obj: (BURST_W), line:31:18, endln:31:25
-                                  |vpiName:BURST_W
-                                |vpiOperand:
-                                \_constant: , line:31:26, endln:31:27
-                                  |vpiConstType:9
-                                  |vpiDecompile:1
-                                  |vpiSize:64
-                                  |UINT:1
-                              |vpiRightRange:
-                              \_constant: , line:31:28, endln:31:29
-                                |vpiConstType:9
-                                |vpiDecompile:0
-                                |vpiSize:64
-                                |UINT:0
-                      |vpiTypespecMember:
-                      \_typespec_member: (data), line:59:36, endln:59:40
-                        |vpiName:data
-                        |vpiTypespec:
-                        \_logic_typespec: , line:59:6, endln:59:11
-                          |vpiRange:
-                          \_range: , line:59:13, endln:59:23, parent:Response
-                            |vpiLeftRange:
-                            \_operation: , line:59:13, endln:59:19
-                              |vpiOpType:11
-                              |vpiOperand:
-                              \_ref_obj: (Response.DATA_W), line:59:13, endln:59:19, parent:Response
-                                |vpiName:DATA_W
-                                |vpiFullName:Response.DATA_W
-                                |vpiActual:
-                                \_parameter: (work@test_program.DATA_W), line:17:14, endln:17:63, parent:work@test_program
-                              |vpiOperand:
-                              \_constant: , line:59:20, endln:59:21
-                                |vpiConstType:9
-                                |vpiDecompile:1
-                                |vpiSize:64
-                                |UINT:1
-                            |vpiRightRange:
-                            \_constant: , line:59:22, endln:59:23
-                              |vpiConstType:9
-                              |vpiDecompile:0
-                              |vpiSize:64
-                              |UINT:0
-                      |vpiTypespecMember:
-                      \_typespec_member: (latency), line:60:36, endln:60:43
-                        |vpiName:latency
-                        |vpiTypespec:
-                        \_bit_typespec: , line:60:6, endln:60:9
-                          |vpiRange:
-                          \_range: , line:60:11, endln:60:15, parent:Response
-                            |vpiLeftRange:
-                            \_constant: , line:60:11, endln:60:13
-                              |vpiConstType:9
-                              |vpiDecompile:31
-                              |vpiSize:64
-                              |UINT:31
-                            |vpiRightRange:
-                            \_constant: , line:60:14, endln:60:15
-                              |vpiConstType:9
-                              |vpiDecompile:0
-                              |vpiSize:64
-                              |UINT:0
                   |vpiRange:
                   \_range: , line:75:35, endln:75:36
                     |vpiLeftRange:
@@ -14087,205 +13348,7 @@ design: (work@top)
             |vpiName:cmd
             |vpiFullName:work@test_program.cmd
             |vpiTypespec:
-            \_struct_typespec: (Command), line:45:11, endln:45:17, parent:work@test_program.cmd
-              |vpiName:Command
-              |vpiTypespecMember:
-              \_typespec_member: (trans), line:47:36, endln:47:41, parent:Command
-                |vpiName:trans
-                |vpiTypespec:
-                \_enum_typespec: (Transaction), line:37:5, endln:37:16, parent:trans
-                  |vpiName:Transaction
-                  |vpiBaseTypespec:
-                  \_bit_typespec: , line:33:16, endln:33:19, parent:Transaction
-                  |vpiEnumConst:
-                  \_enum_const: (WRITE), line:35:7, endln:35:12, parent:Transaction
-                    |vpiName:WRITE
-                    |vpiDecompile:0
-                    |UINT:0
-                    |vpiSize:64
-                  |vpiEnumConst:
-                  \_enum_const: (READ), line:36:7, endln:36:11, parent:Transaction
-                    |vpiName:READ
-                    |vpiDecompile:1
-                    |UINT:1
-                    |vpiSize:64
-              |vpiTypespecMember:
-              \_typespec_member: (burstcount), line:48:36, endln:48:46, parent:Command
-                |vpiName:burstcount
-                |vpiTypespec:
-                \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:burstcount
-                  |vpiName:Burstcount
-                  |vpiRange:
-                  \_range: , line:31:18, endln:31:29, parent:Burstcount
-                    |vpiLeftRange:
-                    \_operation: , line:31:18, endln:31:25
-                      |vpiOpType:11
-                      |vpiOperand:
-                      \_ref_obj: (work@test_program.cmd.Command.burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                        |vpiName:BURST_W
-                        |vpiFullName:work@test_program.cmd.Command.burstcount.Burstcount.BURST_W
-                        |vpiActual:
-                        \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                      |vpiOperand:
-                      \_constant: , line:31:26, endln:31:27
-                        |vpiConstType:9
-                        |vpiDecompile:1
-                        |vpiSize:64
-                        |UINT:1
-                    |vpiRightRange:
-                    \_constant: , line:31:28, endln:31:29
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-                  |vpiTypedefAlias:
-                  \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:Burstcount
-                    |vpiName:Burstcount
-                    |vpiRange:
-                    \_range: , line:31:18, endln:31:29, parent:Burstcount
-                      |vpiLeftRange:
-                      \_operation: , line:31:18, endln:31:25
-                        |vpiOpType:11
-                        |vpiOperand:
-                        \_ref_obj: (work@test_program.cmd.Command.burstcount.Burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                          |vpiName:BURST_W
-                          |vpiFullName:work@test_program.cmd.Command.burstcount.Burstcount.Burstcount.BURST_W
-                          |vpiActual:
-                          \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                        |vpiOperand:
-                        \_constant: , line:31:26, endln:31:27
-                          |vpiConstType:9
-                          |vpiDecompile:1
-                          |vpiSize:64
-                          |UINT:1
-                      |vpiRightRange:
-                      \_constant: , line:31:28, endln:31:29
-                        |vpiConstType:9
-                        |vpiDecompile:0
-                        |vpiSize:64
-                        |UINT:0
-              |vpiTypespecMember:
-              \_typespec_member: (addr), line:49:36, endln:49:40, parent:Command
-                |vpiName:addr
-                |vpiTypespec:
-                \_logic_typespec: , line:49:7, endln:49:12, parent:addr
-                  |vpiRange:
-                  \_range: , line:49:14, endln:49:25
-                    |vpiLeftRange:
-                    \_operation: , line:49:14, endln:49:20
-                      |vpiOpType:11
-                      |vpiOperand:
-                      \_ref_obj: (work@test_program.cmd.Command.addr.ADDR_W), line:49:14, endln:49:20
-                        |vpiName:ADDR_W
-                        |vpiFullName:work@test_program.cmd.Command.addr.ADDR_W
-                        |vpiActual:
-                        \_parameter: (work@test_program.ADDR_W), line:13:14, endln:13:43, parent:work@test_program
-                      |vpiOperand:
-                      \_constant: , line:49:21, endln:49:22
-                        |vpiConstType:9
-                        |vpiDecompile:1
-                        |vpiSize:64
-                        |UINT:1
-                    |vpiRightRange:
-                    \_constant: , line:49:24, endln:49:25
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-              |vpiTypespecMember:
-              \_typespec_member: (data), line:50:36, endln:50:40, parent:Command
-                |vpiName:data
-                |vpiTypespec:
-                \_logic_typespec: , line:50:7, endln:50:12, parent:data
-                  |vpiRange:
-                  \_range: , line:50:14, endln:50:24
-                    |vpiLeftRange:
-                    \_operation: , line:50:14, endln:50:20
-                      |vpiOpType:11
-                      |vpiOperand:
-                      \_ref_obj: (work@test_program.cmd.Command.data.DATA_W), line:50:14, endln:50:20
-                        |vpiName:DATA_W
-                        |vpiFullName:work@test_program.cmd.Command.data.DATA_W
-                        |vpiActual:
-                        \_parameter: (work@test_program.DATA_W), line:17:14, endln:17:63, parent:work@test_program
-                      |vpiOperand:
-                      \_constant: , line:50:21, endln:50:22
-                        |vpiConstType:9
-                        |vpiDecompile:1
-                        |vpiSize:64
-                        |UINT:1
-                    |vpiRightRange:
-                    \_constant: , line:50:23, endln:50:24
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-              |vpiTypespecMember:
-              \_typespec_member: (byteenable), line:51:36, endln:51:46, parent:Command
-                |vpiName:byteenable
-                |vpiTypespec:
-                \_logic_typespec: , line:51:7, endln:51:12, parent:byteenable
-                  |vpiRange:
-                  \_range: , line:51:14, endln:51:29
-                    |vpiLeftRange:
-                    \_operation: , line:51:14, endln:51:25
-                      |vpiOpType:11
-                      |vpiOperand:
-                      \_ref_obj: (work@test_program.cmd.Command.byteenable.NUM_SYMBOLS), line:51:14, endln:51:25
-                        |vpiName:NUM_SYMBOLS
-                        |vpiFullName:work@test_program.cmd.Command.byteenable.NUM_SYMBOLS
-                        |vpiActual:
-                        \_parameter: (work@test_program.NUM_SYMBOLS), line:16:14, endln:16:42, parent:work@test_program
-                      |vpiOperand:
-                      \_constant: , line:51:26, endln:51:27
-                        |vpiConstType:9
-                        |vpiDecompile:1
-                        |vpiSize:64
-                        |UINT:1
-                    |vpiRightRange:
-                    \_constant: , line:51:28, endln:51:29
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-              |vpiTypespecMember:
-              \_typespec_member: (cmd_delay), line:52:36, endln:52:45, parent:Command
-                |vpiName:cmd_delay
-                |vpiTypespec:
-                \_bit_typespec: , line:52:7, endln:52:10, parent:cmd_delay
-                  |vpiRange:
-                  \_range: , line:52:12, endln:52:16
-                    |vpiLeftRange:
-                    \_constant: , line:52:12, endln:52:14
-                      |vpiConstType:9
-                      |vpiDecompile:31
-                      |vpiSize:64
-                      |UINT:31
-                    |vpiRightRange:
-                    \_constant: , line:52:15, endln:52:16
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-              |vpiTypespecMember:
-              \_typespec_member: (data_idles), line:53:36, endln:53:46, parent:Command
-                |vpiName:data_idles
-                |vpiTypespec:
-                \_bit_typespec: , line:53:7, endln:53:10, parent:data_idles
-                  |vpiRange:
-                  \_range: , line:53:12, endln:53:16
-                    |vpiLeftRange:
-                    \_constant: , line:53:12, endln:53:14
-                      |vpiConstType:9
-                      |vpiDecompile:31
-                      |vpiSize:64
-                      |UINT:31
-                    |vpiRightRange:
-                    \_constant: , line:53:15, endln:53:16
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
+            \_struct_typespec: (Command), line:45:11, endln:45:17
         |vpiStmt:
         \_assign_stmt: , parent:work@test_program
           |vpiLhs:
@@ -14293,110 +13356,7 @@ design: (work@top)
             |vpiName:actual_rsp
             |vpiFullName:work@test_program.actual_rsp
             |vpiTypespec:
-            \_struct_typespec: (Response), line:56:11, endln:56:17, parent:work@test_program.actual_rsp
-              |vpiName:Response
-              |vpiTypespecMember:
-              \_typespec_member: (burstcount), line:58:36, endln:58:46, parent:Response
-                |vpiName:burstcount
-                |vpiTypespec:
-                \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:burstcount
-                  |vpiName:Burstcount
-                  |vpiRange:
-                  \_range: , line:31:18, endln:31:29, parent:Burstcount
-                    |vpiLeftRange:
-                    \_operation: , line:31:18, endln:31:25
-                      |vpiOpType:11
-                      |vpiOperand:
-                      \_ref_obj: (work@test_program.actual_rsp.Response.burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                        |vpiName:BURST_W
-                        |vpiFullName:work@test_program.actual_rsp.Response.burstcount.Burstcount.BURST_W
-                        |vpiActual:
-                        \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                      |vpiOperand:
-                      \_constant: , line:31:26, endln:31:27
-                        |vpiConstType:9
-                        |vpiDecompile:1
-                        |vpiSize:64
-                        |UINT:1
-                    |vpiRightRange:
-                    \_constant: , line:31:28, endln:31:29
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-                  |vpiTypedefAlias:
-                  \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:Burstcount
-                    |vpiName:Burstcount
-                    |vpiRange:
-                    \_range: , line:31:18, endln:31:29, parent:Burstcount
-                      |vpiLeftRange:
-                      \_operation: , line:31:18, endln:31:25
-                        |vpiOpType:11
-                        |vpiOperand:
-                        \_ref_obj: (work@test_program.actual_rsp.Response.burstcount.Burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                          |vpiName:BURST_W
-                          |vpiFullName:work@test_program.actual_rsp.Response.burstcount.Burstcount.Burstcount.BURST_W
-                          |vpiActual:
-                          \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                        |vpiOperand:
-                        \_constant: , line:31:26, endln:31:27
-                          |vpiConstType:9
-                          |vpiDecompile:1
-                          |vpiSize:64
-                          |UINT:1
-                      |vpiRightRange:
-                      \_constant: , line:31:28, endln:31:29
-                        |vpiConstType:9
-                        |vpiDecompile:0
-                        |vpiSize:64
-                        |UINT:0
-              |vpiTypespecMember:
-              \_typespec_member: (data), line:59:36, endln:59:40, parent:Response
-                |vpiName:data
-                |vpiTypespec:
-                \_logic_typespec: , line:59:6, endln:59:11, parent:data
-                  |vpiRange:
-                  \_range: , line:59:13, endln:59:23
-                    |vpiLeftRange:
-                    \_operation: , line:59:13, endln:59:19
-                      |vpiOpType:11
-                      |vpiOperand:
-                      \_ref_obj: (work@test_program.actual_rsp.Response.data.DATA_W), line:59:13, endln:59:19
-                        |vpiName:DATA_W
-                        |vpiFullName:work@test_program.actual_rsp.Response.data.DATA_W
-                        |vpiActual:
-                        \_parameter: (work@test_program.DATA_W), line:17:14, endln:17:63, parent:work@test_program
-                      |vpiOperand:
-                      \_constant: , line:59:20, endln:59:21
-                        |vpiConstType:9
-                        |vpiDecompile:1
-                        |vpiSize:64
-                        |UINT:1
-                    |vpiRightRange:
-                    \_constant: , line:59:22, endln:59:23
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-              |vpiTypespecMember:
-              \_typespec_member: (latency), line:60:36, endln:60:43, parent:Response
-                |vpiName:latency
-                |vpiTypespec:
-                \_bit_typespec: , line:60:6, endln:60:9, parent:latency
-                  |vpiRange:
-                  \_range: , line:60:11, endln:60:15
-                    |vpiLeftRange:
-                    \_constant: , line:60:11, endln:60:13
-                      |vpiConstType:9
-                      |vpiDecompile:31
-                      |vpiSize:64
-                      |UINT:31
-                    |vpiRightRange:
-                    \_constant: , line:60:14, endln:60:15
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
+            \_struct_typespec: (Response), line:56:11, endln:56:17
         |vpiStmt:
         \_assign_stmt: , parent:work@test_program
           |vpiLhs:
@@ -14404,110 +13364,7 @@ design: (work@top)
             |vpiName:exp_rsp
             |vpiFullName:work@test_program.exp_rsp
             |vpiTypespec:
-            \_struct_typespec: (Response), line:56:11, endln:56:17, parent:work@test_program.exp_rsp
-              |vpiName:Response
-              |vpiTypespecMember:
-              \_typespec_member: (burstcount), line:58:36, endln:58:46, parent:Response
-                |vpiName:burstcount
-                |vpiTypespec:
-                \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:burstcount
-                  |vpiName:Burstcount
-                  |vpiRange:
-                  \_range: , line:31:18, endln:31:29, parent:Burstcount
-                    |vpiLeftRange:
-                    \_operation: , line:31:18, endln:31:25
-                      |vpiOpType:11
-                      |vpiOperand:
-                      \_ref_obj: (work@test_program.exp_rsp.Response.burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                        |vpiName:BURST_W
-                        |vpiFullName:work@test_program.exp_rsp.Response.burstcount.Burstcount.BURST_W
-                        |vpiActual:
-                        \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                      |vpiOperand:
-                      \_constant: , line:31:26, endln:31:27
-                        |vpiConstType:9
-                        |vpiDecompile:1
-                        |vpiSize:64
-                        |UINT:1
-                    |vpiRightRange:
-                    \_constant: , line:31:28, endln:31:29
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-                  |vpiTypedefAlias:
-                  \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:Burstcount
-                    |vpiName:Burstcount
-                    |vpiRange:
-                    \_range: , line:31:18, endln:31:29, parent:Burstcount
-                      |vpiLeftRange:
-                      \_operation: , line:31:18, endln:31:25
-                        |vpiOpType:11
-                        |vpiOperand:
-                        \_ref_obj: (work@test_program.exp_rsp.Response.burstcount.Burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                          |vpiName:BURST_W
-                          |vpiFullName:work@test_program.exp_rsp.Response.burstcount.Burstcount.Burstcount.BURST_W
-                          |vpiActual:
-                          \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                        |vpiOperand:
-                        \_constant: , line:31:26, endln:31:27
-                          |vpiConstType:9
-                          |vpiDecompile:1
-                          |vpiSize:64
-                          |UINT:1
-                      |vpiRightRange:
-                      \_constant: , line:31:28, endln:31:29
-                        |vpiConstType:9
-                        |vpiDecompile:0
-                        |vpiSize:64
-                        |UINT:0
-              |vpiTypespecMember:
-              \_typespec_member: (data), line:59:36, endln:59:40, parent:Response
-                |vpiName:data
-                |vpiTypespec:
-                \_logic_typespec: , line:59:6, endln:59:11, parent:data
-                  |vpiRange:
-                  \_range: , line:59:13, endln:59:23
-                    |vpiLeftRange:
-                    \_operation: , line:59:13, endln:59:19
-                      |vpiOpType:11
-                      |vpiOperand:
-                      \_ref_obj: (work@test_program.exp_rsp.Response.data.DATA_W), line:59:13, endln:59:19
-                        |vpiName:DATA_W
-                        |vpiFullName:work@test_program.exp_rsp.Response.data.DATA_W
-                        |vpiActual:
-                        \_parameter: (work@test_program.DATA_W), line:17:14, endln:17:63, parent:work@test_program
-                      |vpiOperand:
-                      \_constant: , line:59:20, endln:59:21
-                        |vpiConstType:9
-                        |vpiDecompile:1
-                        |vpiSize:64
-                        |UINT:1
-                    |vpiRightRange:
-                    \_constant: , line:59:22, endln:59:23
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-              |vpiTypespecMember:
-              \_typespec_member: (latency), line:60:36, endln:60:43, parent:Response
-                |vpiName:latency
-                |vpiTypespec:
-                \_bit_typespec: , line:60:6, endln:60:9, parent:latency
-                  |vpiRange:
-                  \_range: , line:60:11, endln:60:15
-                    |vpiLeftRange:
-                    \_constant: , line:60:11, endln:60:13
-                      |vpiConstType:9
-                      |vpiDecompile:31
-                      |vpiSize:64
-                      |UINT:31
-                    |vpiRightRange:
-                    \_constant: , line:60:14, endln:60:15
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
+            \_struct_typespec: (Response), line:56:11, endln:56:17
         |vpiStmt:
         \_assignment: , line:397:6, endln:397:52, parent:work@test_program
           |vpiOpType:82
@@ -14523,7 +13380,7 @@ design: (work@top)
             \_bit_select: (read_command_queue_master), parent:read_command_queue_master[1].pop_front
               |vpiName:read_command_queue_master
               |vpiIndex:
-              \_constant: , line:397:38, endln:397:39, parent:read_command_queue_master
+              \_constant: , line:397:38, endln:397:39
                 |vpiConstType:9
                 |vpiDecompile:1
                 |vpiSize:64
@@ -14638,205 +13495,7 @@ design: (work@top)
             |vpiName:actual_cmd
             |vpiFullName:work@test_program.actual_cmd
             |vpiTypespec:
-            \_struct_typespec: (Command), line:45:11, endln:45:17, parent:work@test_program.actual_cmd
-              |vpiName:Command
-              |vpiTypespecMember:
-              \_typespec_member: (trans), line:47:36, endln:47:41, parent:Command
-                |vpiName:trans
-                |vpiTypespec:
-                \_enum_typespec: (Transaction), line:37:5, endln:37:16, parent:trans
-                  |vpiName:Transaction
-                  |vpiBaseTypespec:
-                  \_bit_typespec: , line:33:16, endln:33:19, parent:Transaction
-                  |vpiEnumConst:
-                  \_enum_const: (WRITE), line:35:7, endln:35:12, parent:Transaction
-                    |vpiName:WRITE
-                    |vpiDecompile:0
-                    |UINT:0
-                    |vpiSize:64
-                  |vpiEnumConst:
-                  \_enum_const: (READ), line:36:7, endln:36:11, parent:Transaction
-                    |vpiName:READ
-                    |vpiDecompile:1
-                    |UINT:1
-                    |vpiSize:64
-              |vpiTypespecMember:
-              \_typespec_member: (burstcount), line:48:36, endln:48:46, parent:Command
-                |vpiName:burstcount
-                |vpiTypespec:
-                \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:burstcount
-                  |vpiName:Burstcount
-                  |vpiRange:
-                  \_range: , line:31:18, endln:31:29, parent:Burstcount
-                    |vpiLeftRange:
-                    \_operation: , line:31:18, endln:31:25
-                      |vpiOpType:11
-                      |vpiOperand:
-                      \_ref_obj: (work@test_program.actual_cmd.Command.burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                        |vpiName:BURST_W
-                        |vpiFullName:work@test_program.actual_cmd.Command.burstcount.Burstcount.BURST_W
-                        |vpiActual:
-                        \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                      |vpiOperand:
-                      \_constant: , line:31:26, endln:31:27
-                        |vpiConstType:9
-                        |vpiDecompile:1
-                        |vpiSize:64
-                        |UINT:1
-                    |vpiRightRange:
-                    \_constant: , line:31:28, endln:31:29
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-                  |vpiTypedefAlias:
-                  \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:Burstcount
-                    |vpiName:Burstcount
-                    |vpiRange:
-                    \_range: , line:31:18, endln:31:29, parent:Burstcount
-                      |vpiLeftRange:
-                      \_operation: , line:31:18, endln:31:25
-                        |vpiOpType:11
-                        |vpiOperand:
-                        \_ref_obj: (work@test_program.actual_cmd.Command.burstcount.Burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                          |vpiName:BURST_W
-                          |vpiFullName:work@test_program.actual_cmd.Command.burstcount.Burstcount.Burstcount.BURST_W
-                          |vpiActual:
-                          \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                        |vpiOperand:
-                        \_constant: , line:31:26, endln:31:27
-                          |vpiConstType:9
-                          |vpiDecompile:1
-                          |vpiSize:64
-                          |UINT:1
-                      |vpiRightRange:
-                      \_constant: , line:31:28, endln:31:29
-                        |vpiConstType:9
-                        |vpiDecompile:0
-                        |vpiSize:64
-                        |UINT:0
-              |vpiTypespecMember:
-              \_typespec_member: (addr), line:49:36, endln:49:40, parent:Command
-                |vpiName:addr
-                |vpiTypespec:
-                \_logic_typespec: , line:49:7, endln:49:12, parent:addr
-                  |vpiRange:
-                  \_range: , line:49:14, endln:49:25
-                    |vpiLeftRange:
-                    \_operation: , line:49:14, endln:49:20
-                      |vpiOpType:11
-                      |vpiOperand:
-                      \_ref_obj: (work@test_program.actual_cmd.Command.addr.ADDR_W), line:49:14, endln:49:20
-                        |vpiName:ADDR_W
-                        |vpiFullName:work@test_program.actual_cmd.Command.addr.ADDR_W
-                        |vpiActual:
-                        \_parameter: (work@test_program.ADDR_W), line:13:14, endln:13:43, parent:work@test_program
-                      |vpiOperand:
-                      \_constant: , line:49:21, endln:49:22
-                        |vpiConstType:9
-                        |vpiDecompile:1
-                        |vpiSize:64
-                        |UINT:1
-                    |vpiRightRange:
-                    \_constant: , line:49:24, endln:49:25
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-              |vpiTypespecMember:
-              \_typespec_member: (data), line:50:36, endln:50:40, parent:Command
-                |vpiName:data
-                |vpiTypespec:
-                \_logic_typespec: , line:50:7, endln:50:12, parent:data
-                  |vpiRange:
-                  \_range: , line:50:14, endln:50:24
-                    |vpiLeftRange:
-                    \_operation: , line:50:14, endln:50:20
-                      |vpiOpType:11
-                      |vpiOperand:
-                      \_ref_obj: (work@test_program.actual_cmd.Command.data.DATA_W), line:50:14, endln:50:20
-                        |vpiName:DATA_W
-                        |vpiFullName:work@test_program.actual_cmd.Command.data.DATA_W
-                        |vpiActual:
-                        \_parameter: (work@test_program.DATA_W), line:17:14, endln:17:63, parent:work@test_program
-                      |vpiOperand:
-                      \_constant: , line:50:21, endln:50:22
-                        |vpiConstType:9
-                        |vpiDecompile:1
-                        |vpiSize:64
-                        |UINT:1
-                    |vpiRightRange:
-                    \_constant: , line:50:23, endln:50:24
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-              |vpiTypespecMember:
-              \_typespec_member: (byteenable), line:51:36, endln:51:46, parent:Command
-                |vpiName:byteenable
-                |vpiTypespec:
-                \_logic_typespec: , line:51:7, endln:51:12, parent:byteenable
-                  |vpiRange:
-                  \_range: , line:51:14, endln:51:29
-                    |vpiLeftRange:
-                    \_operation: , line:51:14, endln:51:25
-                      |vpiOpType:11
-                      |vpiOperand:
-                      \_ref_obj: (work@test_program.actual_cmd.Command.byteenable.NUM_SYMBOLS), line:51:14, endln:51:25
-                        |vpiName:NUM_SYMBOLS
-                        |vpiFullName:work@test_program.actual_cmd.Command.byteenable.NUM_SYMBOLS
-                        |vpiActual:
-                        \_parameter: (work@test_program.NUM_SYMBOLS), line:16:14, endln:16:42, parent:work@test_program
-                      |vpiOperand:
-                      \_constant: , line:51:26, endln:51:27
-                        |vpiConstType:9
-                        |vpiDecompile:1
-                        |vpiSize:64
-                        |UINT:1
-                    |vpiRightRange:
-                    \_constant: , line:51:28, endln:51:29
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-              |vpiTypespecMember:
-              \_typespec_member: (cmd_delay), line:52:36, endln:52:45, parent:Command
-                |vpiName:cmd_delay
-                |vpiTypespec:
-                \_bit_typespec: , line:52:7, endln:52:10, parent:cmd_delay
-                  |vpiRange:
-                  \_range: , line:52:12, endln:52:16
-                    |vpiLeftRange:
-                    \_constant: , line:52:12, endln:52:14
-                      |vpiConstType:9
-                      |vpiDecompile:31
-                      |vpiSize:64
-                      |UINT:31
-                    |vpiRightRange:
-                    \_constant: , line:52:15, endln:52:16
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-              |vpiTypespecMember:
-              \_typespec_member: (data_idles), line:53:36, endln:53:46, parent:Command
-                |vpiName:data_idles
-                |vpiTypespec:
-                \_bit_typespec: , line:53:7, endln:53:10, parent:data_idles
-                  |vpiRange:
-                  \_range: , line:53:12, endln:53:16
-                    |vpiLeftRange:
-                    \_constant: , line:53:12, endln:53:14
-                      |vpiConstType:9
-                      |vpiDecompile:31
-                      |vpiSize:64
-                      |UINT:31
-                    |vpiRightRange:
-                    \_constant: , line:53:15, endln:53:16
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
+            \_struct_typespec: (Command), line:45:11, endln:45:17
         |vpiStmt:
         \_assign_stmt: , parent:work@test_program
           |vpiLhs:
@@ -14844,205 +13503,7 @@ design: (work@top)
             |vpiName:exp_cmd
             |vpiFullName:work@test_program.exp_cmd
             |vpiTypespec:
-            \_struct_typespec: (Command), line:45:11, endln:45:17, parent:work@test_program.exp_cmd
-              |vpiName:Command
-              |vpiTypespecMember:
-              \_typespec_member: (trans), line:47:36, endln:47:41, parent:Command
-                |vpiName:trans
-                |vpiTypespec:
-                \_enum_typespec: (Transaction), line:37:5, endln:37:16, parent:trans
-                  |vpiName:Transaction
-                  |vpiBaseTypespec:
-                  \_bit_typespec: , line:33:16, endln:33:19, parent:Transaction
-                  |vpiEnumConst:
-                  \_enum_const: (WRITE), line:35:7, endln:35:12, parent:Transaction
-                    |vpiName:WRITE
-                    |vpiDecompile:0
-                    |UINT:0
-                    |vpiSize:64
-                  |vpiEnumConst:
-                  \_enum_const: (READ), line:36:7, endln:36:11, parent:Transaction
-                    |vpiName:READ
-                    |vpiDecompile:1
-                    |UINT:1
-                    |vpiSize:64
-              |vpiTypespecMember:
-              \_typespec_member: (burstcount), line:48:36, endln:48:46, parent:Command
-                |vpiName:burstcount
-                |vpiTypespec:
-                \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:burstcount
-                  |vpiName:Burstcount
-                  |vpiRange:
-                  \_range: , line:31:18, endln:31:29, parent:Burstcount
-                    |vpiLeftRange:
-                    \_operation: , line:31:18, endln:31:25
-                      |vpiOpType:11
-                      |vpiOperand:
-                      \_ref_obj: (work@test_program.exp_cmd.Command.burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                        |vpiName:BURST_W
-                        |vpiFullName:work@test_program.exp_cmd.Command.burstcount.Burstcount.BURST_W
-                        |vpiActual:
-                        \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                      |vpiOperand:
-                      \_constant: , line:31:26, endln:31:27
-                        |vpiConstType:9
-                        |vpiDecompile:1
-                        |vpiSize:64
-                        |UINT:1
-                    |vpiRightRange:
-                    \_constant: , line:31:28, endln:31:29
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-                  |vpiTypedefAlias:
-                  \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:Burstcount
-                    |vpiName:Burstcount
-                    |vpiRange:
-                    \_range: , line:31:18, endln:31:29, parent:Burstcount
-                      |vpiLeftRange:
-                      \_operation: , line:31:18, endln:31:25
-                        |vpiOpType:11
-                        |vpiOperand:
-                        \_ref_obj: (work@test_program.exp_cmd.Command.burstcount.Burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                          |vpiName:BURST_W
-                          |vpiFullName:work@test_program.exp_cmd.Command.burstcount.Burstcount.Burstcount.BURST_W
-                          |vpiActual:
-                          \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                        |vpiOperand:
-                        \_constant: , line:31:26, endln:31:27
-                          |vpiConstType:9
-                          |vpiDecompile:1
-                          |vpiSize:64
-                          |UINT:1
-                      |vpiRightRange:
-                      \_constant: , line:31:28, endln:31:29
-                        |vpiConstType:9
-                        |vpiDecompile:0
-                        |vpiSize:64
-                        |UINT:0
-              |vpiTypespecMember:
-              \_typespec_member: (addr), line:49:36, endln:49:40, parent:Command
-                |vpiName:addr
-                |vpiTypespec:
-                \_logic_typespec: , line:49:7, endln:49:12, parent:addr
-                  |vpiRange:
-                  \_range: , line:49:14, endln:49:25
-                    |vpiLeftRange:
-                    \_operation: , line:49:14, endln:49:20
-                      |vpiOpType:11
-                      |vpiOperand:
-                      \_ref_obj: (work@test_program.exp_cmd.Command.addr.ADDR_W), line:49:14, endln:49:20
-                        |vpiName:ADDR_W
-                        |vpiFullName:work@test_program.exp_cmd.Command.addr.ADDR_W
-                        |vpiActual:
-                        \_parameter: (work@test_program.ADDR_W), line:13:14, endln:13:43, parent:work@test_program
-                      |vpiOperand:
-                      \_constant: , line:49:21, endln:49:22
-                        |vpiConstType:9
-                        |vpiDecompile:1
-                        |vpiSize:64
-                        |UINT:1
-                    |vpiRightRange:
-                    \_constant: , line:49:24, endln:49:25
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-              |vpiTypespecMember:
-              \_typespec_member: (data), line:50:36, endln:50:40, parent:Command
-                |vpiName:data
-                |vpiTypespec:
-                \_logic_typespec: , line:50:7, endln:50:12, parent:data
-                  |vpiRange:
-                  \_range: , line:50:14, endln:50:24
-                    |vpiLeftRange:
-                    \_operation: , line:50:14, endln:50:20
-                      |vpiOpType:11
-                      |vpiOperand:
-                      \_ref_obj: (work@test_program.exp_cmd.Command.data.DATA_W), line:50:14, endln:50:20
-                        |vpiName:DATA_W
-                        |vpiFullName:work@test_program.exp_cmd.Command.data.DATA_W
-                        |vpiActual:
-                        \_parameter: (work@test_program.DATA_W), line:17:14, endln:17:63, parent:work@test_program
-                      |vpiOperand:
-                      \_constant: , line:50:21, endln:50:22
-                        |vpiConstType:9
-                        |vpiDecompile:1
-                        |vpiSize:64
-                        |UINT:1
-                    |vpiRightRange:
-                    \_constant: , line:50:23, endln:50:24
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-              |vpiTypespecMember:
-              \_typespec_member: (byteenable), line:51:36, endln:51:46, parent:Command
-                |vpiName:byteenable
-                |vpiTypespec:
-                \_logic_typespec: , line:51:7, endln:51:12, parent:byteenable
-                  |vpiRange:
-                  \_range: , line:51:14, endln:51:29
-                    |vpiLeftRange:
-                    \_operation: , line:51:14, endln:51:25
-                      |vpiOpType:11
-                      |vpiOperand:
-                      \_ref_obj: (work@test_program.exp_cmd.Command.byteenable.NUM_SYMBOLS), line:51:14, endln:51:25
-                        |vpiName:NUM_SYMBOLS
-                        |vpiFullName:work@test_program.exp_cmd.Command.byteenable.NUM_SYMBOLS
-                        |vpiActual:
-                        \_parameter: (work@test_program.NUM_SYMBOLS), line:16:14, endln:16:42, parent:work@test_program
-                      |vpiOperand:
-                      \_constant: , line:51:26, endln:51:27
-                        |vpiConstType:9
-                        |vpiDecompile:1
-                        |vpiSize:64
-                        |UINT:1
-                    |vpiRightRange:
-                    \_constant: , line:51:28, endln:51:29
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-              |vpiTypespecMember:
-              \_typespec_member: (cmd_delay), line:52:36, endln:52:45, parent:Command
-                |vpiName:cmd_delay
-                |vpiTypespec:
-                \_bit_typespec: , line:52:7, endln:52:10, parent:cmd_delay
-                  |vpiRange:
-                  \_range: , line:52:12, endln:52:16
-                    |vpiLeftRange:
-                    \_constant: , line:52:12, endln:52:14
-                      |vpiConstType:9
-                      |vpiDecompile:31
-                      |vpiSize:64
-                      |UINT:31
-                    |vpiRightRange:
-                    \_constant: , line:52:15, endln:52:16
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-              |vpiTypespecMember:
-              \_typespec_member: (data_idles), line:53:36, endln:53:46, parent:Command
-                |vpiName:data_idles
-                |vpiTypespec:
-                \_bit_typespec: , line:53:7, endln:53:10, parent:data_idles
-                  |vpiRange:
-                  \_range: , line:53:12, endln:53:16
-                    |vpiLeftRange:
-                    \_constant: , line:53:12, endln:53:14
-                      |vpiConstType:9
-                      |vpiDecompile:31
-                      |vpiSize:64
-                      |UINT:31
-                    |vpiRightRange:
-                    \_constant: , line:53:15, endln:53:16
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
+            \_struct_typespec: (Command), line:45:11, endln:45:17
         |vpiStmt:
         \_assign_stmt: , parent:work@test_program
           |vpiLhs:
@@ -15050,110 +13511,7 @@ design: (work@top)
             |vpiName:rsp
             |vpiFullName:work@test_program.rsp
             |vpiTypespec:
-            \_struct_typespec: (Response), line:56:11, endln:56:17, parent:work@test_program.rsp
-              |vpiName:Response
-              |vpiTypespecMember:
-              \_typespec_member: (burstcount), line:58:36, endln:58:46, parent:Response
-                |vpiName:burstcount
-                |vpiTypespec:
-                \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:burstcount
-                  |vpiName:Burstcount
-                  |vpiRange:
-                  \_range: , line:31:18, endln:31:29, parent:Burstcount
-                    |vpiLeftRange:
-                    \_operation: , line:31:18, endln:31:25
-                      |vpiOpType:11
-                      |vpiOperand:
-                      \_ref_obj: (work@test_program.rsp.Response.burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                        |vpiName:BURST_W
-                        |vpiFullName:work@test_program.rsp.Response.burstcount.Burstcount.BURST_W
-                        |vpiActual:
-                        \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                      |vpiOperand:
-                      \_constant: , line:31:26, endln:31:27
-                        |vpiConstType:9
-                        |vpiDecompile:1
-                        |vpiSize:64
-                        |UINT:1
-                    |vpiRightRange:
-                    \_constant: , line:31:28, endln:31:29
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-                  |vpiTypedefAlias:
-                  \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:Burstcount
-                    |vpiName:Burstcount
-                    |vpiRange:
-                    \_range: , line:31:18, endln:31:29, parent:Burstcount
-                      |vpiLeftRange:
-                      \_operation: , line:31:18, endln:31:25
-                        |vpiOpType:11
-                        |vpiOperand:
-                        \_ref_obj: (work@test_program.rsp.Response.burstcount.Burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                          |vpiName:BURST_W
-                          |vpiFullName:work@test_program.rsp.Response.burstcount.Burstcount.Burstcount.BURST_W
-                          |vpiActual:
-                          \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                        |vpiOperand:
-                        \_constant: , line:31:26, endln:31:27
-                          |vpiConstType:9
-                          |vpiDecompile:1
-                          |vpiSize:64
-                          |UINT:1
-                      |vpiRightRange:
-                      \_constant: , line:31:28, endln:31:29
-                        |vpiConstType:9
-                        |vpiDecompile:0
-                        |vpiSize:64
-                        |UINT:0
-              |vpiTypespecMember:
-              \_typespec_member: (data), line:59:36, endln:59:40, parent:Response
-                |vpiName:data
-                |vpiTypespec:
-                \_logic_typespec: , line:59:6, endln:59:11, parent:data
-                  |vpiRange:
-                  \_range: , line:59:13, endln:59:23
-                    |vpiLeftRange:
-                    \_operation: , line:59:13, endln:59:19
-                      |vpiOpType:11
-                      |vpiOperand:
-                      \_ref_obj: (work@test_program.rsp.Response.data.DATA_W), line:59:13, endln:59:19
-                        |vpiName:DATA_W
-                        |vpiFullName:work@test_program.rsp.Response.data.DATA_W
-                        |vpiActual:
-                        \_parameter: (work@test_program.DATA_W), line:17:14, endln:17:63, parent:work@test_program
-                      |vpiOperand:
-                      \_constant: , line:59:20, endln:59:21
-                        |vpiConstType:9
-                        |vpiDecompile:1
-                        |vpiSize:64
-                        |UINT:1
-                    |vpiRightRange:
-                    \_constant: , line:59:22, endln:59:23
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-              |vpiTypespecMember:
-              \_typespec_member: (latency), line:60:36, endln:60:43, parent:Response
-                |vpiName:latency
-                |vpiTypespec:
-                \_bit_typespec: , line:60:6, endln:60:9, parent:latency
-                  |vpiRange:
-                  \_range: , line:60:11, endln:60:15
-                    |vpiLeftRange:
-                    \_constant: , line:60:11, endln:60:13
-                      |vpiConstType:9
-                      |vpiDecompile:31
-                      |vpiSize:64
-                      |UINT:31
-                    |vpiRightRange:
-                    \_constant: , line:60:14, endln:60:15
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
+            \_struct_typespec: (Response), line:56:11, endln:56:17
         |vpiStmt:
         \_assign_stmt: , parent:work@test_program
           |vpiLhs:
@@ -15211,7 +13569,7 @@ design: (work@top)
               \_sys_func_call: ($urandom_range), line:434:31, endln:434:74
                 |vpiName:$urandom_range
                 |vpiArgument:
-                \_constant: , line:434:46, endln:434:47, parent:$urandom_range
+                \_constant: , line:434:46, endln:434:47
                   |vpiConstType:9
                   |vpiDecompile:0
                   |vpiSize:64
@@ -15264,7 +13622,7 @@ design: (work@top)
               |vpiName:actual_cmd
               |vpiFullName:work@test_program.actual_cmd
             |vpiArgument:
-            \_constant: , line:439:59, endln:439:60, parent:get_expected_command_for_slave
+            \_constant: , line:439:59, endln:439:60
               |vpiConstType:9
               |vpiDecompile:1
               |vpiSize:64
@@ -15458,7 +13816,7 @@ design: (work@top)
       \_sys_func_call: ($display), line:527:6, endln:527:47, parent:work@test_program
         |vpiName:$display
         |vpiArgument:
-        \_constant: , line:527:15, endln:527:45, parent:$display
+        \_constant: , line:527:15, endln:527:45
           |vpiConstType:6
           |vpiDecompile:Starting master test program
           |vpiSize:28
@@ -15467,7 +13825,7 @@ design: (work@top)
       \_sys_func_call: ($display), line:529:6, endln:529:65, parent:work@test_program
         |vpiName:$display
         |vpiArgument:
-        \_constant: , line:529:15, endln:529:63, parent:$display
+        \_constant: , line:529:15, endln:529:63
           |vpiConstType:6
           |vpiDecompile:Master sending out non bursting write commands
           |vpiSize:46
@@ -15478,7 +13836,7 @@ design: (work@top)
         |vpiTask:
         \_task: (work@test_program.master_send_commands), line:544:3, endln:568:10, parent:work@test_program
         |vpiArgument:
-        \_constant: , line:530:27, endln:530:29, parent:master_send_commands
+        \_constant: , line:530:27, endln:530:29
           |vpiConstType:9
           |vpiDecompile:10
           |vpiSize:64
@@ -15489,10 +13847,6 @@ design: (work@top)
           |vpiFullName:work@test_program.WRITE
           |vpiActual:
           \_enum_const: (WRITE), line:35:7, endln:35:12
-            |vpiName:WRITE
-            |vpiDecompile:0
-            |UINT:0
-            |vpiSize:64
         |vpiArgument:
         \_ref_obj: (work@test_program.NOBURST), line:530:38, endln:530:45, parent:master_send_commands
           |vpiName:NOBURST
@@ -15507,7 +13861,7 @@ design: (work@top)
       \_sys_func_call: ($display), line:532:6, endln:532:64, parent:work@test_program
         |vpiName:$display
         |vpiArgument:
-        \_constant: , line:532:15, endln:532:62, parent:$display
+        \_constant: , line:532:15, endln:532:62
           |vpiConstType:6
           |vpiDecompile:Master sending out non bursting read commands
           |vpiSize:45
@@ -15518,7 +13872,7 @@ design: (work@top)
         |vpiTask:
         \_task: (work@test_program.master_send_commands), line:544:3, endln:568:10, parent:work@test_program
         |vpiArgument:
-        \_constant: , line:533:27, endln:533:29, parent:master_send_commands
+        \_constant: , line:533:27, endln:533:29
           |vpiConstType:9
           |vpiDecompile:10
           |vpiSize:64
@@ -15539,7 +13893,7 @@ design: (work@top)
       \_sys_func_call: ($display), line:535:6, endln:535:58, parent:work@test_program
         |vpiName:$display
         |vpiArgument:
-        \_constant: , line:535:15, endln:535:56, parent:$display
+        \_constant: , line:535:15, endln:535:56
           |vpiConstType:6
           |vpiDecompile:Master sending out burst write commands
           |vpiSize:39
@@ -15550,7 +13904,7 @@ design: (work@top)
         |vpiTask:
         \_task: (work@test_program.master_send_commands), line:544:3, endln:568:10, parent:work@test_program
         |vpiArgument:
-        \_constant: , line:536:27, endln:536:29, parent:master_send_commands
+        \_constant: , line:536:27, endln:536:29
           |vpiConstType:9
           |vpiDecompile:10
           |vpiSize:64
@@ -15575,7 +13929,7 @@ design: (work@top)
       \_sys_func_call: ($display), line:538:6, endln:538:57, parent:work@test_program
         |vpiName:$display
         |vpiArgument:
-        \_constant: , line:538:15, endln:538:55, parent:$display
+        \_constant: , line:538:15, endln:538:55
           |vpiConstType:6
           |vpiDecompile:Master sending out burst read commands
           |vpiSize:38
@@ -15586,7 +13940,7 @@ design: (work@top)
         |vpiTask:
         \_task: (work@test_program.master_send_commands), line:544:3, endln:568:10, parent:work@test_program
         |vpiArgument:
-        \_constant: , line:539:27, endln:539:29, parent:master_send_commands
+        \_constant: , line:539:27, endln:539:29
           |vpiConstType:9
           |vpiDecompile:10
           |vpiSize:64
@@ -15607,7 +13961,7 @@ design: (work@top)
       \_sys_func_call: ($display), line:541:6, endln:541:51, parent:work@test_program
         |vpiName:$display
         |vpiArgument:
-        \_constant: , line:541:15, endln:541:49, parent:$display
+        \_constant: , line:541:15, endln:541:49
           |vpiConstType:6
           |vpiDecompile:Master has sent out all commands
           |vpiSize:32
@@ -15657,170 +14011,6 @@ design: (work@top)
                 |vpiFullName:work@test_program.cmd
                 |vpiTypespec:
                 \_struct_typespec: (Command), line:45:11, endln:45:17
-                  |vpiName:Command
-                  |vpiTypespecMember:
-                  \_typespec_member: (trans), line:47:36, endln:47:41
-                    |vpiName:trans
-                    |vpiTypespec:
-                    \_enum_typespec: (Transaction), line:37:5, endln:37:16
-                      |vpiName:Transaction
-                      |vpiBaseTypespec:
-                      \_bit_typespec: , line:33:16, endln:33:19
-                      |vpiEnumConst:
-                      \_enum_const: (WRITE), line:35:7, endln:35:12
-                      |vpiEnumConst:
-                      \_enum_const: (READ), line:36:7, endln:36:11
-                  |vpiTypespecMember:
-                  \_typespec_member: (burstcount), line:48:36, endln:48:46
-                    |vpiName:burstcount
-                    |vpiTypespec:
-                    \_logic_typespec: (Burstcount), line:31:11, endln:31:16
-                      |vpiName:Burstcount
-                      |vpiRange:
-                      \_range: , line:31:18, endln:31:29, parent:Burstcount
-                        |vpiLeftRange:
-                        \_operation: , line:31:18, endln:31:25
-                          |vpiOpType:11
-                          |vpiOperand:
-                          \_ref_obj: (Burstcount.BURST_W), line:31:18, endln:31:25
-                            |vpiName:BURST_W
-                            |vpiFullName:Burstcount.BURST_W
-                          |vpiOperand:
-                          \_constant: , line:31:26, endln:31:27
-                            |vpiConstType:9
-                            |vpiDecompile:1
-                            |vpiSize:64
-                            |UINT:1
-                        |vpiRightRange:
-                        \_constant: , line:31:28, endln:31:29
-                          |vpiConstType:9
-                          |vpiDecompile:0
-                          |vpiSize:64
-                          |UINT:0
-                      |vpiTypedefAlias:
-                      \_logic_typespec: (Burstcount), line:31:11, endln:31:16
-                  |vpiTypespecMember:
-                  \_typespec_member: (addr), line:49:36, endln:49:40
-                    |vpiName:addr
-                    |vpiTypespec:
-                    \_logic_typespec: , line:49:7, endln:49:12
-                      |vpiRange:
-                      \_range: , line:49:14, endln:49:25, parent:Command
-                        |vpiLeftRange:
-                        \_operation: , line:49:14, endln:49:20
-                          |vpiOpType:11
-                          |vpiOperand:
-                          \_ref_obj: (Command.ADDR_W), line:49:14, endln:49:20, parent:Command
-                            |vpiName:ADDR_W
-                            |vpiFullName:Command.ADDR_W
-                            |vpiActual:
-                            \_parameter: (work@test_program.ADDR_W), line:13:14, endln:13:43, parent:work@test_program
-                          |vpiOperand:
-                          \_constant: , line:49:21, endln:49:22
-                            |vpiConstType:9
-                            |vpiDecompile:1
-                            |vpiSize:64
-                            |UINT:1
-                        |vpiRightRange:
-                        \_constant: , line:49:24, endln:49:25
-                          |vpiConstType:9
-                          |vpiDecompile:0
-                          |vpiSize:64
-                          |UINT:0
-                  |vpiTypespecMember:
-                  \_typespec_member: (data), line:50:36, endln:50:40
-                    |vpiName:data
-                    |vpiTypespec:
-                    \_logic_typespec: , line:50:7, endln:50:12
-                      |vpiRange:
-                      \_range: , line:50:14, endln:50:24, parent:Command
-                        |vpiLeftRange:
-                        \_operation: , line:50:14, endln:50:20
-                          |vpiOpType:11
-                          |vpiOperand:
-                          \_ref_obj: (Command.DATA_W), line:50:14, endln:50:20, parent:Command
-                            |vpiName:DATA_W
-                            |vpiFullName:Command.DATA_W
-                            |vpiActual:
-                            \_parameter: (work@test_program.DATA_W), line:17:14, endln:17:63, parent:work@test_program
-                          |vpiOperand:
-                          \_constant: , line:50:21, endln:50:22
-                            |vpiConstType:9
-                            |vpiDecompile:1
-                            |vpiSize:64
-                            |UINT:1
-                        |vpiRightRange:
-                        \_constant: , line:50:23, endln:50:24
-                          |vpiConstType:9
-                          |vpiDecompile:0
-                          |vpiSize:64
-                          |UINT:0
-                  |vpiTypespecMember:
-                  \_typespec_member: (byteenable), line:51:36, endln:51:46
-                    |vpiName:byteenable
-                    |vpiTypespec:
-                    \_logic_typespec: , line:51:7, endln:51:12
-                      |vpiRange:
-                      \_range: , line:51:14, endln:51:29, parent:Command
-                        |vpiLeftRange:
-                        \_operation: , line:51:14, endln:51:25
-                          |vpiOpType:11
-                          |vpiOperand:
-                          \_ref_obj: (Command.NUM_SYMBOLS), line:51:14, endln:51:25, parent:Command
-                            |vpiName:NUM_SYMBOLS
-                            |vpiFullName:Command.NUM_SYMBOLS
-                            |vpiActual:
-                            \_parameter: (work@test_program.NUM_SYMBOLS), line:16:14, endln:16:42, parent:work@test_program
-                          |vpiOperand:
-                          \_constant: , line:51:26, endln:51:27
-                            |vpiConstType:9
-                            |vpiDecompile:1
-                            |vpiSize:64
-                            |UINT:1
-                        |vpiRightRange:
-                        \_constant: , line:51:28, endln:51:29
-                          |vpiConstType:9
-                          |vpiDecompile:0
-                          |vpiSize:64
-                          |UINT:0
-                  |vpiTypespecMember:
-                  \_typespec_member: (cmd_delay), line:52:36, endln:52:45
-                    |vpiName:cmd_delay
-                    |vpiTypespec:
-                    \_bit_typespec: , line:52:7, endln:52:10
-                      |vpiRange:
-                      \_range: , line:52:12, endln:52:16, parent:Command
-                        |vpiLeftRange:
-                        \_constant: , line:52:12, endln:52:14
-                          |vpiConstType:9
-                          |vpiDecompile:31
-                          |vpiSize:64
-                          |UINT:31
-                        |vpiRightRange:
-                        \_constant: , line:52:15, endln:52:16
-                          |vpiConstType:9
-                          |vpiDecompile:0
-                          |vpiSize:64
-                          |UINT:0
-                  |vpiTypespecMember:
-                  \_typespec_member: (data_idles), line:53:36, endln:53:46
-                    |vpiName:data_idles
-                    |vpiTypespec:
-                    \_bit_typespec: , line:53:7, endln:53:10
-                      |vpiRange:
-                      \_range: , line:53:12, endln:53:16, parent:Command
-                        |vpiLeftRange:
-                        \_constant: , line:53:12, endln:53:14
-                          |vpiConstType:9
-                          |vpiDecompile:31
-                          |vpiSize:64
-                          |UINT:31
-                        |vpiRightRange:
-                        \_constant: , line:53:15, endln:53:16
-                          |vpiConstType:9
-                          |vpiDecompile:0
-                          |vpiSize:64
-                          |UINT:0
             |vpiStmt:
             \_assign_stmt: , parent:work@test_program
               |vpiLhs:
@@ -15853,10 +14043,6 @@ design: (work@top)
                   |vpiName:read_command_queue_master
                   |vpiIndex:
                   \_constant: , line:254:38, endln:254:39
-                    |vpiConstType:9
-                    |vpiDecompile:0
-                    |vpiSize:64
-                    |UINT:0
                 |vpiActual:
                 \_ref_obj: (pop_front)
                   |vpiName:pop_front
@@ -16011,10 +14197,6 @@ design: (work@top)
               \_assign_stmt: , parent:work@test_program
                 |vpiRhs:
                 \_constant: , line:290:19, endln:290:20
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
                 |vpiLhs:
                 \_int_var: (work@test_program.i), line:290:11, endln:290:14
                   |vpiName:i
@@ -16041,10 +14223,6 @@ design: (work@top)
                     |vpiName:$urandom_range
                     |vpiArgument:
                     \_constant: , line:291:46, endln:291:47
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
                     |vpiArgument:
                     \_ref_obj: (work@test_program.MAX_COMMAND_BACKPRESSURE), line:291:49, endln:291:73, parent:$urandom_range
                       |vpiName:MAX_COMMAND_BACKPRESSURE
@@ -16094,10 +14272,6 @@ design: (work@top)
                   |vpiFullName:work@test_program.actual_cmd
                 |vpiArgument:
                 \_constant: , line:296:59, endln:296:60
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
             |vpiStmt:
             \_task_call: (verify_command), line:297:6, endln:297:42, parent:work@test_program
               |vpiName:verify_command
@@ -16214,10 +14388,6 @@ design: (work@top)
                   \_int_var: (work@test_program.pending_read_cycles_slave_0), line:332:7, endln:332:34, parent:work@test_program
                 |vpiOperand:
                 \_constant: , line:334:40, endln:334:41
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
               |vpiStmt:
               \_begin: (work@test_program), line:334:43, endln:336:9
                 |vpiFullName:work@test_program
@@ -16297,10 +14467,6 @@ design: (work@top)
                   |vpiName:read_command_queue_master
                   |vpiIndex:
                   \_constant: , line:397:38, endln:397:39
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
                 |vpiActual:
                 \_ref_obj: (pop_front)
                   |vpiName:pop_front
@@ -16455,10 +14621,6 @@ design: (work@top)
               \_assign_stmt: , parent:work@test_program
                 |vpiRhs:
                 \_constant: , line:433:19, endln:433:20
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
                 |vpiLhs:
                 \_int_var: (work@test_program.i), line:433:11, endln:433:14
                   |vpiName:i
@@ -16485,10 +14647,6 @@ design: (work@top)
                     |vpiName:$urandom_range
                     |vpiArgument:
                     \_constant: , line:434:46, endln:434:47
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
                     |vpiArgument:
                     \_ref_obj: (work@test_program.MAX_COMMAND_BACKPRESSURE), line:434:49, endln:434:73, parent:$urandom_range
                       |vpiName:MAX_COMMAND_BACKPRESSURE
@@ -16538,10 +14696,6 @@ design: (work@top)
                   |vpiFullName:work@test_program.actual_cmd
                 |vpiArgument:
                 \_constant: , line:439:59, endln:439:60
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
             |vpiStmt:
             \_task_call: (verify_command), line:440:6, endln:440:42, parent:work@test_program
               |vpiName:verify_command
@@ -16658,10 +14812,6 @@ design: (work@top)
                   \_int_var: (work@test_program.pending_read_cycles_slave_1), line:475:7, endln:475:34, parent:work@test_program
                 |vpiOperand:
                 \_constant: , line:477:40, endln:477:41
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
               |vpiStmt:
               \_begin: (work@test_program), line:477:43, endln:479:9
                 |vpiFullName:work@test_program
@@ -16709,28 +14859,16 @@ design: (work@top)
                   |vpiName:reset_reset_n
               |vpiOperand:
               \_constant: , line:526:42, endln:526:43
-                |vpiConstType:9
-                |vpiDecompile:1
-                |vpiSize:64
-                |UINT:1
           |vpiStmt:
           \_sys_func_call: ($display), line:527:6, endln:527:47, parent:work@test_program
             |vpiName:$display
             |vpiArgument:
             \_constant: , line:527:15, endln:527:45
-              |vpiConstType:6
-              |vpiDecompile:Starting master test program
-              |vpiSize:28
-              |STRING:Starting master test program
           |vpiStmt:
           \_sys_func_call: ($display), line:529:6, endln:529:65, parent:work@test_program
             |vpiName:$display
             |vpiArgument:
             \_constant: , line:529:15, endln:529:63
-              |vpiConstType:6
-              |vpiDecompile:Master sending out non bursting write commands
-              |vpiSize:46
-              |STRING:Master sending out non bursting write commands
           |vpiStmt:
           \_task_call: (master_send_commands), line:530:6, endln:530:47, parent:work@test_program
             |vpiName:master_send_commands
@@ -16738,10 +14876,6 @@ design: (work@top)
             \_task: (work@test_program.master_send_commands), line:544:3, endln:568:10, parent:work@test_program
             |vpiArgument:
             \_constant: , line:530:27, endln:530:29
-              |vpiConstType:9
-              |vpiDecompile:10
-              |vpiSize:64
-              |UINT:10
             |vpiArgument:
             \_ref_obj: (work@test_program.WRITE), line:530:31, endln:530:36, parent:master_send_commands
               |vpiName:WRITE
@@ -16759,10 +14893,6 @@ design: (work@top)
             |vpiName:$display
             |vpiArgument:
             \_constant: , line:532:15, endln:532:62
-              |vpiConstType:6
-              |vpiDecompile:Master sending out non bursting read commands
-              |vpiSize:45
-              |STRING:Master sending out non bursting read commands
           |vpiStmt:
           \_task_call: (master_send_commands), line:533:6, endln:533:46, parent:work@test_program
             |vpiName:master_send_commands
@@ -16770,10 +14900,6 @@ design: (work@top)
             \_task: (work@test_program.master_send_commands), line:544:3, endln:568:10, parent:work@test_program
             |vpiArgument:
             \_constant: , line:533:27, endln:533:29
-              |vpiConstType:9
-              |vpiDecompile:10
-              |vpiSize:64
-              |UINT:10
             |vpiArgument:
             \_ref_obj: (work@test_program.READ), line:533:31, endln:533:35, parent:master_send_commands
               |vpiName:READ
@@ -16791,10 +14917,6 @@ design: (work@top)
             |vpiName:$display
             |vpiArgument:
             \_constant: , line:535:15, endln:535:56
-              |vpiConstType:6
-              |vpiDecompile:Master sending out burst write commands
-              |vpiSize:39
-              |STRING:Master sending out burst write commands
           |vpiStmt:
           \_task_call: (master_send_commands), line:536:6, endln:536:45, parent:work@test_program
             |vpiName:master_send_commands
@@ -16802,10 +14924,6 @@ design: (work@top)
             \_task: (work@test_program.master_send_commands), line:544:3, endln:568:10, parent:work@test_program
             |vpiArgument:
             \_constant: , line:536:27, endln:536:29
-              |vpiConstType:9
-              |vpiDecompile:10
-              |vpiSize:64
-              |UINT:10
             |vpiArgument:
             \_ref_obj: (work@test_program.WRITE), line:536:31, endln:536:36, parent:master_send_commands
               |vpiName:WRITE
@@ -16823,10 +14941,6 @@ design: (work@top)
             |vpiName:$display
             |vpiArgument:
             \_constant: , line:538:15, endln:538:55
-              |vpiConstType:6
-              |vpiDecompile:Master sending out burst read commands
-              |vpiSize:38
-              |STRING:Master sending out burst read commands
           |vpiStmt:
           \_task_call: (master_send_commands), line:539:6, endln:539:44, parent:work@test_program
             |vpiName:master_send_commands
@@ -16834,10 +14948,6 @@ design: (work@top)
             \_task: (work@test_program.master_send_commands), line:544:3, endln:568:10, parent:work@test_program
             |vpiArgument:
             \_constant: , line:539:27, endln:539:29
-              |vpiConstType:9
-              |vpiDecompile:10
-              |vpiSize:64
-              |UINT:10
             |vpiArgument:
             \_ref_obj: (work@test_program.READ), line:539:31, endln:539:35, parent:master_send_commands
               |vpiName:READ
@@ -16855,10 +14965,6 @@ design: (work@top)
             |vpiName:$display
             |vpiArgument:
             \_constant: , line:541:15, endln:541:49
-              |vpiConstType:6
-              |vpiDecompile:Master has sent out all commands
-              |vpiSize:32
-              |STRING:Master has sent out all commands
       |vpiTaskFunc:
       \_task: (work@test_program.configure_and_push_command_to_master_0), line:224:3, endln:245:10, parent:work@test_program
         |vpiVisibility:1
@@ -21117,205 +19223,7 @@ design: (work@top)
       |vpiName:cmd
       |vpiDirection:1
       |vpiTypedef:
-      \_struct_typespec: (Command), line:45:11, endln:45:17, parent:cmd
-        |vpiName:Command
-        |vpiTypespecMember:
-        \_typespec_member: (trans), line:47:36, endln:47:41, parent:Command
-          |vpiName:trans
-          |vpiTypespec:
-          \_enum_typespec: (Transaction), line:37:5, endln:37:16, parent:trans
-            |vpiName:Transaction
-            |vpiBaseTypespec:
-            \_bit_typespec: , line:33:16, endln:33:19, parent:Transaction
-            |vpiEnumConst:
-            \_enum_const: (WRITE), line:35:7, endln:35:12, parent:Transaction
-              |vpiName:WRITE
-              |vpiDecompile:0
-              |UINT:0
-              |vpiSize:64
-            |vpiEnumConst:
-            \_enum_const: (READ), line:36:7, endln:36:11, parent:Transaction
-              |vpiName:READ
-              |vpiDecompile:1
-              |UINT:1
-              |vpiSize:64
-        |vpiTypespecMember:
-        \_typespec_member: (burstcount), line:48:36, endln:48:46, parent:Command
-          |vpiName:burstcount
-          |vpiTypespec:
-          \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:burstcount
-            |vpiName:Burstcount
-            |vpiRange:
-            \_range: , line:31:18, endln:31:29, parent:Burstcount
-              |vpiLeftRange:
-              \_operation: , line:31:18, endln:31:25
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.configure_and_push_command_to_master_0.cmd.Command.burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                  |vpiName:BURST_W
-                  |vpiFullName:work@test_program.configure_and_push_command_to_master_0.cmd.Command.burstcount.Burstcount.BURST_W
-                  |vpiActual:
-                  \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:31:26, endln:31:27
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:31:28, endln:31:29
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-            |vpiTypedefAlias:
-            \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:Burstcount
-              |vpiName:Burstcount
-              |vpiRange:
-              \_range: , line:31:18, endln:31:29, parent:Burstcount
-                |vpiLeftRange:
-                \_operation: , line:31:18, endln:31:25
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (work@test_program.configure_and_push_command_to_master_0.cmd.Command.burstcount.Burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                    |vpiName:BURST_W
-                    |vpiFullName:work@test_program.configure_and_push_command_to_master_0.cmd.Command.burstcount.Burstcount.Burstcount.BURST_W
-                    |vpiActual:
-                    \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                  |vpiOperand:
-                  \_constant: , line:31:26, endln:31:27
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:31:28, endln:31:29
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (addr), line:49:36, endln:49:40, parent:Command
-          |vpiName:addr
-          |vpiTypespec:
-          \_logic_typespec: , line:49:7, endln:49:12, parent:addr
-            |vpiRange:
-            \_range: , line:49:14, endln:49:25
-              |vpiLeftRange:
-              \_operation: , line:49:14, endln:49:20
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.configure_and_push_command_to_master_0.cmd.Command.addr.ADDR_W), line:49:14, endln:49:20
-                  |vpiName:ADDR_W
-                  |vpiFullName:work@test_program.configure_and_push_command_to_master_0.cmd.Command.addr.ADDR_W
-                  |vpiActual:
-                  \_parameter: (work@test_program.ADDR_W), line:13:14, endln:13:43, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:49:21, endln:49:22
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:49:24, endln:49:25
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (data), line:50:36, endln:50:40, parent:Command
-          |vpiName:data
-          |vpiTypespec:
-          \_logic_typespec: , line:50:7, endln:50:12, parent:data
-            |vpiRange:
-            \_range: , line:50:14, endln:50:24
-              |vpiLeftRange:
-              \_operation: , line:50:14, endln:50:20
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.configure_and_push_command_to_master_0.cmd.Command.data.DATA_W), line:50:14, endln:50:20
-                  |vpiName:DATA_W
-                  |vpiFullName:work@test_program.configure_and_push_command_to_master_0.cmd.Command.data.DATA_W
-                  |vpiActual:
-                  \_parameter: (work@test_program.DATA_W), line:17:14, endln:17:63, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:50:21, endln:50:22
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:50:23, endln:50:24
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (byteenable), line:51:36, endln:51:46, parent:Command
-          |vpiName:byteenable
-          |vpiTypespec:
-          \_logic_typespec: , line:51:7, endln:51:12, parent:byteenable
-            |vpiRange:
-            \_range: , line:51:14, endln:51:29
-              |vpiLeftRange:
-              \_operation: , line:51:14, endln:51:25
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.configure_and_push_command_to_master_0.cmd.Command.byteenable.NUM_SYMBOLS), line:51:14, endln:51:25
-                  |vpiName:NUM_SYMBOLS
-                  |vpiFullName:work@test_program.configure_and_push_command_to_master_0.cmd.Command.byteenable.NUM_SYMBOLS
-                  |vpiActual:
-                  \_parameter: (work@test_program.NUM_SYMBOLS), line:16:14, endln:16:42, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:51:26, endln:51:27
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:51:28, endln:51:29
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (cmd_delay), line:52:36, endln:52:45, parent:Command
-          |vpiName:cmd_delay
-          |vpiTypespec:
-          \_bit_typespec: , line:52:7, endln:52:10, parent:cmd_delay
-            |vpiRange:
-            \_range: , line:52:12, endln:52:16
-              |vpiLeftRange:
-              \_constant: , line:52:12, endln:52:14
-                |vpiConstType:9
-                |vpiDecompile:31
-                |vpiSize:64
-                |UINT:31
-              |vpiRightRange:
-              \_constant: , line:52:15, endln:52:16
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (data_idles), line:53:36, endln:53:46, parent:Command
-          |vpiName:data_idles
-          |vpiTypespec:
-          \_bit_typespec: , line:53:7, endln:53:10, parent:data_idles
-            |vpiRange:
-            \_range: , line:53:12, endln:53:16
-              |vpiLeftRange:
-              \_constant: , line:53:12, endln:53:14
-                |vpiConstType:9
-                |vpiDecompile:31
-                |vpiSize:64
-                |UINT:31
-              |vpiRightRange:
-              \_constant: , line:53:15, endln:53:16
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
+      \_struct_typespec: (Command), line:45:11, endln:45:17
     |vpiStmt:
     \_begin: (work@test_program.configure_and_push_command_to_master_0), parent:work@test_program.configure_and_push_command_to_master_0
       |vpiFullName:work@test_program.configure_and_push_command_to_master_0
@@ -21432,10 +19340,6 @@ design: (work@top)
             \_assign_stmt: , parent:work@test_program.configure_and_push_command_to_master_0
               |vpiRhs:
               \_constant: , line:234:22, endln:234:23
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
               |vpiLhs:
               \_int_var: (work@test_program.configure_and_push_command_to_master_0.i), line:234:14, endln:234:17
                 |vpiName:i
@@ -21541,17 +19445,9 @@ design: (work@top)
               \_bit_select: (data_idles), parent:cmd.data_idles[0]
                 |vpiName:data_idles
                 |vpiIndex:
-                \_constant: , line:241:63, endln:241:64, parent:data_idles
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
+                \_constant: , line:241:63, endln:241:64
             |vpiArgument:
-            \_constant: , line:241:67, endln:241:68, parent:$root.tb.dut.master_0.set_command_idle
-              |vpiConstType:9
-              |vpiDecompile:0
-              |vpiSize:64
-              |UINT:0
+            \_constant: , line:241:67, endln:241:68
       |vpiStmt:
       \_func_call: ($root.tb.dut.master_0.push_command), line:244:6, endln:244:43, parent:work@test_program.configure_and_push_command_to_master_0
         |vpiName:$root.tb.dut.master_0.push_command
@@ -21619,110 +19515,7 @@ design: (work@top)
                 |vpiName:rsp
                 |vpiFullName:work@test_program.get_read_response_from_master_0.rsp
                 |vpiTypespec:
-                \_struct_typespec: (Response), line:56:11, endln:56:17, parent:work@test_program.get_read_response_from_master_0.rsp
-                  |vpiName:Response
-                  |vpiTypespecMember:
-                  \_typespec_member: (burstcount), line:58:36, endln:58:46, parent:Response
-                    |vpiName:burstcount
-                    |vpiTypespec:
-                    \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:burstcount
-                      |vpiName:Burstcount
-                      |vpiRange:
-                      \_range: , line:31:18, endln:31:29, parent:Burstcount
-                        |vpiLeftRange:
-                        \_operation: , line:31:18, endln:31:25
-                          |vpiOpType:11
-                          |vpiOperand:
-                          \_ref_obj: (work@test_program.get_read_response_from_master_0.rsp.Response.burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                            |vpiName:BURST_W
-                            |vpiFullName:work@test_program.get_read_response_from_master_0.rsp.Response.burstcount.Burstcount.BURST_W
-                            |vpiActual:
-                            \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                          |vpiOperand:
-                          \_constant: , line:31:26, endln:31:27
-                            |vpiConstType:9
-                            |vpiDecompile:1
-                            |vpiSize:64
-                            |UINT:1
-                        |vpiRightRange:
-                        \_constant: , line:31:28, endln:31:29
-                          |vpiConstType:9
-                          |vpiDecompile:0
-                          |vpiSize:64
-                          |UINT:0
-                      |vpiTypedefAlias:
-                      \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:Burstcount
-                        |vpiName:Burstcount
-                        |vpiRange:
-                        \_range: , line:31:18, endln:31:29, parent:Burstcount
-                          |vpiLeftRange:
-                          \_operation: , line:31:18, endln:31:25
-                            |vpiOpType:11
-                            |vpiOperand:
-                            \_ref_obj: (work@test_program.get_read_response_from_master_0.rsp.Response.burstcount.Burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                              |vpiName:BURST_W
-                              |vpiFullName:work@test_program.get_read_response_from_master_0.rsp.Response.burstcount.Burstcount.Burstcount.BURST_W
-                              |vpiActual:
-                              \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                            |vpiOperand:
-                            \_constant: , line:31:26, endln:31:27
-                              |vpiConstType:9
-                              |vpiDecompile:1
-                              |vpiSize:64
-                              |UINT:1
-                          |vpiRightRange:
-                          \_constant: , line:31:28, endln:31:29
-                            |vpiConstType:9
-                            |vpiDecompile:0
-                            |vpiSize:64
-                            |UINT:0
-                  |vpiTypespecMember:
-                  \_typespec_member: (data), line:59:36, endln:59:40, parent:Response
-                    |vpiName:data
-                    |vpiTypespec:
-                    \_logic_typespec: , line:59:6, endln:59:11, parent:data
-                      |vpiRange:
-                      \_range: , line:59:13, endln:59:23
-                        |vpiLeftRange:
-                        \_operation: , line:59:13, endln:59:19
-                          |vpiOpType:11
-                          |vpiOperand:
-                          \_ref_obj: (work@test_program.get_read_response_from_master_0.rsp.Response.data.DATA_W), line:59:13, endln:59:19
-                            |vpiName:DATA_W
-                            |vpiFullName:work@test_program.get_read_response_from_master_0.rsp.Response.data.DATA_W
-                            |vpiActual:
-                            \_parameter: (work@test_program.DATA_W), line:17:14, endln:17:63, parent:work@test_program
-                          |vpiOperand:
-                          \_constant: , line:59:20, endln:59:21
-                            |vpiConstType:9
-                            |vpiDecompile:1
-                            |vpiSize:64
-                            |UINT:1
-                        |vpiRightRange:
-                        \_constant: , line:59:22, endln:59:23
-                          |vpiConstType:9
-                          |vpiDecompile:0
-                          |vpiSize:64
-                          |UINT:0
-                  |vpiTypespecMember:
-                  \_typespec_member: (latency), line:60:36, endln:60:43, parent:Response
-                    |vpiName:latency
-                    |vpiTypespec:
-                    \_bit_typespec: , line:60:6, endln:60:9, parent:latency
-                      |vpiRange:
-                      \_range: , line:60:11, endln:60:15
-                        |vpiLeftRange:
-                        \_constant: , line:60:11, endln:60:13
-                          |vpiConstType:9
-                          |vpiDecompile:31
-                          |vpiSize:64
-                          |UINT:31
-                        |vpiRightRange:
-                        \_constant: , line:60:14, endln:60:15
-                          |vpiConstType:9
-                          |vpiDecompile:0
-                          |vpiSize:64
-                          |UINT:0
+                \_struct_typespec: (Response), line:56:11, endln:56:17
             |vpiActual:
             \_ref_obj: (burstcount), parent:rsp.burstcount
               |vpiName:burstcount
@@ -21730,10 +19523,6 @@ design: (work@top)
         \_assign_stmt: , parent:work@test_program.get_read_response_from_master_0
           |vpiRhs:
           \_constant: , line:272:19, endln:272:20
-            |vpiConstType:9
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
           |vpiLhs:
           \_int_var: (work@test_program.get_read_response_from_master_0.i), line:272:11, endln:272:14
             |vpiName:i
@@ -21925,205 +19714,7 @@ design: (work@top)
                     |vpiName:cmd
                     |vpiFullName:work@test_program.get_command_from_slave_0.cmd
                     |vpiTypespec:
-                    \_struct_typespec: (Command), line:45:11, endln:45:17, parent:work@test_program.get_command_from_slave_0.cmd
-                      |vpiName:Command
-                      |vpiTypespecMember:
-                      \_typespec_member: (trans), line:47:36, endln:47:41, parent:Command
-                        |vpiName:trans
-                        |vpiTypespec:
-                        \_enum_typespec: (Transaction), line:37:5, endln:37:16, parent:trans
-                          |vpiName:Transaction
-                          |vpiBaseTypespec:
-                          \_bit_typespec: , line:33:16, endln:33:19, parent:Transaction
-                          |vpiEnumConst:
-                          \_enum_const: (WRITE), line:35:7, endln:35:12, parent:Transaction
-                            |vpiName:WRITE
-                            |vpiDecompile:0
-                            |UINT:0
-                            |vpiSize:64
-                          |vpiEnumConst:
-                          \_enum_const: (READ), line:36:7, endln:36:11, parent:Transaction
-                            |vpiName:READ
-                            |vpiDecompile:1
-                            |UINT:1
-                            |vpiSize:64
-                      |vpiTypespecMember:
-                      \_typespec_member: (burstcount), line:48:36, endln:48:46, parent:Command
-                        |vpiName:burstcount
-                        |vpiTypespec:
-                        \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:burstcount
-                          |vpiName:Burstcount
-                          |vpiRange:
-                          \_range: , line:31:18, endln:31:29, parent:Burstcount
-                            |vpiLeftRange:
-                            \_operation: , line:31:18, endln:31:25
-                              |vpiOpType:11
-                              |vpiOperand:
-                              \_ref_obj: (work@test_program.get_command_from_slave_0.cmd.Command.burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                                |vpiName:BURST_W
-                                |vpiFullName:work@test_program.get_command_from_slave_0.cmd.Command.burstcount.Burstcount.BURST_W
-                                |vpiActual:
-                                \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                              |vpiOperand:
-                              \_constant: , line:31:26, endln:31:27
-                                |vpiConstType:9
-                                |vpiDecompile:1
-                                |vpiSize:64
-                                |UINT:1
-                            |vpiRightRange:
-                            \_constant: , line:31:28, endln:31:29
-                              |vpiConstType:9
-                              |vpiDecompile:0
-                              |vpiSize:64
-                              |UINT:0
-                          |vpiTypedefAlias:
-                          \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:Burstcount
-                            |vpiName:Burstcount
-                            |vpiRange:
-                            \_range: , line:31:18, endln:31:29, parent:Burstcount
-                              |vpiLeftRange:
-                              \_operation: , line:31:18, endln:31:25
-                                |vpiOpType:11
-                                |vpiOperand:
-                                \_ref_obj: (work@test_program.get_command_from_slave_0.cmd.Command.burstcount.Burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                                  |vpiName:BURST_W
-                                  |vpiFullName:work@test_program.get_command_from_slave_0.cmd.Command.burstcount.Burstcount.Burstcount.BURST_W
-                                  |vpiActual:
-                                  \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                                |vpiOperand:
-                                \_constant: , line:31:26, endln:31:27
-                                  |vpiConstType:9
-                                  |vpiDecompile:1
-                                  |vpiSize:64
-                                  |UINT:1
-                              |vpiRightRange:
-                              \_constant: , line:31:28, endln:31:29
-                                |vpiConstType:9
-                                |vpiDecompile:0
-                                |vpiSize:64
-                                |UINT:0
-                      |vpiTypespecMember:
-                      \_typespec_member: (addr), line:49:36, endln:49:40, parent:Command
-                        |vpiName:addr
-                        |vpiTypespec:
-                        \_logic_typespec: , line:49:7, endln:49:12, parent:addr
-                          |vpiRange:
-                          \_range: , line:49:14, endln:49:25
-                            |vpiLeftRange:
-                            \_operation: , line:49:14, endln:49:20
-                              |vpiOpType:11
-                              |vpiOperand:
-                              \_ref_obj: (work@test_program.get_command_from_slave_0.cmd.Command.addr.ADDR_W), line:49:14, endln:49:20
-                                |vpiName:ADDR_W
-                                |vpiFullName:work@test_program.get_command_from_slave_0.cmd.Command.addr.ADDR_W
-                                |vpiActual:
-                                \_parameter: (work@test_program.ADDR_W), line:13:14, endln:13:43, parent:work@test_program
-                              |vpiOperand:
-                              \_constant: , line:49:21, endln:49:22
-                                |vpiConstType:9
-                                |vpiDecompile:1
-                                |vpiSize:64
-                                |UINT:1
-                            |vpiRightRange:
-                            \_constant: , line:49:24, endln:49:25
-                              |vpiConstType:9
-                              |vpiDecompile:0
-                              |vpiSize:64
-                              |UINT:0
-                      |vpiTypespecMember:
-                      \_typespec_member: (data), line:50:36, endln:50:40, parent:Command
-                        |vpiName:data
-                        |vpiTypespec:
-                        \_logic_typespec: , line:50:7, endln:50:12, parent:data
-                          |vpiRange:
-                          \_range: , line:50:14, endln:50:24
-                            |vpiLeftRange:
-                            \_operation: , line:50:14, endln:50:20
-                              |vpiOpType:11
-                              |vpiOperand:
-                              \_ref_obj: (work@test_program.get_command_from_slave_0.cmd.Command.data.DATA_W), line:50:14, endln:50:20
-                                |vpiName:DATA_W
-                                |vpiFullName:work@test_program.get_command_from_slave_0.cmd.Command.data.DATA_W
-                                |vpiActual:
-                                \_parameter: (work@test_program.DATA_W), line:17:14, endln:17:63, parent:work@test_program
-                              |vpiOperand:
-                              \_constant: , line:50:21, endln:50:22
-                                |vpiConstType:9
-                                |vpiDecompile:1
-                                |vpiSize:64
-                                |UINT:1
-                            |vpiRightRange:
-                            \_constant: , line:50:23, endln:50:24
-                              |vpiConstType:9
-                              |vpiDecompile:0
-                              |vpiSize:64
-                              |UINT:0
-                      |vpiTypespecMember:
-                      \_typespec_member: (byteenable), line:51:36, endln:51:46, parent:Command
-                        |vpiName:byteenable
-                        |vpiTypespec:
-                        \_logic_typespec: , line:51:7, endln:51:12, parent:byteenable
-                          |vpiRange:
-                          \_range: , line:51:14, endln:51:29
-                            |vpiLeftRange:
-                            \_operation: , line:51:14, endln:51:25
-                              |vpiOpType:11
-                              |vpiOperand:
-                              \_ref_obj: (work@test_program.get_command_from_slave_0.cmd.Command.byteenable.NUM_SYMBOLS), line:51:14, endln:51:25
-                                |vpiName:NUM_SYMBOLS
-                                |vpiFullName:work@test_program.get_command_from_slave_0.cmd.Command.byteenable.NUM_SYMBOLS
-                                |vpiActual:
-                                \_parameter: (work@test_program.NUM_SYMBOLS), line:16:14, endln:16:42, parent:work@test_program
-                              |vpiOperand:
-                              \_constant: , line:51:26, endln:51:27
-                                |vpiConstType:9
-                                |vpiDecompile:1
-                                |vpiSize:64
-                                |UINT:1
-                            |vpiRightRange:
-                            \_constant: , line:51:28, endln:51:29
-                              |vpiConstType:9
-                              |vpiDecompile:0
-                              |vpiSize:64
-                              |UINT:0
-                      |vpiTypespecMember:
-                      \_typespec_member: (cmd_delay), line:52:36, endln:52:45, parent:Command
-                        |vpiName:cmd_delay
-                        |vpiTypespec:
-                        \_bit_typespec: , line:52:7, endln:52:10, parent:cmd_delay
-                          |vpiRange:
-                          \_range: , line:52:12, endln:52:16
-                            |vpiLeftRange:
-                            \_constant: , line:52:12, endln:52:14
-                              |vpiConstType:9
-                              |vpiDecompile:31
-                              |vpiSize:64
-                              |UINT:31
-                            |vpiRightRange:
-                            \_constant: , line:52:15, endln:52:16
-                              |vpiConstType:9
-                              |vpiDecompile:0
-                              |vpiSize:64
-                              |UINT:0
-                      |vpiTypespecMember:
-                      \_typespec_member: (data_idles), line:53:36, endln:53:46, parent:Command
-                        |vpiName:data_idles
-                        |vpiTypespec:
-                        \_bit_typespec: , line:53:7, endln:53:10, parent:data_idles
-                          |vpiRange:
-                          \_range: , line:53:12, endln:53:16
-                            |vpiLeftRange:
-                            \_constant: , line:53:12, endln:53:14
-                              |vpiConstType:9
-                              |vpiDecompile:31
-                              |vpiSize:64
-                              |UINT:31
-                            |vpiRightRange:
-                            \_constant: , line:53:15, endln:53:16
-                              |vpiConstType:9
-                              |vpiDecompile:0
-                              |vpiSize:64
-                              |UINT:0
+                    \_struct_typespec: (Command), line:45:11, endln:45:17
                 |vpiActual:
                 \_ref_obj: (burstcount), parent:cmd.burstcount
                   |vpiName:burstcount
@@ -22131,10 +19722,6 @@ design: (work@top)
             \_assign_stmt: , parent:work@test_program.get_command_from_slave_0
               |vpiRhs:
               \_constant: , line:319:21, endln:319:22
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
               |vpiLhs:
               \_int_var: (work@test_program.get_command_from_slave_0.i), line:319:13, endln:319:16
                 |vpiName:i
@@ -22251,110 +19838,7 @@ design: (work@top)
       |vpiName:rsp
       |vpiDirection:1
       |vpiTypedef:
-      \_struct_typespec: (Response), line:56:11, endln:56:17, parent:rsp
-        |vpiName:Response
-        |vpiTypespecMember:
-        \_typespec_member: (burstcount), line:58:36, endln:58:46, parent:Response
-          |vpiName:burstcount
-          |vpiTypespec:
-          \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:burstcount
-            |vpiName:Burstcount
-            |vpiRange:
-            \_range: , line:31:18, endln:31:29, parent:Burstcount
-              |vpiLeftRange:
-              \_operation: , line:31:18, endln:31:25
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.configure_and_push_response_to_slave_0.rsp.Response.burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                  |vpiName:BURST_W
-                  |vpiFullName:work@test_program.configure_and_push_response_to_slave_0.rsp.Response.burstcount.Burstcount.BURST_W
-                  |vpiActual:
-                  \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:31:26, endln:31:27
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:31:28, endln:31:29
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-            |vpiTypedefAlias:
-            \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:Burstcount
-              |vpiName:Burstcount
-              |vpiRange:
-              \_range: , line:31:18, endln:31:29, parent:Burstcount
-                |vpiLeftRange:
-                \_operation: , line:31:18, endln:31:25
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (work@test_program.configure_and_push_response_to_slave_0.rsp.Response.burstcount.Burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                    |vpiName:BURST_W
-                    |vpiFullName:work@test_program.configure_and_push_response_to_slave_0.rsp.Response.burstcount.Burstcount.Burstcount.BURST_W
-                    |vpiActual:
-                    \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                  |vpiOperand:
-                  \_constant: , line:31:26, endln:31:27
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:31:28, endln:31:29
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (data), line:59:36, endln:59:40, parent:Response
-          |vpiName:data
-          |vpiTypespec:
-          \_logic_typespec: , line:59:6, endln:59:11, parent:data
-            |vpiRange:
-            \_range: , line:59:13, endln:59:23
-              |vpiLeftRange:
-              \_operation: , line:59:13, endln:59:19
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.configure_and_push_response_to_slave_0.rsp.Response.data.DATA_W), line:59:13, endln:59:19
-                  |vpiName:DATA_W
-                  |vpiFullName:work@test_program.configure_and_push_response_to_slave_0.rsp.Response.data.DATA_W
-                  |vpiActual:
-                  \_parameter: (work@test_program.DATA_W), line:17:14, endln:17:63, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:59:20, endln:59:21
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:59:22, endln:59:23
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (latency), line:60:36, endln:60:43, parent:Response
-          |vpiName:latency
-          |vpiTypespec:
-          \_bit_typespec: , line:60:6, endln:60:9, parent:latency
-            |vpiRange:
-            \_range: , line:60:11, endln:60:15
-              |vpiLeftRange:
-              \_constant: , line:60:11, endln:60:13
-                |vpiConstType:9
-                |vpiDecompile:31
-                |vpiSize:64
-                |UINT:31
-              |vpiRightRange:
-              \_constant: , line:60:14, endln:60:15
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
+      \_struct_typespec: (Response), line:56:11, endln:56:17
     |vpiStmt:
     \_begin: (work@test_program.configure_and_push_response_to_slave_0), parent:work@test_program.configure_and_push_response_to_slave_0
       |vpiFullName:work@test_program.configure_and_push_response_to_slave_0
@@ -22404,10 +19888,6 @@ design: (work@top)
         \_assign_stmt: , parent:work@test_program.configure_and_push_response_to_slave_0
           |vpiRhs:
           \_constant: , line:348:19, endln:348:20
-            |vpiConstType:9
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
           |vpiLhs:
           \_int_var: (work@test_program.configure_and_push_response_to_slave_0.i), line:348:11, endln:348:14
             |vpiName:i
@@ -22455,10 +19935,6 @@ design: (work@top)
                 |vpiFullName:work@test_program.configure_and_push_response_to_slave_0.i
               |vpiOperand:
               \_constant: , line:351:18, endln:351:19
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
             |vpiStmt:
             \_begin: (work@test_program.configure_and_push_response_to_slave_0), line:351:21, endln:354:12
               |vpiFullName:work@test_program.configure_and_push_response_to_slave_0
@@ -22624,10 +20100,6 @@ design: (work@top)
                 |vpiName:burstcount
           |vpiOperand:
           \_constant: , line:361:107, endln:361:108
-            |vpiConstType:9
-            |vpiDecompile:1
-            |vpiSize:64
-            |UINT:1
     |vpiVariables:
     \_int_var: (work@test_program.configure_and_push_response_to_slave_0.read_response_latency), line:344:6, endln:344:9, parent:work@test_program.configure_and_push_response_to_slave_0
       |vpiName:read_response_latency
@@ -22645,205 +20117,7 @@ design: (work@top)
       |vpiName:cmd
       |vpiDirection:1
       |vpiTypedef:
-      \_struct_typespec: (Command), line:45:11, endln:45:17, parent:cmd
-        |vpiName:Command
-        |vpiTypespecMember:
-        \_typespec_member: (trans), line:47:36, endln:47:41, parent:Command
-          |vpiName:trans
-          |vpiTypespec:
-          \_enum_typespec: (Transaction), line:37:5, endln:37:16, parent:trans
-            |vpiName:Transaction
-            |vpiBaseTypespec:
-            \_bit_typespec: , line:33:16, endln:33:19, parent:Transaction
-            |vpiEnumConst:
-            \_enum_const: (WRITE), line:35:7, endln:35:12, parent:Transaction
-              |vpiName:WRITE
-              |vpiDecompile:0
-              |UINT:0
-              |vpiSize:64
-            |vpiEnumConst:
-            \_enum_const: (READ), line:36:7, endln:36:11, parent:Transaction
-              |vpiName:READ
-              |vpiDecompile:1
-              |UINT:1
-              |vpiSize:64
-        |vpiTypespecMember:
-        \_typespec_member: (burstcount), line:48:36, endln:48:46, parent:Command
-          |vpiName:burstcount
-          |vpiTypespec:
-          \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:burstcount
-            |vpiName:Burstcount
-            |vpiRange:
-            \_range: , line:31:18, endln:31:29, parent:Burstcount
-              |vpiLeftRange:
-              \_operation: , line:31:18, endln:31:25
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.configure_and_push_command_to_master_1.cmd.Command.burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                  |vpiName:BURST_W
-                  |vpiFullName:work@test_program.configure_and_push_command_to_master_1.cmd.Command.burstcount.Burstcount.BURST_W
-                  |vpiActual:
-                  \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:31:26, endln:31:27
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:31:28, endln:31:29
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-            |vpiTypedefAlias:
-            \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:Burstcount
-              |vpiName:Burstcount
-              |vpiRange:
-              \_range: , line:31:18, endln:31:29, parent:Burstcount
-                |vpiLeftRange:
-                \_operation: , line:31:18, endln:31:25
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (work@test_program.configure_and_push_command_to_master_1.cmd.Command.burstcount.Burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                    |vpiName:BURST_W
-                    |vpiFullName:work@test_program.configure_and_push_command_to_master_1.cmd.Command.burstcount.Burstcount.Burstcount.BURST_W
-                    |vpiActual:
-                    \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                  |vpiOperand:
-                  \_constant: , line:31:26, endln:31:27
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:31:28, endln:31:29
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (addr), line:49:36, endln:49:40, parent:Command
-          |vpiName:addr
-          |vpiTypespec:
-          \_logic_typespec: , line:49:7, endln:49:12, parent:addr
-            |vpiRange:
-            \_range: , line:49:14, endln:49:25
-              |vpiLeftRange:
-              \_operation: , line:49:14, endln:49:20
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.configure_and_push_command_to_master_1.cmd.Command.addr.ADDR_W), line:49:14, endln:49:20
-                  |vpiName:ADDR_W
-                  |vpiFullName:work@test_program.configure_and_push_command_to_master_1.cmd.Command.addr.ADDR_W
-                  |vpiActual:
-                  \_parameter: (work@test_program.ADDR_W), line:13:14, endln:13:43, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:49:21, endln:49:22
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:49:24, endln:49:25
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (data), line:50:36, endln:50:40, parent:Command
-          |vpiName:data
-          |vpiTypespec:
-          \_logic_typespec: , line:50:7, endln:50:12, parent:data
-            |vpiRange:
-            \_range: , line:50:14, endln:50:24
-              |vpiLeftRange:
-              \_operation: , line:50:14, endln:50:20
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.configure_and_push_command_to_master_1.cmd.Command.data.DATA_W), line:50:14, endln:50:20
-                  |vpiName:DATA_W
-                  |vpiFullName:work@test_program.configure_and_push_command_to_master_1.cmd.Command.data.DATA_W
-                  |vpiActual:
-                  \_parameter: (work@test_program.DATA_W), line:17:14, endln:17:63, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:50:21, endln:50:22
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:50:23, endln:50:24
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (byteenable), line:51:36, endln:51:46, parent:Command
-          |vpiName:byteenable
-          |vpiTypespec:
-          \_logic_typespec: , line:51:7, endln:51:12, parent:byteenable
-            |vpiRange:
-            \_range: , line:51:14, endln:51:29
-              |vpiLeftRange:
-              \_operation: , line:51:14, endln:51:25
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.configure_and_push_command_to_master_1.cmd.Command.byteenable.NUM_SYMBOLS), line:51:14, endln:51:25
-                  |vpiName:NUM_SYMBOLS
-                  |vpiFullName:work@test_program.configure_and_push_command_to_master_1.cmd.Command.byteenable.NUM_SYMBOLS
-                  |vpiActual:
-                  \_parameter: (work@test_program.NUM_SYMBOLS), line:16:14, endln:16:42, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:51:26, endln:51:27
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:51:28, endln:51:29
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (cmd_delay), line:52:36, endln:52:45, parent:Command
-          |vpiName:cmd_delay
-          |vpiTypespec:
-          \_bit_typespec: , line:52:7, endln:52:10, parent:cmd_delay
-            |vpiRange:
-            \_range: , line:52:12, endln:52:16
-              |vpiLeftRange:
-              \_constant: , line:52:12, endln:52:14
-                |vpiConstType:9
-                |vpiDecompile:31
-                |vpiSize:64
-                |UINT:31
-              |vpiRightRange:
-              \_constant: , line:52:15, endln:52:16
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (data_idles), line:53:36, endln:53:46, parent:Command
-          |vpiName:data_idles
-          |vpiTypespec:
-          \_bit_typespec: , line:53:7, endln:53:10, parent:data_idles
-            |vpiRange:
-            \_range: , line:53:12, endln:53:16
-              |vpiLeftRange:
-              \_constant: , line:53:12, endln:53:14
-                |vpiConstType:9
-                |vpiDecompile:31
-                |vpiSize:64
-                |UINT:31
-              |vpiRightRange:
-              \_constant: , line:53:15, endln:53:16
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
+      \_struct_typespec: (Command), line:45:11, endln:45:17
     |vpiStmt:
     \_begin: (work@test_program.configure_and_push_command_to_master_1), parent:work@test_program.configure_and_push_command_to_master_1
       |vpiFullName:work@test_program.configure_and_push_command_to_master_1
@@ -22960,10 +20234,6 @@ design: (work@top)
             \_assign_stmt: , parent:work@test_program.configure_and_push_command_to_master_1
               |vpiRhs:
               \_constant: , line:377:22, endln:377:23
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
               |vpiLhs:
               \_int_var: (work@test_program.configure_and_push_command_to_master_1.i), line:377:14, endln:377:17
                 |vpiName:i
@@ -23069,17 +20339,9 @@ design: (work@top)
               \_bit_select: (data_idles), parent:cmd.data_idles[0]
                 |vpiName:data_idles
                 |vpiIndex:
-                \_constant: , line:384:63, endln:384:64, parent:data_idles
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
+                \_constant: , line:384:63, endln:384:64
             |vpiArgument:
-            \_constant: , line:384:67, endln:384:68, parent:$root.tb.dut.master_1.set_command_idle
-              |vpiConstType:9
-              |vpiDecompile:0
-              |vpiSize:64
-              |UINT:0
+            \_constant: , line:384:67, endln:384:68
       |vpiStmt:
       \_func_call: ($root.tb.dut.master_1.push_command), line:387:6, endln:387:43, parent:work@test_program.configure_and_push_command_to_master_1
         |vpiName:$root.tb.dut.master_1.push_command
@@ -23147,110 +20409,7 @@ design: (work@top)
                 |vpiName:rsp
                 |vpiFullName:work@test_program.get_read_response_from_master_1.rsp
                 |vpiTypespec:
-                \_struct_typespec: (Response), line:56:11, endln:56:17, parent:work@test_program.get_read_response_from_master_1.rsp
-                  |vpiName:Response
-                  |vpiTypespecMember:
-                  \_typespec_member: (burstcount), line:58:36, endln:58:46, parent:Response
-                    |vpiName:burstcount
-                    |vpiTypespec:
-                    \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:burstcount
-                      |vpiName:Burstcount
-                      |vpiRange:
-                      \_range: , line:31:18, endln:31:29, parent:Burstcount
-                        |vpiLeftRange:
-                        \_operation: , line:31:18, endln:31:25
-                          |vpiOpType:11
-                          |vpiOperand:
-                          \_ref_obj: (work@test_program.get_read_response_from_master_1.rsp.Response.burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                            |vpiName:BURST_W
-                            |vpiFullName:work@test_program.get_read_response_from_master_1.rsp.Response.burstcount.Burstcount.BURST_W
-                            |vpiActual:
-                            \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                          |vpiOperand:
-                          \_constant: , line:31:26, endln:31:27
-                            |vpiConstType:9
-                            |vpiDecompile:1
-                            |vpiSize:64
-                            |UINT:1
-                        |vpiRightRange:
-                        \_constant: , line:31:28, endln:31:29
-                          |vpiConstType:9
-                          |vpiDecompile:0
-                          |vpiSize:64
-                          |UINT:0
-                      |vpiTypedefAlias:
-                      \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:Burstcount
-                        |vpiName:Burstcount
-                        |vpiRange:
-                        \_range: , line:31:18, endln:31:29, parent:Burstcount
-                          |vpiLeftRange:
-                          \_operation: , line:31:18, endln:31:25
-                            |vpiOpType:11
-                            |vpiOperand:
-                            \_ref_obj: (work@test_program.get_read_response_from_master_1.rsp.Response.burstcount.Burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                              |vpiName:BURST_W
-                              |vpiFullName:work@test_program.get_read_response_from_master_1.rsp.Response.burstcount.Burstcount.Burstcount.BURST_W
-                              |vpiActual:
-                              \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                            |vpiOperand:
-                            \_constant: , line:31:26, endln:31:27
-                              |vpiConstType:9
-                              |vpiDecompile:1
-                              |vpiSize:64
-                              |UINT:1
-                          |vpiRightRange:
-                          \_constant: , line:31:28, endln:31:29
-                            |vpiConstType:9
-                            |vpiDecompile:0
-                            |vpiSize:64
-                            |UINT:0
-                  |vpiTypespecMember:
-                  \_typespec_member: (data), line:59:36, endln:59:40, parent:Response
-                    |vpiName:data
-                    |vpiTypespec:
-                    \_logic_typespec: , line:59:6, endln:59:11, parent:data
-                      |vpiRange:
-                      \_range: , line:59:13, endln:59:23
-                        |vpiLeftRange:
-                        \_operation: , line:59:13, endln:59:19
-                          |vpiOpType:11
-                          |vpiOperand:
-                          \_ref_obj: (work@test_program.get_read_response_from_master_1.rsp.Response.data.DATA_W), line:59:13, endln:59:19
-                            |vpiName:DATA_W
-                            |vpiFullName:work@test_program.get_read_response_from_master_1.rsp.Response.data.DATA_W
-                            |vpiActual:
-                            \_parameter: (work@test_program.DATA_W), line:17:14, endln:17:63, parent:work@test_program
-                          |vpiOperand:
-                          \_constant: , line:59:20, endln:59:21
-                            |vpiConstType:9
-                            |vpiDecompile:1
-                            |vpiSize:64
-                            |UINT:1
-                        |vpiRightRange:
-                        \_constant: , line:59:22, endln:59:23
-                          |vpiConstType:9
-                          |vpiDecompile:0
-                          |vpiSize:64
-                          |UINT:0
-                  |vpiTypespecMember:
-                  \_typespec_member: (latency), line:60:36, endln:60:43, parent:Response
-                    |vpiName:latency
-                    |vpiTypespec:
-                    \_bit_typespec: , line:60:6, endln:60:9, parent:latency
-                      |vpiRange:
-                      \_range: , line:60:11, endln:60:15
-                        |vpiLeftRange:
-                        \_constant: , line:60:11, endln:60:13
-                          |vpiConstType:9
-                          |vpiDecompile:31
-                          |vpiSize:64
-                          |UINT:31
-                        |vpiRightRange:
-                        \_constant: , line:60:14, endln:60:15
-                          |vpiConstType:9
-                          |vpiDecompile:0
-                          |vpiSize:64
-                          |UINT:0
+                \_struct_typespec: (Response), line:56:11, endln:56:17
             |vpiActual:
             \_ref_obj: (burstcount), parent:rsp.burstcount
               |vpiName:burstcount
@@ -23258,10 +20417,6 @@ design: (work@top)
         \_assign_stmt: , parent:work@test_program.get_read_response_from_master_1
           |vpiRhs:
           \_constant: , line:415:19, endln:415:20
-            |vpiConstType:9
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
           |vpiLhs:
           \_int_var: (work@test_program.get_read_response_from_master_1.i), line:415:11, endln:415:14
             |vpiName:i
@@ -23453,205 +20608,7 @@ design: (work@top)
                     |vpiName:cmd
                     |vpiFullName:work@test_program.get_command_from_slave_1.cmd
                     |vpiTypespec:
-                    \_struct_typespec: (Command), line:45:11, endln:45:17, parent:work@test_program.get_command_from_slave_1.cmd
-                      |vpiName:Command
-                      |vpiTypespecMember:
-                      \_typespec_member: (trans), line:47:36, endln:47:41, parent:Command
-                        |vpiName:trans
-                        |vpiTypespec:
-                        \_enum_typespec: (Transaction), line:37:5, endln:37:16, parent:trans
-                          |vpiName:Transaction
-                          |vpiBaseTypespec:
-                          \_bit_typespec: , line:33:16, endln:33:19, parent:Transaction
-                          |vpiEnumConst:
-                          \_enum_const: (WRITE), line:35:7, endln:35:12, parent:Transaction
-                            |vpiName:WRITE
-                            |vpiDecompile:0
-                            |UINT:0
-                            |vpiSize:64
-                          |vpiEnumConst:
-                          \_enum_const: (READ), line:36:7, endln:36:11, parent:Transaction
-                            |vpiName:READ
-                            |vpiDecompile:1
-                            |UINT:1
-                            |vpiSize:64
-                      |vpiTypespecMember:
-                      \_typespec_member: (burstcount), line:48:36, endln:48:46, parent:Command
-                        |vpiName:burstcount
-                        |vpiTypespec:
-                        \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:burstcount
-                          |vpiName:Burstcount
-                          |vpiRange:
-                          \_range: , line:31:18, endln:31:29, parent:Burstcount
-                            |vpiLeftRange:
-                            \_operation: , line:31:18, endln:31:25
-                              |vpiOpType:11
-                              |vpiOperand:
-                              \_ref_obj: (work@test_program.get_command_from_slave_1.cmd.Command.burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                                |vpiName:BURST_W
-                                |vpiFullName:work@test_program.get_command_from_slave_1.cmd.Command.burstcount.Burstcount.BURST_W
-                                |vpiActual:
-                                \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                              |vpiOperand:
-                              \_constant: , line:31:26, endln:31:27
-                                |vpiConstType:9
-                                |vpiDecompile:1
-                                |vpiSize:64
-                                |UINT:1
-                            |vpiRightRange:
-                            \_constant: , line:31:28, endln:31:29
-                              |vpiConstType:9
-                              |vpiDecompile:0
-                              |vpiSize:64
-                              |UINT:0
-                          |vpiTypedefAlias:
-                          \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:Burstcount
-                            |vpiName:Burstcount
-                            |vpiRange:
-                            \_range: , line:31:18, endln:31:29, parent:Burstcount
-                              |vpiLeftRange:
-                              \_operation: , line:31:18, endln:31:25
-                                |vpiOpType:11
-                                |vpiOperand:
-                                \_ref_obj: (work@test_program.get_command_from_slave_1.cmd.Command.burstcount.Burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                                  |vpiName:BURST_W
-                                  |vpiFullName:work@test_program.get_command_from_slave_1.cmd.Command.burstcount.Burstcount.Burstcount.BURST_W
-                                  |vpiActual:
-                                  \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                                |vpiOperand:
-                                \_constant: , line:31:26, endln:31:27
-                                  |vpiConstType:9
-                                  |vpiDecompile:1
-                                  |vpiSize:64
-                                  |UINT:1
-                              |vpiRightRange:
-                              \_constant: , line:31:28, endln:31:29
-                                |vpiConstType:9
-                                |vpiDecompile:0
-                                |vpiSize:64
-                                |UINT:0
-                      |vpiTypespecMember:
-                      \_typespec_member: (addr), line:49:36, endln:49:40, parent:Command
-                        |vpiName:addr
-                        |vpiTypespec:
-                        \_logic_typespec: , line:49:7, endln:49:12, parent:addr
-                          |vpiRange:
-                          \_range: , line:49:14, endln:49:25
-                            |vpiLeftRange:
-                            \_operation: , line:49:14, endln:49:20
-                              |vpiOpType:11
-                              |vpiOperand:
-                              \_ref_obj: (work@test_program.get_command_from_slave_1.cmd.Command.addr.ADDR_W), line:49:14, endln:49:20
-                                |vpiName:ADDR_W
-                                |vpiFullName:work@test_program.get_command_from_slave_1.cmd.Command.addr.ADDR_W
-                                |vpiActual:
-                                \_parameter: (work@test_program.ADDR_W), line:13:14, endln:13:43, parent:work@test_program
-                              |vpiOperand:
-                              \_constant: , line:49:21, endln:49:22
-                                |vpiConstType:9
-                                |vpiDecompile:1
-                                |vpiSize:64
-                                |UINT:1
-                            |vpiRightRange:
-                            \_constant: , line:49:24, endln:49:25
-                              |vpiConstType:9
-                              |vpiDecompile:0
-                              |vpiSize:64
-                              |UINT:0
-                      |vpiTypespecMember:
-                      \_typespec_member: (data), line:50:36, endln:50:40, parent:Command
-                        |vpiName:data
-                        |vpiTypespec:
-                        \_logic_typespec: , line:50:7, endln:50:12, parent:data
-                          |vpiRange:
-                          \_range: , line:50:14, endln:50:24
-                            |vpiLeftRange:
-                            \_operation: , line:50:14, endln:50:20
-                              |vpiOpType:11
-                              |vpiOperand:
-                              \_ref_obj: (work@test_program.get_command_from_slave_1.cmd.Command.data.DATA_W), line:50:14, endln:50:20
-                                |vpiName:DATA_W
-                                |vpiFullName:work@test_program.get_command_from_slave_1.cmd.Command.data.DATA_W
-                                |vpiActual:
-                                \_parameter: (work@test_program.DATA_W), line:17:14, endln:17:63, parent:work@test_program
-                              |vpiOperand:
-                              \_constant: , line:50:21, endln:50:22
-                                |vpiConstType:9
-                                |vpiDecompile:1
-                                |vpiSize:64
-                                |UINT:1
-                            |vpiRightRange:
-                            \_constant: , line:50:23, endln:50:24
-                              |vpiConstType:9
-                              |vpiDecompile:0
-                              |vpiSize:64
-                              |UINT:0
-                      |vpiTypespecMember:
-                      \_typespec_member: (byteenable), line:51:36, endln:51:46, parent:Command
-                        |vpiName:byteenable
-                        |vpiTypespec:
-                        \_logic_typespec: , line:51:7, endln:51:12, parent:byteenable
-                          |vpiRange:
-                          \_range: , line:51:14, endln:51:29
-                            |vpiLeftRange:
-                            \_operation: , line:51:14, endln:51:25
-                              |vpiOpType:11
-                              |vpiOperand:
-                              \_ref_obj: (work@test_program.get_command_from_slave_1.cmd.Command.byteenable.NUM_SYMBOLS), line:51:14, endln:51:25
-                                |vpiName:NUM_SYMBOLS
-                                |vpiFullName:work@test_program.get_command_from_slave_1.cmd.Command.byteenable.NUM_SYMBOLS
-                                |vpiActual:
-                                \_parameter: (work@test_program.NUM_SYMBOLS), line:16:14, endln:16:42, parent:work@test_program
-                              |vpiOperand:
-                              \_constant: , line:51:26, endln:51:27
-                                |vpiConstType:9
-                                |vpiDecompile:1
-                                |vpiSize:64
-                                |UINT:1
-                            |vpiRightRange:
-                            \_constant: , line:51:28, endln:51:29
-                              |vpiConstType:9
-                              |vpiDecompile:0
-                              |vpiSize:64
-                              |UINT:0
-                      |vpiTypespecMember:
-                      \_typespec_member: (cmd_delay), line:52:36, endln:52:45, parent:Command
-                        |vpiName:cmd_delay
-                        |vpiTypespec:
-                        \_bit_typespec: , line:52:7, endln:52:10, parent:cmd_delay
-                          |vpiRange:
-                          \_range: , line:52:12, endln:52:16
-                            |vpiLeftRange:
-                            \_constant: , line:52:12, endln:52:14
-                              |vpiConstType:9
-                              |vpiDecompile:31
-                              |vpiSize:64
-                              |UINT:31
-                            |vpiRightRange:
-                            \_constant: , line:52:15, endln:52:16
-                              |vpiConstType:9
-                              |vpiDecompile:0
-                              |vpiSize:64
-                              |UINT:0
-                      |vpiTypespecMember:
-                      \_typespec_member: (data_idles), line:53:36, endln:53:46, parent:Command
-                        |vpiName:data_idles
-                        |vpiTypespec:
-                        \_bit_typespec: , line:53:7, endln:53:10, parent:data_idles
-                          |vpiRange:
-                          \_range: , line:53:12, endln:53:16
-                            |vpiLeftRange:
-                            \_constant: , line:53:12, endln:53:14
-                              |vpiConstType:9
-                              |vpiDecompile:31
-                              |vpiSize:64
-                              |UINT:31
-                            |vpiRightRange:
-                            \_constant: , line:53:15, endln:53:16
-                              |vpiConstType:9
-                              |vpiDecompile:0
-                              |vpiSize:64
-                              |UINT:0
+                    \_struct_typespec: (Command), line:45:11, endln:45:17
                 |vpiActual:
                 \_ref_obj: (burstcount), parent:cmd.burstcount
                   |vpiName:burstcount
@@ -23659,10 +20616,6 @@ design: (work@top)
             \_assign_stmt: , parent:work@test_program.get_command_from_slave_1
               |vpiRhs:
               \_constant: , line:462:21, endln:462:22
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
               |vpiLhs:
               \_int_var: (work@test_program.get_command_from_slave_1.i), line:462:13, endln:462:16
                 |vpiName:i
@@ -23779,110 +20732,7 @@ design: (work@top)
       |vpiName:rsp
       |vpiDirection:1
       |vpiTypedef:
-      \_struct_typespec: (Response), line:56:11, endln:56:17, parent:rsp
-        |vpiName:Response
-        |vpiTypespecMember:
-        \_typespec_member: (burstcount), line:58:36, endln:58:46, parent:Response
-          |vpiName:burstcount
-          |vpiTypespec:
-          \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:burstcount
-            |vpiName:Burstcount
-            |vpiRange:
-            \_range: , line:31:18, endln:31:29, parent:Burstcount
-              |vpiLeftRange:
-              \_operation: , line:31:18, endln:31:25
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.configure_and_push_response_to_slave_1.rsp.Response.burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                  |vpiName:BURST_W
-                  |vpiFullName:work@test_program.configure_and_push_response_to_slave_1.rsp.Response.burstcount.Burstcount.BURST_W
-                  |vpiActual:
-                  \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:31:26, endln:31:27
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:31:28, endln:31:29
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-            |vpiTypedefAlias:
-            \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:Burstcount
-              |vpiName:Burstcount
-              |vpiRange:
-              \_range: , line:31:18, endln:31:29, parent:Burstcount
-                |vpiLeftRange:
-                \_operation: , line:31:18, endln:31:25
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (work@test_program.configure_and_push_response_to_slave_1.rsp.Response.burstcount.Burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                    |vpiName:BURST_W
-                    |vpiFullName:work@test_program.configure_and_push_response_to_slave_1.rsp.Response.burstcount.Burstcount.Burstcount.BURST_W
-                    |vpiActual:
-                    \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                  |vpiOperand:
-                  \_constant: , line:31:26, endln:31:27
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:31:28, endln:31:29
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (data), line:59:36, endln:59:40, parent:Response
-          |vpiName:data
-          |vpiTypespec:
-          \_logic_typespec: , line:59:6, endln:59:11, parent:data
-            |vpiRange:
-            \_range: , line:59:13, endln:59:23
-              |vpiLeftRange:
-              \_operation: , line:59:13, endln:59:19
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.configure_and_push_response_to_slave_1.rsp.Response.data.DATA_W), line:59:13, endln:59:19
-                  |vpiName:DATA_W
-                  |vpiFullName:work@test_program.configure_and_push_response_to_slave_1.rsp.Response.data.DATA_W
-                  |vpiActual:
-                  \_parameter: (work@test_program.DATA_W), line:17:14, endln:17:63, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:59:20, endln:59:21
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:59:22, endln:59:23
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (latency), line:60:36, endln:60:43, parent:Response
-          |vpiName:latency
-          |vpiTypespec:
-          \_bit_typespec: , line:60:6, endln:60:9, parent:latency
-            |vpiRange:
-            \_range: , line:60:11, endln:60:15
-              |vpiLeftRange:
-              \_constant: , line:60:11, endln:60:13
-                |vpiConstType:9
-                |vpiDecompile:31
-                |vpiSize:64
-                |UINT:31
-              |vpiRightRange:
-              \_constant: , line:60:14, endln:60:15
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
+      \_struct_typespec: (Response), line:56:11, endln:56:17
     |vpiStmt:
     \_begin: (work@test_program.configure_and_push_response_to_slave_1), parent:work@test_program.configure_and_push_response_to_slave_1
       |vpiFullName:work@test_program.configure_and_push_response_to_slave_1
@@ -23932,10 +20782,6 @@ design: (work@top)
         \_assign_stmt: , parent:work@test_program.configure_and_push_response_to_slave_1
           |vpiRhs:
           \_constant: , line:491:19, endln:491:20
-            |vpiConstType:9
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
           |vpiLhs:
           \_int_var: (work@test_program.configure_and_push_response_to_slave_1.i), line:491:11, endln:491:14
             |vpiName:i
@@ -23983,10 +20829,6 @@ design: (work@top)
                 |vpiFullName:work@test_program.configure_and_push_response_to_slave_1.i
               |vpiOperand:
               \_constant: , line:494:18, endln:494:19
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
             |vpiStmt:
             \_begin: (work@test_program.configure_and_push_response_to_slave_1), line:494:21, endln:497:12
               |vpiFullName:work@test_program.configure_and_push_response_to_slave_1
@@ -24152,10 +20994,6 @@ design: (work@top)
                 |vpiName:burstcount
           |vpiOperand:
           \_constant: , line:504:107, endln:504:108
-            |vpiConstType:9
-            |vpiDecompile:1
-            |vpiSize:64
-            |UINT:1
     |vpiVariables:
     \_int_var: (work@test_program.configure_and_push_response_to_slave_1.read_response_latency), line:487:6, endln:487:9, parent:work@test_program.configure_and_push_response_to_slave_1
       |vpiName:read_response_latency
@@ -24173,49 +21011,19 @@ design: (work@top)
       |vpiName:num_command
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:545:6, endln:545:9, parent:num_command
+      \_int_typespec: , line:545:6, endln:545:9
     |vpiIODecl:
     \_io_decl: (trans), parent:work@test_program.master_send_commands
       |vpiName:trans
       |vpiDirection:1
       |vpiTypedef:
-      \_enum_typespec: (Transaction), line:37:5, endln:37:16, parent:trans
-        |vpiName:Transaction
-        |vpiBaseTypespec:
-        \_bit_typespec: , line:33:16, endln:33:19, parent:Transaction
-        |vpiEnumConst:
-        \_enum_const: (WRITE), line:35:7, endln:35:12, parent:Transaction
-          |vpiName:WRITE
-          |vpiDecompile:0
-          |UINT:0
-          |vpiSize:64
-        |vpiEnumConst:
-        \_enum_const: (READ), line:36:7, endln:36:11, parent:Transaction
-          |vpiName:READ
-          |vpiDecompile:1
-          |UINT:1
-          |vpiSize:64
+      \_enum_typespec: (Transaction), line:37:5, endln:37:16
     |vpiIODecl:
     \_io_decl: (burstmode), parent:work@test_program.master_send_commands
       |vpiName:burstmode
       |vpiDirection:1
       |vpiTypedef:
-      \_enum_typespec: (Burstmode), line:43:5, endln:43:14, parent:burstmode
-        |vpiName:Burstmode
-        |vpiBaseTypespec:
-        \_bit_typespec: , line:39:16, endln:39:19, parent:Burstmode
-        |vpiEnumConst:
-        \_enum_const: (NOBURST), line:41:7, endln:41:14, parent:Burstmode
-          |vpiName:NOBURST
-          |vpiDecompile:0
-          |UINT:0
-          |vpiSize:64
-        |vpiEnumConst:
-        \_enum_const: (BURST), line:42:7, endln:42:12, parent:Burstmode
-          |vpiName:BURST
-          |vpiDecompile:1
-          |UINT:1
-          |vpiSize:64
+      \_enum_typespec: (Burstmode), line:43:5, endln:43:14
     |vpiStmt:
     \_begin: (work@test_program.master_send_commands), parent:work@test_program.master_send_commands
       |vpiFullName:work@test_program.master_send_commands
@@ -24239,10 +21047,6 @@ design: (work@top)
         \_assign_stmt: , parent:work@test_program.master_send_commands
           |vpiRhs:
           \_constant: , line:554:19, endln:554:20
-            |vpiConstType:9
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
           |vpiLhs:
           \_int_var: (work@test_program.master_send_commands.i), line:554:11, endln:554:14
             |vpiName:i
@@ -24271,26 +21075,14 @@ design: (work@top)
             \_sys_func_call: ($urandom_range), line:557:23, endln:557:46
               |vpiName:$urandom_range
               |vpiArgument:
-              \_constant: , line:557:38, endln:557:39, parent:$urandom_range
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
+              \_constant: , line:557:38, endln:557:39
               |vpiArgument:
               \_operation: , line:557:40, endln:557:41, parent:$urandom_range
                 |vpiOpType:11
                 |vpiOperand:
                 \_constant: , line:557:40, endln:557:41
-                  |vpiConstType:9
-                  |vpiDecompile:2
-                  |vpiSize:64
-                  |UINT:2
                 |vpiOperand:
                 \_constant: , line:557:44, endln:557:45
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
           |vpiStmt:
           \_assignment: , line:558:9, endln:558:46, parent:work@test_program.master_send_commands
             |vpiOpType:82
@@ -24305,26 +21097,14 @@ design: (work@top)
             \_sys_func_call: ($urandom_range), line:558:23, endln:558:46
               |vpiName:$urandom_range
               |vpiArgument:
-              \_constant: , line:558:38, endln:558:39, parent:$urandom_range
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
+              \_constant: , line:558:38, endln:558:39
               |vpiArgument:
               \_operation: , line:558:40, endln:558:41, parent:$urandom_range
                 |vpiOpType:11
                 |vpiOperand:
                 \_constant: , line:558:40, endln:558:41
-                  |vpiConstType:9
-                  |vpiDecompile:2
-                  |vpiSize:64
-                  |UINT:2
                 |vpiOperand:
                 \_constant: , line:558:44, endln:558:45
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
           |vpiStmt:
           \_assignment: , line:560:9, endln:564:10, parent:work@test_program.master_send_commands
             |vpiOpType:82
@@ -24386,423 +21166,19 @@ design: (work@top)
       |vpiName:cmd
       |vpiFullName:work@test_program.master_send_commands.cmd
       |vpiTypespec:
-      \_struct_typespec: (Command), line:45:11, endln:45:17, parent:work@test_program.master_send_commands.cmd
-        |vpiName:Command
-        |vpiTypespecMember:
-        \_typespec_member: (trans), line:47:36, endln:47:41, parent:Command
-          |vpiName:trans
-          |vpiTypespec:
-          \_enum_typespec: (Transaction), line:37:5, endln:37:16, parent:trans
-            |vpiName:Transaction
-            |vpiBaseTypespec:
-            \_bit_typespec: , line:33:16, endln:33:19, parent:Transaction
-            |vpiEnumConst:
-            \_enum_const: (WRITE), line:35:7, endln:35:12, parent:Transaction
-              |vpiName:WRITE
-              |vpiDecompile:0
-              |UINT:0
-              |vpiSize:64
-            |vpiEnumConst:
-            \_enum_const: (READ), line:36:7, endln:36:11, parent:Transaction
-              |vpiName:READ
-              |vpiDecompile:1
-              |UINT:1
-              |vpiSize:64
-        |vpiTypespecMember:
-        \_typespec_member: (burstcount), line:48:36, endln:48:46, parent:Command
-          |vpiName:burstcount
-          |vpiTypespec:
-          \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:burstcount
-            |vpiName:Burstcount
-            |vpiRange:
-            \_range: , line:31:18, endln:31:29, parent:Burstcount
-              |vpiLeftRange:
-              \_operation: , line:31:18, endln:31:25
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.master_send_commands.cmd.Command.burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                  |vpiName:BURST_W
-                  |vpiFullName:work@test_program.master_send_commands.cmd.Command.burstcount.Burstcount.BURST_W
-                  |vpiActual:
-                  \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:31:26, endln:31:27
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:31:28, endln:31:29
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-            |vpiTypedefAlias:
-            \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:Burstcount
-              |vpiName:Burstcount
-              |vpiRange:
-              \_range: , line:31:18, endln:31:29, parent:Burstcount
-                |vpiLeftRange:
-                \_operation: , line:31:18, endln:31:25
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (work@test_program.master_send_commands.cmd.Command.burstcount.Burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                    |vpiName:BURST_W
-                    |vpiFullName:work@test_program.master_send_commands.cmd.Command.burstcount.Burstcount.Burstcount.BURST_W
-                    |vpiActual:
-                    \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                  |vpiOperand:
-                  \_constant: , line:31:26, endln:31:27
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:31:28, endln:31:29
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (addr), line:49:36, endln:49:40, parent:Command
-          |vpiName:addr
-          |vpiTypespec:
-          \_logic_typespec: , line:49:7, endln:49:12, parent:addr
-            |vpiRange:
-            \_range: , line:49:14, endln:49:25
-              |vpiLeftRange:
-              \_operation: , line:49:14, endln:49:20
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.master_send_commands.cmd.Command.addr.ADDR_W), line:49:14, endln:49:20
-                  |vpiName:ADDR_W
-                  |vpiFullName:work@test_program.master_send_commands.cmd.Command.addr.ADDR_W
-                  |vpiActual:
-                  \_parameter: (work@test_program.ADDR_W), line:13:14, endln:13:43, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:49:21, endln:49:22
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:49:24, endln:49:25
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (data), line:50:36, endln:50:40, parent:Command
-          |vpiName:data
-          |vpiTypespec:
-          \_logic_typespec: , line:50:7, endln:50:12, parent:data
-            |vpiRange:
-            \_range: , line:50:14, endln:50:24
-              |vpiLeftRange:
-              \_operation: , line:50:14, endln:50:20
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.master_send_commands.cmd.Command.data.DATA_W), line:50:14, endln:50:20
-                  |vpiName:DATA_W
-                  |vpiFullName:work@test_program.master_send_commands.cmd.Command.data.DATA_W
-                  |vpiActual:
-                  \_parameter: (work@test_program.DATA_W), line:17:14, endln:17:63, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:50:21, endln:50:22
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:50:23, endln:50:24
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (byteenable), line:51:36, endln:51:46, parent:Command
-          |vpiName:byteenable
-          |vpiTypespec:
-          \_logic_typespec: , line:51:7, endln:51:12, parent:byteenable
-            |vpiRange:
-            \_range: , line:51:14, endln:51:29
-              |vpiLeftRange:
-              \_operation: , line:51:14, endln:51:25
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.master_send_commands.cmd.Command.byteenable.NUM_SYMBOLS), line:51:14, endln:51:25
-                  |vpiName:NUM_SYMBOLS
-                  |vpiFullName:work@test_program.master_send_commands.cmd.Command.byteenable.NUM_SYMBOLS
-                  |vpiActual:
-                  \_parameter: (work@test_program.NUM_SYMBOLS), line:16:14, endln:16:42, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:51:26, endln:51:27
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:51:28, endln:51:29
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (cmd_delay), line:52:36, endln:52:45, parent:Command
-          |vpiName:cmd_delay
-          |vpiTypespec:
-          \_bit_typespec: , line:52:7, endln:52:10, parent:cmd_delay
-            |vpiRange:
-            \_range: , line:52:12, endln:52:16
-              |vpiLeftRange:
-              \_constant: , line:52:12, endln:52:14
-                |vpiConstType:9
-                |vpiDecompile:31
-                |vpiSize:64
-                |UINT:31
-              |vpiRightRange:
-              \_constant: , line:52:15, endln:52:16
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (data_idles), line:53:36, endln:53:46, parent:Command
-          |vpiName:data_idles
-          |vpiTypespec:
-          \_bit_typespec: , line:53:7, endln:53:10, parent:data_idles
-            |vpiRange:
-            \_range: , line:53:12, endln:53:16
-              |vpiLeftRange:
-              \_constant: , line:53:12, endln:53:14
-                |vpiConstType:9
-                |vpiDecompile:31
-                |vpiSize:64
-                |UINT:31
-              |vpiRightRange:
-              \_constant: , line:53:15, endln:53:16
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
+      \_struct_typespec: (Command), line:45:11, endln:45:17
     |vpiVariables:
     \_struct_var: (work@test_program.master_send_commands.rsp), line:551:6, endln:551:14, parent:work@test_program.master_send_commands
       |vpiName:rsp
       |vpiFullName:work@test_program.master_send_commands.rsp
       |vpiTypespec:
-      \_struct_typespec: (Response), line:56:11, endln:56:17, parent:work@test_program.master_send_commands.rsp
-        |vpiName:Response
-        |vpiTypespecMember:
-        \_typespec_member: (burstcount), line:58:36, endln:58:46, parent:Response
-          |vpiName:burstcount
-          |vpiTypespec:
-          \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:burstcount
-            |vpiName:Burstcount
-            |vpiRange:
-            \_range: , line:31:18, endln:31:29, parent:Burstcount
-              |vpiLeftRange:
-              \_operation: , line:31:18, endln:31:25
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.master_send_commands.rsp.Response.burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                  |vpiName:BURST_W
-                  |vpiFullName:work@test_program.master_send_commands.rsp.Response.burstcount.Burstcount.BURST_W
-                  |vpiActual:
-                  \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:31:26, endln:31:27
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:31:28, endln:31:29
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-            |vpiTypedefAlias:
-            \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:Burstcount
-              |vpiName:Burstcount
-              |vpiRange:
-              \_range: , line:31:18, endln:31:29, parent:Burstcount
-                |vpiLeftRange:
-                \_operation: , line:31:18, endln:31:25
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (work@test_program.master_send_commands.rsp.Response.burstcount.Burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                    |vpiName:BURST_W
-                    |vpiFullName:work@test_program.master_send_commands.rsp.Response.burstcount.Burstcount.Burstcount.BURST_W
-                    |vpiActual:
-                    \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                  |vpiOperand:
-                  \_constant: , line:31:26, endln:31:27
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:31:28, endln:31:29
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (data), line:59:36, endln:59:40, parent:Response
-          |vpiName:data
-          |vpiTypespec:
-          \_logic_typespec: , line:59:6, endln:59:11, parent:data
-            |vpiRange:
-            \_range: , line:59:13, endln:59:23
-              |vpiLeftRange:
-              \_operation: , line:59:13, endln:59:19
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.master_send_commands.rsp.Response.data.DATA_W), line:59:13, endln:59:19
-                  |vpiName:DATA_W
-                  |vpiFullName:work@test_program.master_send_commands.rsp.Response.data.DATA_W
-                  |vpiActual:
-                  \_parameter: (work@test_program.DATA_W), line:17:14, endln:17:63, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:59:20, endln:59:21
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:59:22, endln:59:23
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (latency), line:60:36, endln:60:43, parent:Response
-          |vpiName:latency
-          |vpiTypespec:
-          \_bit_typespec: , line:60:6, endln:60:9, parent:latency
-            |vpiRange:
-            \_range: , line:60:11, endln:60:15
-              |vpiLeftRange:
-              \_constant: , line:60:11, endln:60:13
-                |vpiConstType:9
-                |vpiDecompile:31
-                |vpiSize:64
-                |UINT:31
-              |vpiRightRange:
-              \_constant: , line:60:14, endln:60:15
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
+      \_struct_typespec: (Response), line:56:11, endln:56:17
     |vpiVariables:
     \_struct_var: (work@test_program.master_send_commands.exp_rsp), line:551:6, endln:551:14, parent:work@test_program.master_send_commands
       |vpiName:exp_rsp
       |vpiFullName:work@test_program.master_send_commands.exp_rsp
       |vpiTypespec:
-      \_struct_typespec: (Response), line:56:11, endln:56:17, parent:work@test_program.master_send_commands.exp_rsp
-        |vpiName:Response
-        |vpiTypespecMember:
-        \_typespec_member: (burstcount), line:58:36, endln:58:46, parent:Response
-          |vpiName:burstcount
-          |vpiTypespec:
-          \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:burstcount
-            |vpiName:Burstcount
-            |vpiRange:
-            \_range: , line:31:18, endln:31:29, parent:Burstcount
-              |vpiLeftRange:
-              \_operation: , line:31:18, endln:31:25
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.master_send_commands.exp_rsp.Response.burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                  |vpiName:BURST_W
-                  |vpiFullName:work@test_program.master_send_commands.exp_rsp.Response.burstcount.Burstcount.BURST_W
-                  |vpiActual:
-                  \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:31:26, endln:31:27
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:31:28, endln:31:29
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-            |vpiTypedefAlias:
-            \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:Burstcount
-              |vpiName:Burstcount
-              |vpiRange:
-              \_range: , line:31:18, endln:31:29, parent:Burstcount
-                |vpiLeftRange:
-                \_operation: , line:31:18, endln:31:25
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (work@test_program.master_send_commands.exp_rsp.Response.burstcount.Burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                    |vpiName:BURST_W
-                    |vpiFullName:work@test_program.master_send_commands.exp_rsp.Response.burstcount.Burstcount.Burstcount.BURST_W
-                    |vpiActual:
-                    \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                  |vpiOperand:
-                  \_constant: , line:31:26, endln:31:27
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:31:28, endln:31:29
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (data), line:59:36, endln:59:40, parent:Response
-          |vpiName:data
-          |vpiTypespec:
-          \_logic_typespec: , line:59:6, endln:59:11, parent:data
-            |vpiRange:
-            \_range: , line:59:13, endln:59:23
-              |vpiLeftRange:
-              \_operation: , line:59:13, endln:59:19
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.master_send_commands.exp_rsp.Response.data.DATA_W), line:59:13, endln:59:19
-                  |vpiName:DATA_W
-                  |vpiFullName:work@test_program.master_send_commands.exp_rsp.Response.data.DATA_W
-                  |vpiActual:
-                  \_parameter: (work@test_program.DATA_W), line:17:14, endln:17:63, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:59:20, endln:59:21
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:59:22, endln:59:23
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (latency), line:60:36, endln:60:43, parent:Response
-          |vpiName:latency
-          |vpiTypespec:
-          \_bit_typespec: , line:60:6, endln:60:9, parent:latency
-            |vpiRange:
-            \_range: , line:60:11, endln:60:15
-              |vpiLeftRange:
-              \_constant: , line:60:11, endln:60:13
-                |vpiConstType:9
-                |vpiDecompile:31
-                |vpiSize:64
-                |UINT:31
-              |vpiRightRange:
-              \_constant: , line:60:14, endln:60:15
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
+      \_struct_typespec: (Response), line:56:11, endln:56:17
     |vpiVariables:
     \_int_var: (work@test_program.master_send_commands.master_id), line:552:6, endln:552:9, parent:work@test_program.master_send_commands
       |vpiName:master_id
@@ -24826,49 +21202,19 @@ design: (work@top)
       |vpiName:trans
       |vpiDirection:1
       |vpiTypedef:
-      \_enum_typespec: (Transaction), line:37:5, endln:37:16, parent:trans
-        |vpiName:Transaction
-        |vpiBaseTypespec:
-        \_bit_typespec: , line:33:16, endln:33:19, parent:Transaction
-        |vpiEnumConst:
-        \_enum_const: (WRITE), line:35:7, endln:35:12, parent:Transaction
-          |vpiName:WRITE
-          |vpiDecompile:0
-          |UINT:0
-          |vpiSize:64
-        |vpiEnumConst:
-        \_enum_const: (READ), line:36:7, endln:36:11, parent:Transaction
-          |vpiName:READ
-          |vpiDecompile:1
-          |UINT:1
-          |vpiSize:64
+      \_enum_typespec: (Transaction), line:37:5, endln:37:16
     |vpiIODecl:
     \_io_decl: (burstmode), parent:work@test_program.create_command
       |vpiName:burstmode
       |vpiDirection:1
       |vpiTypedef:
-      \_enum_typespec: (Burstmode), line:43:5, endln:43:14, parent:burstmode
-        |vpiName:Burstmode
-        |vpiBaseTypespec:
-        \_bit_typespec: , line:39:16, endln:39:19, parent:Burstmode
-        |vpiEnumConst:
-        \_enum_const: (NOBURST), line:41:7, endln:41:14, parent:Burstmode
-          |vpiName:NOBURST
-          |vpiDecompile:0
-          |UINT:0
-          |vpiSize:64
-        |vpiEnumConst:
-        \_enum_const: (BURST), line:42:7, endln:42:12, parent:Burstmode
-          |vpiName:BURST
-          |vpiDecompile:1
-          |UINT:1
-          |vpiSize:64
+      \_enum_typespec: (Burstmode), line:43:5, endln:43:14
     |vpiIODecl:
     \_io_decl: (slave_id), parent:work@test_program.create_command
       |vpiName:slave_id
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:573:6, endln:573:9, parent:slave_id
+      \_int_typespec: , line:573:6, endln:573:9
     |vpiStmt:
     \_begin: (work@test_program.create_command), parent:work@test_program.create_command
       |vpiFullName:work@test_program.create_command
@@ -24918,10 +21264,6 @@ design: (work@top)
               |vpiFullName:work@test_program.create_command.cmd.burstcount
             |vpiRhs:
             \_constant: , line:581:38, endln:581:39
-              |vpiConstType:9
-              |vpiDecompile:1
-              |vpiSize:64
-              |UINT:1
       |vpiStmt:
       \_assignment: , line:584:6, endln:584:40, parent:work@test_program.create_command
         |vpiOpType:82
@@ -24967,11 +21309,7 @@ design: (work@top)
         \_sys_func_call: ($urandom_range), line:586:35, endln:586:70
           |vpiName:$urandom_range
           |vpiArgument:
-          \_constant: , line:586:50, endln:586:51, parent:$urandom_range
-            |vpiConstType:9
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
+          \_constant: , line:586:50, endln:586:51
           |vpiArgument:
           \_ref_obj: (work@test_program.create_command.MAX_COMMAND_IDLE), line:586:53, endln:586:69, parent:$urandom_range
             |vpiName:MAX_COMMAND_IDLE
@@ -25019,205 +21357,7 @@ design: (work@top)
                     |vpiName:cmd
                     |vpiFullName:work@test_program.create_command.cmd
                     |vpiTypespec:
-                    \_struct_typespec: (Command), line:45:11, endln:45:17, parent:work@test_program.create_command.cmd
-                      |vpiName:Command
-                      |vpiTypespecMember:
-                      \_typespec_member: (trans), line:47:36, endln:47:41, parent:Command
-                        |vpiName:trans
-                        |vpiTypespec:
-                        \_enum_typespec: (Transaction), line:37:5, endln:37:16, parent:trans
-                          |vpiName:Transaction
-                          |vpiBaseTypespec:
-                          \_bit_typespec: , line:33:16, endln:33:19, parent:Transaction
-                          |vpiEnumConst:
-                          \_enum_const: (WRITE), line:35:7, endln:35:12, parent:Transaction
-                            |vpiName:WRITE
-                            |vpiDecompile:0
-                            |UINT:0
-                            |vpiSize:64
-                          |vpiEnumConst:
-                          \_enum_const: (READ), line:36:7, endln:36:11, parent:Transaction
-                            |vpiName:READ
-                            |vpiDecompile:1
-                            |UINT:1
-                            |vpiSize:64
-                      |vpiTypespecMember:
-                      \_typespec_member: (burstcount), line:48:36, endln:48:46, parent:Command
-                        |vpiName:burstcount
-                        |vpiTypespec:
-                        \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:burstcount
-                          |vpiName:Burstcount
-                          |vpiRange:
-                          \_range: , line:31:18, endln:31:29, parent:Burstcount
-                            |vpiLeftRange:
-                            \_operation: , line:31:18, endln:31:25
-                              |vpiOpType:11
-                              |vpiOperand:
-                              \_ref_obj: (work@test_program.create_command.cmd.Command.burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                                |vpiName:BURST_W
-                                |vpiFullName:work@test_program.create_command.cmd.Command.burstcount.Burstcount.BURST_W
-                                |vpiActual:
-                                \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                              |vpiOperand:
-                              \_constant: , line:31:26, endln:31:27
-                                |vpiConstType:9
-                                |vpiDecompile:1
-                                |vpiSize:64
-                                |UINT:1
-                            |vpiRightRange:
-                            \_constant: , line:31:28, endln:31:29
-                              |vpiConstType:9
-                              |vpiDecompile:0
-                              |vpiSize:64
-                              |UINT:0
-                          |vpiTypedefAlias:
-                          \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:Burstcount
-                            |vpiName:Burstcount
-                            |vpiRange:
-                            \_range: , line:31:18, endln:31:29, parent:Burstcount
-                              |vpiLeftRange:
-                              \_operation: , line:31:18, endln:31:25
-                                |vpiOpType:11
-                                |vpiOperand:
-                                \_ref_obj: (work@test_program.create_command.cmd.Command.burstcount.Burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                                  |vpiName:BURST_W
-                                  |vpiFullName:work@test_program.create_command.cmd.Command.burstcount.Burstcount.Burstcount.BURST_W
-                                  |vpiActual:
-                                  \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                                |vpiOperand:
-                                \_constant: , line:31:26, endln:31:27
-                                  |vpiConstType:9
-                                  |vpiDecompile:1
-                                  |vpiSize:64
-                                  |UINT:1
-                              |vpiRightRange:
-                              \_constant: , line:31:28, endln:31:29
-                                |vpiConstType:9
-                                |vpiDecompile:0
-                                |vpiSize:64
-                                |UINT:0
-                      |vpiTypespecMember:
-                      \_typespec_member: (addr), line:49:36, endln:49:40, parent:Command
-                        |vpiName:addr
-                        |vpiTypespec:
-                        \_logic_typespec: , line:49:7, endln:49:12, parent:addr
-                          |vpiRange:
-                          \_range: , line:49:14, endln:49:25
-                            |vpiLeftRange:
-                            \_operation: , line:49:14, endln:49:20
-                              |vpiOpType:11
-                              |vpiOperand:
-                              \_ref_obj: (work@test_program.create_command.cmd.Command.addr.ADDR_W), line:49:14, endln:49:20
-                                |vpiName:ADDR_W
-                                |vpiFullName:work@test_program.create_command.cmd.Command.addr.ADDR_W
-                                |vpiActual:
-                                \_parameter: (work@test_program.ADDR_W), line:13:14, endln:13:43, parent:work@test_program
-                              |vpiOperand:
-                              \_constant: , line:49:21, endln:49:22
-                                |vpiConstType:9
-                                |vpiDecompile:1
-                                |vpiSize:64
-                                |UINT:1
-                            |vpiRightRange:
-                            \_constant: , line:49:24, endln:49:25
-                              |vpiConstType:9
-                              |vpiDecompile:0
-                              |vpiSize:64
-                              |UINT:0
-                      |vpiTypespecMember:
-                      \_typespec_member: (data), line:50:36, endln:50:40, parent:Command
-                        |vpiName:data
-                        |vpiTypespec:
-                        \_logic_typespec: , line:50:7, endln:50:12, parent:data
-                          |vpiRange:
-                          \_range: , line:50:14, endln:50:24
-                            |vpiLeftRange:
-                            \_operation: , line:50:14, endln:50:20
-                              |vpiOpType:11
-                              |vpiOperand:
-                              \_ref_obj: (work@test_program.create_command.cmd.Command.data.DATA_W), line:50:14, endln:50:20
-                                |vpiName:DATA_W
-                                |vpiFullName:work@test_program.create_command.cmd.Command.data.DATA_W
-                                |vpiActual:
-                                \_parameter: (work@test_program.DATA_W), line:17:14, endln:17:63, parent:work@test_program
-                              |vpiOperand:
-                              \_constant: , line:50:21, endln:50:22
-                                |vpiConstType:9
-                                |vpiDecompile:1
-                                |vpiSize:64
-                                |UINT:1
-                            |vpiRightRange:
-                            \_constant: , line:50:23, endln:50:24
-                              |vpiConstType:9
-                              |vpiDecompile:0
-                              |vpiSize:64
-                              |UINT:0
-                      |vpiTypespecMember:
-                      \_typespec_member: (byteenable), line:51:36, endln:51:46, parent:Command
-                        |vpiName:byteenable
-                        |vpiTypespec:
-                        \_logic_typespec: , line:51:7, endln:51:12, parent:byteenable
-                          |vpiRange:
-                          \_range: , line:51:14, endln:51:29
-                            |vpiLeftRange:
-                            \_operation: , line:51:14, endln:51:25
-                              |vpiOpType:11
-                              |vpiOperand:
-                              \_ref_obj: (work@test_program.create_command.cmd.Command.byteenable.NUM_SYMBOLS), line:51:14, endln:51:25
-                                |vpiName:NUM_SYMBOLS
-                                |vpiFullName:work@test_program.create_command.cmd.Command.byteenable.NUM_SYMBOLS
-                                |vpiActual:
-                                \_parameter: (work@test_program.NUM_SYMBOLS), line:16:14, endln:16:42, parent:work@test_program
-                              |vpiOperand:
-                              \_constant: , line:51:26, endln:51:27
-                                |vpiConstType:9
-                                |vpiDecompile:1
-                                |vpiSize:64
-                                |UINT:1
-                            |vpiRightRange:
-                            \_constant: , line:51:28, endln:51:29
-                              |vpiConstType:9
-                              |vpiDecompile:0
-                              |vpiSize:64
-                              |UINT:0
-                      |vpiTypespecMember:
-                      \_typespec_member: (cmd_delay), line:52:36, endln:52:45, parent:Command
-                        |vpiName:cmd_delay
-                        |vpiTypespec:
-                        \_bit_typespec: , line:52:7, endln:52:10, parent:cmd_delay
-                          |vpiRange:
-                          \_range: , line:52:12, endln:52:16
-                            |vpiLeftRange:
-                            \_constant: , line:52:12, endln:52:14
-                              |vpiConstType:9
-                              |vpiDecompile:31
-                              |vpiSize:64
-                              |UINT:31
-                            |vpiRightRange:
-                            \_constant: , line:52:15, endln:52:16
-                              |vpiConstType:9
-                              |vpiDecompile:0
-                              |vpiSize:64
-                              |UINT:0
-                      |vpiTypespecMember:
-                      \_typespec_member: (data_idles), line:53:36, endln:53:46, parent:Command
-                        |vpiName:data_idles
-                        |vpiTypespec:
-                        \_bit_typespec: , line:53:7, endln:53:10, parent:data_idles
-                          |vpiRange:
-                          \_range: , line:53:12, endln:53:16
-                            |vpiLeftRange:
-                            \_constant: , line:53:12, endln:53:14
-                              |vpiConstType:9
-                              |vpiDecompile:31
-                              |vpiSize:64
-                              |UINT:31
-                            |vpiRightRange:
-                            \_constant: , line:53:15, endln:53:16
-                              |vpiConstType:9
-                              |vpiDecompile:0
-                              |vpiSize:64
-                              |UINT:0
+                    \_struct_typespec: (Command), line:45:11, endln:45:17
                 |vpiActual:
                 \_ref_obj: (burstcount), parent:cmd.burstcount
                   |vpiName:burstcount
@@ -25225,10 +21365,6 @@ design: (work@top)
             \_assign_stmt: , parent:work@test_program.create_command
               |vpiRhs:
               \_constant: , line:589:22, endln:589:23
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
               |vpiLhs:
               \_int_var: (work@test_program.create_command.i), line:589:14, endln:589:17
                 |vpiName:i
@@ -25284,10 +21420,6 @@ design: (work@top)
                     |vpiOpType:33
                     |vpiOperand:
                     \_constant: , line:591:48, endln:591:52
-                      |vpiConstType:3
-                      |vpiDecompile:1'b1
-                      |vpiSize:1
-                      |BIN:1
               |vpiStmt:
               \_assignment: , line:592:12, endln:592:67, parent:work@test_program.create_command
                 |vpiOpType:82
@@ -25304,11 +21436,7 @@ design: (work@top)
                 \_sys_func_call: ($urandom_range), line:592:35, endln:592:67
                   |vpiName:$urandom_range
                   |vpiArgument:
-                  \_constant: , line:592:50, endln:592:51, parent:$urandom_range
-                    |vpiConstType:9
-                    |vpiDecompile:0
-                    |vpiSize:64
-                    |UINT:0
+                  \_constant: , line:592:50, endln:592:51
                   |vpiArgument:
                   \_ref_obj: (work@test_program.create_command.MAX_DATA_IDLE), line:592:53, endln:592:66, parent:$urandom_range
                     |vpiName:MAX_DATA_IDLE
@@ -25328,19 +21456,11 @@ design: (work@top)
               |vpiFullName:work@test_program.create_command.cmd.data_idles
               |vpiIndex:
               \_constant: , line:595:24, endln:595:25, parent:work@test_program.create_command.cmd.data_idles
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
             |vpiRhs:
             \_sys_func_call: ($urandom_range), line:595:35, endln:595:67
               |vpiName:$urandom_range
               |vpiArgument:
-              \_constant: , line:595:50, endln:595:51, parent:$urandom_range
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
+              \_constant: , line:595:50, endln:595:51
               |vpiArgument:
               \_ref_obj: (work@test_program.create_command.MAX_DATA_IDLE), line:595:53, endln:595:66, parent:$urandom_range
                 |vpiName:MAX_DATA_IDLE
@@ -25383,40 +21503,12 @@ design: (work@top)
             |vpiName:burstcount
             |vpiFullName:work@test_program.randomize_burstcount.burstcount
             |vpiTypespec:
-            \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:work@test_program.randomize_burstcount.burstcount
-              |vpiName:Burstcount
-              |vpiRange:
-              \_range: , line:31:18, endln:31:29, parent:Burstcount
-                |vpiLeftRange:
-                \_operation: , line:31:18, endln:31:25
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (work@test_program.randomize_burstcount.burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                    |vpiName:BURST_W
-                    |vpiFullName:work@test_program.randomize_burstcount.burstcount.Burstcount.BURST_W
-                    |vpiActual:
-                    \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                  |vpiOperand:
-                  \_constant: , line:31:26, endln:31:27
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:31:28, endln:31:29
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
+            \_logic_typespec: (Burstcount), line:31:11, endln:31:16
         |vpiRhs:
         \_sys_func_call: ($urandom_range), line:605:19, endln:605:47
           |vpiName:$urandom_range
           |vpiArgument:
-          \_constant: , line:605:34, endln:605:35, parent:$urandom_range
-            |vpiConstType:9
-            |vpiDecompile:1
-            |vpiSize:64
-            |UINT:1
+          \_constant: , line:605:34, endln:605:35
           |vpiArgument:
           \_ref_obj: (work@test_program.randomize_burstcount.MAX_BURST), line:605:37, endln:605:46, parent:$urandom_range
             |vpiName:MAX_BURST
@@ -25448,7 +21540,7 @@ design: (work@top)
       |vpiName:slave_id
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:610:6, endln:610:9, parent:slave_id
+      \_int_typespec: , line:610:6, endln:610:9
     |vpiStmt:
     \_begin: (work@test_program.generate_random_aligned_address), parent:work@test_program.generate_random_aligned_address
       |vpiFullName:work@test_program.generate_random_aligned_address
@@ -25477,16 +21569,8 @@ design: (work@top)
                   \_parameter: (work@test_program.ADDR_W), line:13:14, endln:13:43, parent:work@test_program
                 |vpiOperand:
                 \_constant: , line:612:20, endln:612:21
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
               |vpiRightRange:
               \_constant: , line:612:22, endln:612:23
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
         |vpiRhs:
         \_operation: , line:614:18, endln:614:26
           |vpiOpType:25
@@ -25527,16 +21611,8 @@ design: (work@top)
                   \_parameter: (work@test_program.ADDR_W), line:13:14, endln:13:43, parent:work@test_program
                 |vpiOperand:
                 \_constant: , line:612:20, endln:612:21
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
               |vpiRightRange:
               \_constant: , line:612:22, endln:612:23
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
         |vpiRhs:
         \_operation: , line:615:13, endln:615:22
           |vpiOpType:24
@@ -25601,217 +21677,19 @@ design: (work@top)
       |vpiName:cmd
       |vpiDirection:1
       |vpiTypedef:
-      \_struct_typespec: (Command), line:45:11, endln:45:17, parent:cmd
-        |vpiName:Command
-        |vpiTypespecMember:
-        \_typespec_member: (trans), line:47:36, endln:47:41, parent:Command
-          |vpiName:trans
-          |vpiTypespec:
-          \_enum_typespec: (Transaction), line:37:5, endln:37:16, parent:trans
-            |vpiName:Transaction
-            |vpiBaseTypespec:
-            \_bit_typespec: , line:33:16, endln:33:19, parent:Transaction
-            |vpiEnumConst:
-            \_enum_const: (WRITE), line:35:7, endln:35:12, parent:Transaction
-              |vpiName:WRITE
-              |vpiDecompile:0
-              |UINT:0
-              |vpiSize:64
-            |vpiEnumConst:
-            \_enum_const: (READ), line:36:7, endln:36:11, parent:Transaction
-              |vpiName:READ
-              |vpiDecompile:1
-              |UINT:1
-              |vpiSize:64
-        |vpiTypespecMember:
-        \_typespec_member: (burstcount), line:48:36, endln:48:46, parent:Command
-          |vpiName:burstcount
-          |vpiTypespec:
-          \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:burstcount
-            |vpiName:Burstcount
-            |vpiRange:
-            \_range: , line:31:18, endln:31:29, parent:Burstcount
-              |vpiLeftRange:
-              \_operation: , line:31:18, endln:31:25
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.queue_command.cmd.Command.burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                  |vpiName:BURST_W
-                  |vpiFullName:work@test_program.queue_command.cmd.Command.burstcount.Burstcount.BURST_W
-                  |vpiActual:
-                  \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:31:26, endln:31:27
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:31:28, endln:31:29
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-            |vpiTypedefAlias:
-            \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:Burstcount
-              |vpiName:Burstcount
-              |vpiRange:
-              \_range: , line:31:18, endln:31:29, parent:Burstcount
-                |vpiLeftRange:
-                \_operation: , line:31:18, endln:31:25
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (work@test_program.queue_command.cmd.Command.burstcount.Burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                    |vpiName:BURST_W
-                    |vpiFullName:work@test_program.queue_command.cmd.Command.burstcount.Burstcount.Burstcount.BURST_W
-                    |vpiActual:
-                    \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                  |vpiOperand:
-                  \_constant: , line:31:26, endln:31:27
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:31:28, endln:31:29
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (addr), line:49:36, endln:49:40, parent:Command
-          |vpiName:addr
-          |vpiTypespec:
-          \_logic_typespec: , line:49:7, endln:49:12, parent:addr
-            |vpiRange:
-            \_range: , line:49:14, endln:49:25
-              |vpiLeftRange:
-              \_operation: , line:49:14, endln:49:20
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.queue_command.cmd.Command.addr.ADDR_W), line:49:14, endln:49:20
-                  |vpiName:ADDR_W
-                  |vpiFullName:work@test_program.queue_command.cmd.Command.addr.ADDR_W
-                  |vpiActual:
-                  \_parameter: (work@test_program.ADDR_W), line:13:14, endln:13:43, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:49:21, endln:49:22
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:49:24, endln:49:25
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (data), line:50:36, endln:50:40, parent:Command
-          |vpiName:data
-          |vpiTypespec:
-          \_logic_typespec: , line:50:7, endln:50:12, parent:data
-            |vpiRange:
-            \_range: , line:50:14, endln:50:24
-              |vpiLeftRange:
-              \_operation: , line:50:14, endln:50:20
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.queue_command.cmd.Command.data.DATA_W), line:50:14, endln:50:20
-                  |vpiName:DATA_W
-                  |vpiFullName:work@test_program.queue_command.cmd.Command.data.DATA_W
-                  |vpiActual:
-                  \_parameter: (work@test_program.DATA_W), line:17:14, endln:17:63, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:50:21, endln:50:22
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:50:23, endln:50:24
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (byteenable), line:51:36, endln:51:46, parent:Command
-          |vpiName:byteenable
-          |vpiTypespec:
-          \_logic_typespec: , line:51:7, endln:51:12, parent:byteenable
-            |vpiRange:
-            \_range: , line:51:14, endln:51:29
-              |vpiLeftRange:
-              \_operation: , line:51:14, endln:51:25
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.queue_command.cmd.Command.byteenable.NUM_SYMBOLS), line:51:14, endln:51:25
-                  |vpiName:NUM_SYMBOLS
-                  |vpiFullName:work@test_program.queue_command.cmd.Command.byteenable.NUM_SYMBOLS
-                  |vpiActual:
-                  \_parameter: (work@test_program.NUM_SYMBOLS), line:16:14, endln:16:42, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:51:26, endln:51:27
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:51:28, endln:51:29
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (cmd_delay), line:52:36, endln:52:45, parent:Command
-          |vpiName:cmd_delay
-          |vpiTypespec:
-          \_bit_typespec: , line:52:7, endln:52:10, parent:cmd_delay
-            |vpiRange:
-            \_range: , line:52:12, endln:52:16
-              |vpiLeftRange:
-              \_constant: , line:52:12, endln:52:14
-                |vpiConstType:9
-                |vpiDecompile:31
-                |vpiSize:64
-                |UINT:31
-              |vpiRightRange:
-              \_constant: , line:52:15, endln:52:16
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (data_idles), line:53:36, endln:53:46, parent:Command
-          |vpiName:data_idles
-          |vpiTypespec:
-          \_bit_typespec: , line:53:7, endln:53:10, parent:data_idles
-            |vpiRange:
-            \_range: , line:53:12, endln:53:16
-              |vpiLeftRange:
-              \_constant: , line:53:12, endln:53:14
-                |vpiConstType:9
-                |vpiDecompile:31
-                |vpiSize:64
-                |UINT:31
-              |vpiRightRange:
-              \_constant: , line:53:15, endln:53:16
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
+      \_struct_typespec: (Command), line:45:11, endln:45:17
     |vpiIODecl:
     \_io_decl: (master_id), parent:work@test_program.queue_command
       |vpiName:master_id
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:622:6, endln:622:9, parent:master_id
+      \_int_typespec: , line:622:6, endln:622:9
     |vpiIODecl:
     \_io_decl: (slave_id), parent:work@test_program.queue_command
       |vpiName:slave_id
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:623:6, endln:623:9, parent:slave_id
+      \_int_typespec: , line:623:6, endln:623:9
     |vpiStmt:
     \_begin: (work@test_program.queue_command), parent:work@test_program.queue_command
       |vpiFullName:work@test_program.queue_command
@@ -25879,211 +21757,13 @@ design: (work@top)
       |vpiName:cmd
       |vpiDirection:1
       |vpiTypedef:
-      \_struct_typespec: (Command), line:45:11, endln:45:17, parent:cmd
-        |vpiName:Command
-        |vpiTypespecMember:
-        \_typespec_member: (trans), line:47:36, endln:47:41, parent:Command
-          |vpiName:trans
-          |vpiTypespec:
-          \_enum_typespec: (Transaction), line:37:5, endln:37:16, parent:trans
-            |vpiName:Transaction
-            |vpiBaseTypespec:
-            \_bit_typespec: , line:33:16, endln:33:19, parent:Transaction
-            |vpiEnumConst:
-            \_enum_const: (WRITE), line:35:7, endln:35:12, parent:Transaction
-              |vpiName:WRITE
-              |vpiDecompile:0
-              |UINT:0
-              |vpiSize:64
-            |vpiEnumConst:
-            \_enum_const: (READ), line:36:7, endln:36:11, parent:Transaction
-              |vpiName:READ
-              |vpiDecompile:1
-              |UINT:1
-              |vpiSize:64
-        |vpiTypespecMember:
-        \_typespec_member: (burstcount), line:48:36, endln:48:46, parent:Command
-          |vpiName:burstcount
-          |vpiTypespec:
-          \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:burstcount
-            |vpiName:Burstcount
-            |vpiRange:
-            \_range: , line:31:18, endln:31:29, parent:Burstcount
-              |vpiLeftRange:
-              \_operation: , line:31:18, endln:31:25
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.save_command_master.cmd.Command.burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                  |vpiName:BURST_W
-                  |vpiFullName:work@test_program.save_command_master.cmd.Command.burstcount.Burstcount.BURST_W
-                  |vpiActual:
-                  \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:31:26, endln:31:27
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:31:28, endln:31:29
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-            |vpiTypedefAlias:
-            \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:Burstcount
-              |vpiName:Burstcount
-              |vpiRange:
-              \_range: , line:31:18, endln:31:29, parent:Burstcount
-                |vpiLeftRange:
-                \_operation: , line:31:18, endln:31:25
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (work@test_program.save_command_master.cmd.Command.burstcount.Burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                    |vpiName:BURST_W
-                    |vpiFullName:work@test_program.save_command_master.cmd.Command.burstcount.Burstcount.Burstcount.BURST_W
-                    |vpiActual:
-                    \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                  |vpiOperand:
-                  \_constant: , line:31:26, endln:31:27
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:31:28, endln:31:29
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (addr), line:49:36, endln:49:40, parent:Command
-          |vpiName:addr
-          |vpiTypespec:
-          \_logic_typespec: , line:49:7, endln:49:12, parent:addr
-            |vpiRange:
-            \_range: , line:49:14, endln:49:25
-              |vpiLeftRange:
-              \_operation: , line:49:14, endln:49:20
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.save_command_master.cmd.Command.addr.ADDR_W), line:49:14, endln:49:20
-                  |vpiName:ADDR_W
-                  |vpiFullName:work@test_program.save_command_master.cmd.Command.addr.ADDR_W
-                  |vpiActual:
-                  \_parameter: (work@test_program.ADDR_W), line:13:14, endln:13:43, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:49:21, endln:49:22
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:49:24, endln:49:25
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (data), line:50:36, endln:50:40, parent:Command
-          |vpiName:data
-          |vpiTypespec:
-          \_logic_typespec: , line:50:7, endln:50:12, parent:data
-            |vpiRange:
-            \_range: , line:50:14, endln:50:24
-              |vpiLeftRange:
-              \_operation: , line:50:14, endln:50:20
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.save_command_master.cmd.Command.data.DATA_W), line:50:14, endln:50:20
-                  |vpiName:DATA_W
-                  |vpiFullName:work@test_program.save_command_master.cmd.Command.data.DATA_W
-                  |vpiActual:
-                  \_parameter: (work@test_program.DATA_W), line:17:14, endln:17:63, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:50:21, endln:50:22
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:50:23, endln:50:24
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (byteenable), line:51:36, endln:51:46, parent:Command
-          |vpiName:byteenable
-          |vpiTypespec:
-          \_logic_typespec: , line:51:7, endln:51:12, parent:byteenable
-            |vpiRange:
-            \_range: , line:51:14, endln:51:29
-              |vpiLeftRange:
-              \_operation: , line:51:14, endln:51:25
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.save_command_master.cmd.Command.byteenable.NUM_SYMBOLS), line:51:14, endln:51:25
-                  |vpiName:NUM_SYMBOLS
-                  |vpiFullName:work@test_program.save_command_master.cmd.Command.byteenable.NUM_SYMBOLS
-                  |vpiActual:
-                  \_parameter: (work@test_program.NUM_SYMBOLS), line:16:14, endln:16:42, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:51:26, endln:51:27
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:51:28, endln:51:29
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (cmd_delay), line:52:36, endln:52:45, parent:Command
-          |vpiName:cmd_delay
-          |vpiTypespec:
-          \_bit_typespec: , line:52:7, endln:52:10, parent:cmd_delay
-            |vpiRange:
-            \_range: , line:52:12, endln:52:16
-              |vpiLeftRange:
-              \_constant: , line:52:12, endln:52:14
-                |vpiConstType:9
-                |vpiDecompile:31
-                |vpiSize:64
-                |UINT:31
-              |vpiRightRange:
-              \_constant: , line:52:15, endln:52:16
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (data_idles), line:53:36, endln:53:46, parent:Command
-          |vpiName:data_idles
-          |vpiTypespec:
-          \_bit_typespec: , line:53:7, endln:53:10, parent:data_idles
-            |vpiRange:
-            \_range: , line:53:12, endln:53:16
-              |vpiLeftRange:
-              \_constant: , line:53:12, endln:53:14
-                |vpiConstType:9
-                |vpiDecompile:31
-                |vpiSize:64
-                |UINT:31
-              |vpiRightRange:
-              \_constant: , line:53:15, endln:53:16
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
+      \_struct_typespec: (Command), line:45:11, endln:45:17
     |vpiIODecl:
     \_io_decl: (master_id), parent:work@test_program.save_command_master
       |vpiName:master_id
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:633:6, endln:633:9, parent:master_id
+      \_int_typespec: , line:633:6, endln:633:9
     |vpiStmt:
     \_if_else: , line:636:9, endln:640:12, parent:work@test_program.save_command_master
       |vpiCondition:
@@ -26253,211 +21933,13 @@ design: (work@top)
       |vpiName:cmd
       |vpiDirection:1
       |vpiTypedef:
-      \_struct_typespec: (Command), line:45:11, endln:45:17, parent:cmd
-        |vpiName:Command
-        |vpiTypespecMember:
-        \_typespec_member: (trans), line:47:36, endln:47:41, parent:Command
-          |vpiName:trans
-          |vpiTypespec:
-          \_enum_typespec: (Transaction), line:37:5, endln:37:16, parent:trans
-            |vpiName:Transaction
-            |vpiBaseTypespec:
-            \_bit_typespec: , line:33:16, endln:33:19, parent:Transaction
-            |vpiEnumConst:
-            \_enum_const: (WRITE), line:35:7, endln:35:12, parent:Transaction
-              |vpiName:WRITE
-              |vpiDecompile:0
-              |UINT:0
-              |vpiSize:64
-            |vpiEnumConst:
-            \_enum_const: (READ), line:36:7, endln:36:11, parent:Transaction
-              |vpiName:READ
-              |vpiDecompile:1
-              |UINT:1
-              |vpiSize:64
-        |vpiTypespecMember:
-        \_typespec_member: (burstcount), line:48:36, endln:48:46, parent:Command
-          |vpiName:burstcount
-          |vpiTypespec:
-          \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:burstcount
-            |vpiName:Burstcount
-            |vpiRange:
-            \_range: , line:31:18, endln:31:29, parent:Burstcount
-              |vpiLeftRange:
-              \_operation: , line:31:18, endln:31:25
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.save_command_slave.cmd.Command.burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                  |vpiName:BURST_W
-                  |vpiFullName:work@test_program.save_command_slave.cmd.Command.burstcount.Burstcount.BURST_W
-                  |vpiActual:
-                  \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:31:26, endln:31:27
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:31:28, endln:31:29
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-            |vpiTypedefAlias:
-            \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:Burstcount
-              |vpiName:Burstcount
-              |vpiRange:
-              \_range: , line:31:18, endln:31:29, parent:Burstcount
-                |vpiLeftRange:
-                \_operation: , line:31:18, endln:31:25
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (work@test_program.save_command_slave.cmd.Command.burstcount.Burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                    |vpiName:BURST_W
-                    |vpiFullName:work@test_program.save_command_slave.cmd.Command.burstcount.Burstcount.Burstcount.BURST_W
-                    |vpiActual:
-                    \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                  |vpiOperand:
-                  \_constant: , line:31:26, endln:31:27
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:31:28, endln:31:29
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (addr), line:49:36, endln:49:40, parent:Command
-          |vpiName:addr
-          |vpiTypespec:
-          \_logic_typespec: , line:49:7, endln:49:12, parent:addr
-            |vpiRange:
-            \_range: , line:49:14, endln:49:25
-              |vpiLeftRange:
-              \_operation: , line:49:14, endln:49:20
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.save_command_slave.cmd.Command.addr.ADDR_W), line:49:14, endln:49:20
-                  |vpiName:ADDR_W
-                  |vpiFullName:work@test_program.save_command_slave.cmd.Command.addr.ADDR_W
-                  |vpiActual:
-                  \_parameter: (work@test_program.ADDR_W), line:13:14, endln:13:43, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:49:21, endln:49:22
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:49:24, endln:49:25
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (data), line:50:36, endln:50:40, parent:Command
-          |vpiName:data
-          |vpiTypespec:
-          \_logic_typespec: , line:50:7, endln:50:12, parent:data
-            |vpiRange:
-            \_range: , line:50:14, endln:50:24
-              |vpiLeftRange:
-              \_operation: , line:50:14, endln:50:20
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.save_command_slave.cmd.Command.data.DATA_W), line:50:14, endln:50:20
-                  |vpiName:DATA_W
-                  |vpiFullName:work@test_program.save_command_slave.cmd.Command.data.DATA_W
-                  |vpiActual:
-                  \_parameter: (work@test_program.DATA_W), line:17:14, endln:17:63, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:50:21, endln:50:22
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:50:23, endln:50:24
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (byteenable), line:51:36, endln:51:46, parent:Command
-          |vpiName:byteenable
-          |vpiTypespec:
-          \_logic_typespec: , line:51:7, endln:51:12, parent:byteenable
-            |vpiRange:
-            \_range: , line:51:14, endln:51:29
-              |vpiLeftRange:
-              \_operation: , line:51:14, endln:51:25
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.save_command_slave.cmd.Command.byteenable.NUM_SYMBOLS), line:51:14, endln:51:25
-                  |vpiName:NUM_SYMBOLS
-                  |vpiFullName:work@test_program.save_command_slave.cmd.Command.byteenable.NUM_SYMBOLS
-                  |vpiActual:
-                  \_parameter: (work@test_program.NUM_SYMBOLS), line:16:14, endln:16:42, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:51:26, endln:51:27
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:51:28, endln:51:29
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (cmd_delay), line:52:36, endln:52:45, parent:Command
-          |vpiName:cmd_delay
-          |vpiTypespec:
-          \_bit_typespec: , line:52:7, endln:52:10, parent:cmd_delay
-            |vpiRange:
-            \_range: , line:52:12, endln:52:16
-              |vpiLeftRange:
-              \_constant: , line:52:12, endln:52:14
-                |vpiConstType:9
-                |vpiDecompile:31
-                |vpiSize:64
-                |UINT:31
-              |vpiRightRange:
-              \_constant: , line:52:15, endln:52:16
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (data_idles), line:53:36, endln:53:46, parent:Command
-          |vpiName:data_idles
-          |vpiTypespec:
-          \_bit_typespec: , line:53:7, endln:53:10, parent:data_idles
-            |vpiRange:
-            \_range: , line:53:12, endln:53:16
-              |vpiLeftRange:
-              \_constant: , line:53:12, endln:53:14
-                |vpiConstType:9
-                |vpiDecompile:31
-                |vpiSize:64
-                |UINT:31
-              |vpiRightRange:
-              \_constant: , line:53:15, endln:53:16
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
+      \_struct_typespec: (Command), line:45:11, endln:45:17
     |vpiIODecl:
     \_io_decl: (slave_id), parent:work@test_program.save_command_slave
       |vpiName:slave_id
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:646:6, endln:646:9, parent:slave_id
+      \_int_typespec: , line:646:6, endln:646:9
     |vpiStmt:
     \_begin: (work@test_program.save_command_slave), parent:work@test_program.save_command_slave
       |vpiFullName:work@test_program.save_command_slave
@@ -26656,30 +22138,7 @@ design: (work@top)
       |vpiName:addr
       |vpiDirection:1
       |vpiTypedef:
-      \_logic_typespec: , line:659:6, endln:659:11, parent:addr
-        |vpiRange:
-        \_range: , line:659:13, endln:659:24
-          |vpiLeftRange:
-          \_operation: , line:659:13, endln:659:19
-            |vpiOpType:11
-            |vpiOperand:
-            \_ref_obj: (work@test_program.translate_master_to_slave_address.addr.ADDR_W), line:659:13, endln:659:19
-              |vpiName:ADDR_W
-              |vpiFullName:work@test_program.translate_master_to_slave_address.addr.ADDR_W
-              |vpiActual:
-              \_parameter: (work@test_program.ADDR_W), line:13:14, endln:13:43, parent:work@test_program
-            |vpiOperand:
-            \_constant: , line:659:20, endln:659:21
-              |vpiConstType:9
-              |vpiDecompile:1
-              |vpiSize:64
-              |UINT:1
-          |vpiRightRange:
-          \_constant: , line:659:23, endln:659:24
-            |vpiConstType:9
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
+      \_logic_typespec: , line:659:6, endln:659:11
     |vpiStmt:
     \_begin: (work@test_program.translate_master_to_slave_address), parent:work@test_program.translate_master_to_slave_address
       |vpiFullName:work@test_program.translate_master_to_slave_address
@@ -26729,16 +22188,8 @@ design: (work@top)
                   \_parameter: (work@test_program.ADDR_W), line:13:14, endln:13:43, parent:work@test_program
                 |vpiOperand:
                 \_constant: , line:662:20, endln:662:21
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
               |vpiRightRange:
               \_constant: , line:662:22, endln:662:23
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
         |vpiRhs:
         \_operation: , line:664:18, endln:664:26
           |vpiOpType:25
@@ -26777,16 +22228,8 @@ design: (work@top)
                   \_parameter: (work@test_program.ADDR_W), line:13:14, endln:13:43, parent:work@test_program
                 |vpiOperand:
                 \_constant: , line:662:20, endln:662:21
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
               |vpiRightRange:
               \_constant: , line:662:22, endln:662:23
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
         |vpiRhs:
         \_operation: , line:665:15, endln:665:19
           |vpiOpType:11
@@ -26836,211 +22279,13 @@ design: (work@top)
       |vpiName:cmd
       |vpiDirection:1
       |vpiTypedef:
-      \_struct_typespec: (Command), line:45:11, endln:45:17, parent:cmd
-        |vpiName:Command
-        |vpiTypespecMember:
-        \_typespec_member: (trans), line:47:36, endln:47:41, parent:Command
-          |vpiName:trans
-          |vpiTypespec:
-          \_enum_typespec: (Transaction), line:37:5, endln:37:16, parent:trans
-            |vpiName:Transaction
-            |vpiBaseTypespec:
-            \_bit_typespec: , line:33:16, endln:33:19, parent:Transaction
-            |vpiEnumConst:
-            \_enum_const: (WRITE), line:35:7, endln:35:12, parent:Transaction
-              |vpiName:WRITE
-              |vpiDecompile:0
-              |UINT:0
-              |vpiSize:64
-            |vpiEnumConst:
-            \_enum_const: (READ), line:36:7, endln:36:11, parent:Transaction
-              |vpiName:READ
-              |vpiDecompile:1
-              |UINT:1
-              |vpiSize:64
-        |vpiTypespecMember:
-        \_typespec_member: (burstcount), line:48:36, endln:48:46, parent:Command
-          |vpiName:burstcount
-          |vpiTypespec:
-          \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:burstcount
-            |vpiName:Burstcount
-            |vpiRange:
-            \_range: , line:31:18, endln:31:29, parent:Burstcount
-              |vpiLeftRange:
-              \_operation: , line:31:18, endln:31:25
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.configure_and_push_command_to_master.cmd.Command.burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                  |vpiName:BURST_W
-                  |vpiFullName:work@test_program.configure_and_push_command_to_master.cmd.Command.burstcount.Burstcount.BURST_W
-                  |vpiActual:
-                  \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:31:26, endln:31:27
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:31:28, endln:31:29
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-            |vpiTypedefAlias:
-            \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:Burstcount
-              |vpiName:Burstcount
-              |vpiRange:
-              \_range: , line:31:18, endln:31:29, parent:Burstcount
-                |vpiLeftRange:
-                \_operation: , line:31:18, endln:31:25
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (work@test_program.configure_and_push_command_to_master.cmd.Command.burstcount.Burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                    |vpiName:BURST_W
-                    |vpiFullName:work@test_program.configure_and_push_command_to_master.cmd.Command.burstcount.Burstcount.Burstcount.BURST_W
-                    |vpiActual:
-                    \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                  |vpiOperand:
-                  \_constant: , line:31:26, endln:31:27
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:31:28, endln:31:29
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (addr), line:49:36, endln:49:40, parent:Command
-          |vpiName:addr
-          |vpiTypespec:
-          \_logic_typespec: , line:49:7, endln:49:12, parent:addr
-            |vpiRange:
-            \_range: , line:49:14, endln:49:25
-              |vpiLeftRange:
-              \_operation: , line:49:14, endln:49:20
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.configure_and_push_command_to_master.cmd.Command.addr.ADDR_W), line:49:14, endln:49:20
-                  |vpiName:ADDR_W
-                  |vpiFullName:work@test_program.configure_and_push_command_to_master.cmd.Command.addr.ADDR_W
-                  |vpiActual:
-                  \_parameter: (work@test_program.ADDR_W), line:13:14, endln:13:43, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:49:21, endln:49:22
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:49:24, endln:49:25
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (data), line:50:36, endln:50:40, parent:Command
-          |vpiName:data
-          |vpiTypespec:
-          \_logic_typespec: , line:50:7, endln:50:12, parent:data
-            |vpiRange:
-            \_range: , line:50:14, endln:50:24
-              |vpiLeftRange:
-              \_operation: , line:50:14, endln:50:20
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.configure_and_push_command_to_master.cmd.Command.data.DATA_W), line:50:14, endln:50:20
-                  |vpiName:DATA_W
-                  |vpiFullName:work@test_program.configure_and_push_command_to_master.cmd.Command.data.DATA_W
-                  |vpiActual:
-                  \_parameter: (work@test_program.DATA_W), line:17:14, endln:17:63, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:50:21, endln:50:22
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:50:23, endln:50:24
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (byteenable), line:51:36, endln:51:46, parent:Command
-          |vpiName:byteenable
-          |vpiTypespec:
-          \_logic_typespec: , line:51:7, endln:51:12, parent:byteenable
-            |vpiRange:
-            \_range: , line:51:14, endln:51:29
-              |vpiLeftRange:
-              \_operation: , line:51:14, endln:51:25
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.configure_and_push_command_to_master.cmd.Command.byteenable.NUM_SYMBOLS), line:51:14, endln:51:25
-                  |vpiName:NUM_SYMBOLS
-                  |vpiFullName:work@test_program.configure_and_push_command_to_master.cmd.Command.byteenable.NUM_SYMBOLS
-                  |vpiActual:
-                  \_parameter: (work@test_program.NUM_SYMBOLS), line:16:14, endln:16:42, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:51:26, endln:51:27
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:51:28, endln:51:29
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (cmd_delay), line:52:36, endln:52:45, parent:Command
-          |vpiName:cmd_delay
-          |vpiTypespec:
-          \_bit_typespec: , line:52:7, endln:52:10, parent:cmd_delay
-            |vpiRange:
-            \_range: , line:52:12, endln:52:16
-              |vpiLeftRange:
-              \_constant: , line:52:12, endln:52:14
-                |vpiConstType:9
-                |vpiDecompile:31
-                |vpiSize:64
-                |UINT:31
-              |vpiRightRange:
-              \_constant: , line:52:15, endln:52:16
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (data_idles), line:53:36, endln:53:46, parent:Command
-          |vpiName:data_idles
-          |vpiTypespec:
-          \_bit_typespec: , line:53:7, endln:53:10, parent:data_idles
-            |vpiRange:
-            \_range: , line:53:12, endln:53:16
-              |vpiLeftRange:
-              \_constant: , line:53:12, endln:53:14
-                |vpiConstType:9
-                |vpiDecompile:31
-                |vpiSize:64
-                |UINT:31
-              |vpiRightRange:
-              \_constant: , line:53:15, endln:53:16
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
+      \_struct_typespec: (Command), line:45:11, endln:45:17
     |vpiIODecl:
     \_io_decl: (master_id), parent:work@test_program.configure_and_push_command_to_master
       |vpiName:master_id
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:672:6, endln:672:9, parent:master_id
+      \_int_typespec: , line:672:6, endln:672:9
     |vpiStmt:
     \_if_else: , line:674:6, endln:678:9, parent:work@test_program.configure_and_push_command_to_master
       |vpiCondition:
@@ -27054,10 +22299,6 @@ design: (work@top)
           \_io_decl: (master_id)
         |vpiOperand:
         \_constant: , line:674:23, endln:674:24
-          |vpiConstType:9
-          |vpiDecompile:0
-          |vpiSize:64
-          |UINT:0
       |vpiStmt:
       \_begin: (work@test_program.configure_and_push_command_to_master), line:674:26, endln:676:9
         |vpiFullName:work@test_program.configure_and_push_command_to_master
@@ -27085,10 +22326,6 @@ design: (work@top)
             \_io_decl: (master_id)
           |vpiOperand:
           \_constant: , line:676:32, endln:676:33
-            |vpiConstType:9
-            |vpiDecompile:1
-            |vpiSize:64
-            |UINT:1
         |vpiStmt:
         \_begin: (work@test_program.configure_and_push_command_to_master), line:676:35, endln:678:9
           |vpiFullName:work@test_program.configure_and_push_command_to_master
@@ -27118,211 +22355,13 @@ design: (work@top)
       |vpiName:cmd
       |vpiDirection:1
       |vpiTypedef:
-      \_struct_typespec: (Command), line:45:11, endln:45:17, parent:cmd
-        |vpiName:Command
-        |vpiTypespecMember:
-        \_typespec_member: (trans), line:47:36, endln:47:41, parent:Command
-          |vpiName:trans
-          |vpiTypespec:
-          \_enum_typespec: (Transaction), line:37:5, endln:37:16, parent:trans
-            |vpiName:Transaction
-            |vpiBaseTypespec:
-            \_bit_typespec: , line:33:16, endln:33:19, parent:Transaction
-            |vpiEnumConst:
-            \_enum_const: (WRITE), line:35:7, endln:35:12, parent:Transaction
-              |vpiName:WRITE
-              |vpiDecompile:0
-              |UINT:0
-              |vpiSize:64
-            |vpiEnumConst:
-            \_enum_const: (READ), line:36:7, endln:36:11, parent:Transaction
-              |vpiName:READ
-              |vpiDecompile:1
-              |UINT:1
-              |vpiSize:64
-        |vpiTypespecMember:
-        \_typespec_member: (burstcount), line:48:36, endln:48:46, parent:Command
-          |vpiName:burstcount
-          |vpiTypespec:
-          \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:burstcount
-            |vpiName:Burstcount
-            |vpiRange:
-            \_range: , line:31:18, endln:31:29, parent:Burstcount
-              |vpiLeftRange:
-              \_operation: , line:31:18, endln:31:25
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.get_expected_command_for_slave.cmd.Command.burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                  |vpiName:BURST_W
-                  |vpiFullName:work@test_program.get_expected_command_for_slave.cmd.Command.burstcount.Burstcount.BURST_W
-                  |vpiActual:
-                  \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:31:26, endln:31:27
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:31:28, endln:31:29
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-            |vpiTypedefAlias:
-            \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:Burstcount
-              |vpiName:Burstcount
-              |vpiRange:
-              \_range: , line:31:18, endln:31:29, parent:Burstcount
-                |vpiLeftRange:
-                \_operation: , line:31:18, endln:31:25
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (work@test_program.get_expected_command_for_slave.cmd.Command.burstcount.Burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                    |vpiName:BURST_W
-                    |vpiFullName:work@test_program.get_expected_command_for_slave.cmd.Command.burstcount.Burstcount.Burstcount.BURST_W
-                    |vpiActual:
-                    \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                  |vpiOperand:
-                  \_constant: , line:31:26, endln:31:27
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:31:28, endln:31:29
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (addr), line:49:36, endln:49:40, parent:Command
-          |vpiName:addr
-          |vpiTypespec:
-          \_logic_typespec: , line:49:7, endln:49:12, parent:addr
-            |vpiRange:
-            \_range: , line:49:14, endln:49:25
-              |vpiLeftRange:
-              \_operation: , line:49:14, endln:49:20
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.get_expected_command_for_slave.cmd.Command.addr.ADDR_W), line:49:14, endln:49:20
-                  |vpiName:ADDR_W
-                  |vpiFullName:work@test_program.get_expected_command_for_slave.cmd.Command.addr.ADDR_W
-                  |vpiActual:
-                  \_parameter: (work@test_program.ADDR_W), line:13:14, endln:13:43, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:49:21, endln:49:22
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:49:24, endln:49:25
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (data), line:50:36, endln:50:40, parent:Command
-          |vpiName:data
-          |vpiTypespec:
-          \_logic_typespec: , line:50:7, endln:50:12, parent:data
-            |vpiRange:
-            \_range: , line:50:14, endln:50:24
-              |vpiLeftRange:
-              \_operation: , line:50:14, endln:50:20
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.get_expected_command_for_slave.cmd.Command.data.DATA_W), line:50:14, endln:50:20
-                  |vpiName:DATA_W
-                  |vpiFullName:work@test_program.get_expected_command_for_slave.cmd.Command.data.DATA_W
-                  |vpiActual:
-                  \_parameter: (work@test_program.DATA_W), line:17:14, endln:17:63, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:50:21, endln:50:22
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:50:23, endln:50:24
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (byteenable), line:51:36, endln:51:46, parent:Command
-          |vpiName:byteenable
-          |vpiTypespec:
-          \_logic_typespec: , line:51:7, endln:51:12, parent:byteenable
-            |vpiRange:
-            \_range: , line:51:14, endln:51:29
-              |vpiLeftRange:
-              \_operation: , line:51:14, endln:51:25
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.get_expected_command_for_slave.cmd.Command.byteenable.NUM_SYMBOLS), line:51:14, endln:51:25
-                  |vpiName:NUM_SYMBOLS
-                  |vpiFullName:work@test_program.get_expected_command_for_slave.cmd.Command.byteenable.NUM_SYMBOLS
-                  |vpiActual:
-                  \_parameter: (work@test_program.NUM_SYMBOLS), line:16:14, endln:16:42, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:51:26, endln:51:27
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:51:28, endln:51:29
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (cmd_delay), line:52:36, endln:52:45, parent:Command
-          |vpiName:cmd_delay
-          |vpiTypespec:
-          \_bit_typespec: , line:52:7, endln:52:10, parent:cmd_delay
-            |vpiRange:
-            \_range: , line:52:12, endln:52:16
-              |vpiLeftRange:
-              \_constant: , line:52:12, endln:52:14
-                |vpiConstType:9
-                |vpiDecompile:31
-                |vpiSize:64
-                |UINT:31
-              |vpiRightRange:
-              \_constant: , line:52:15, endln:52:16
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (data_idles), line:53:36, endln:53:46, parent:Command
-          |vpiName:data_idles
-          |vpiTypespec:
-          \_bit_typespec: , line:53:7, endln:53:10, parent:data_idles
-            |vpiRange:
-            \_range: , line:53:12, endln:53:16
-              |vpiLeftRange:
-              \_constant: , line:53:12, endln:53:14
-                |vpiConstType:9
-                |vpiDecompile:31
-                |vpiSize:64
-                |UINT:31
-              |vpiRightRange:
-              \_constant: , line:53:15, endln:53:16
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
+      \_struct_typespec: (Command), line:45:11, endln:45:17
     |vpiIODecl:
     \_io_decl: (slave_id), parent:work@test_program.get_expected_command_for_slave
       |vpiName:slave_id
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:684:6, endln:684:9, parent:slave_id
+      \_int_typespec: , line:684:6, endln:684:9
     |vpiStmt:
     \_begin: (work@test_program.get_expected_command_for_slave), parent:work@test_program.get_expected_command_for_slave
       |vpiFullName:work@test_program.get_expected_command_for_slave
@@ -27330,10 +22369,6 @@ design: (work@top)
       \_assign_stmt: , parent:work@test_program.get_expected_command_for_slave
         |vpiRhs:
         \_constant: , line:688:18, endln:688:19
-          |vpiConstType:9
-          |vpiDecompile:0
-          |vpiSize:64
-          |UINT:0
         |vpiLhs:
         \_int_var: (work@test_program.get_expected_command_for_slave.found), line:688:6, endln:688:9
           |vpiName:found
@@ -27390,205 +22425,7 @@ design: (work@top)
                     |vpiName:exp_cmd
                     |vpiFullName:work@test_program.get_expected_command_for_slave.exp_cmd
                     |vpiTypespec:
-                    \_struct_typespec: (Command), line:45:11, endln:45:17, parent:work@test_program.get_expected_command_for_slave.exp_cmd
-                      |vpiName:Command
-                      |vpiTypespecMember:
-                      \_typespec_member: (trans), line:47:36, endln:47:41, parent:Command
-                        |vpiName:trans
-                        |vpiTypespec:
-                        \_enum_typespec: (Transaction), line:37:5, endln:37:16, parent:trans
-                          |vpiName:Transaction
-                          |vpiBaseTypespec:
-                          \_bit_typespec: , line:33:16, endln:33:19, parent:Transaction
-                          |vpiEnumConst:
-                          \_enum_const: (WRITE), line:35:7, endln:35:12, parent:Transaction
-                            |vpiName:WRITE
-                            |vpiDecompile:0
-                            |UINT:0
-                            |vpiSize:64
-                          |vpiEnumConst:
-                          \_enum_const: (READ), line:36:7, endln:36:11, parent:Transaction
-                            |vpiName:READ
-                            |vpiDecompile:1
-                            |UINT:1
-                            |vpiSize:64
-                      |vpiTypespecMember:
-                      \_typespec_member: (burstcount), line:48:36, endln:48:46, parent:Command
-                        |vpiName:burstcount
-                        |vpiTypespec:
-                        \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:burstcount
-                          |vpiName:Burstcount
-                          |vpiRange:
-                          \_range: , line:31:18, endln:31:29, parent:Burstcount
-                            |vpiLeftRange:
-                            \_operation: , line:31:18, endln:31:25
-                              |vpiOpType:11
-                              |vpiOperand:
-                              \_ref_obj: (work@test_program.get_expected_command_for_slave.exp_cmd.Command.burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                                |vpiName:BURST_W
-                                |vpiFullName:work@test_program.get_expected_command_for_slave.exp_cmd.Command.burstcount.Burstcount.BURST_W
-                                |vpiActual:
-                                \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                              |vpiOperand:
-                              \_constant: , line:31:26, endln:31:27
-                                |vpiConstType:9
-                                |vpiDecompile:1
-                                |vpiSize:64
-                                |UINT:1
-                            |vpiRightRange:
-                            \_constant: , line:31:28, endln:31:29
-                              |vpiConstType:9
-                              |vpiDecompile:0
-                              |vpiSize:64
-                              |UINT:0
-                          |vpiTypedefAlias:
-                          \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:Burstcount
-                            |vpiName:Burstcount
-                            |vpiRange:
-                            \_range: , line:31:18, endln:31:29, parent:Burstcount
-                              |vpiLeftRange:
-                              \_operation: , line:31:18, endln:31:25
-                                |vpiOpType:11
-                                |vpiOperand:
-                                \_ref_obj: (work@test_program.get_expected_command_for_slave.exp_cmd.Command.burstcount.Burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                                  |vpiName:BURST_W
-                                  |vpiFullName:work@test_program.get_expected_command_for_slave.exp_cmd.Command.burstcount.Burstcount.Burstcount.BURST_W
-                                  |vpiActual:
-                                  \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                                |vpiOperand:
-                                \_constant: , line:31:26, endln:31:27
-                                  |vpiConstType:9
-                                  |vpiDecompile:1
-                                  |vpiSize:64
-                                  |UINT:1
-                              |vpiRightRange:
-                              \_constant: , line:31:28, endln:31:29
-                                |vpiConstType:9
-                                |vpiDecompile:0
-                                |vpiSize:64
-                                |UINT:0
-                      |vpiTypespecMember:
-                      \_typespec_member: (addr), line:49:36, endln:49:40, parent:Command
-                        |vpiName:addr
-                        |vpiTypespec:
-                        \_logic_typespec: , line:49:7, endln:49:12, parent:addr
-                          |vpiRange:
-                          \_range: , line:49:14, endln:49:25
-                            |vpiLeftRange:
-                            \_operation: , line:49:14, endln:49:20
-                              |vpiOpType:11
-                              |vpiOperand:
-                              \_ref_obj: (work@test_program.get_expected_command_for_slave.exp_cmd.Command.addr.ADDR_W), line:49:14, endln:49:20
-                                |vpiName:ADDR_W
-                                |vpiFullName:work@test_program.get_expected_command_for_slave.exp_cmd.Command.addr.ADDR_W
-                                |vpiActual:
-                                \_parameter: (work@test_program.ADDR_W), line:13:14, endln:13:43, parent:work@test_program
-                              |vpiOperand:
-                              \_constant: , line:49:21, endln:49:22
-                                |vpiConstType:9
-                                |vpiDecompile:1
-                                |vpiSize:64
-                                |UINT:1
-                            |vpiRightRange:
-                            \_constant: , line:49:24, endln:49:25
-                              |vpiConstType:9
-                              |vpiDecompile:0
-                              |vpiSize:64
-                              |UINT:0
-                      |vpiTypespecMember:
-                      \_typespec_member: (data), line:50:36, endln:50:40, parent:Command
-                        |vpiName:data
-                        |vpiTypespec:
-                        \_logic_typespec: , line:50:7, endln:50:12, parent:data
-                          |vpiRange:
-                          \_range: , line:50:14, endln:50:24
-                            |vpiLeftRange:
-                            \_operation: , line:50:14, endln:50:20
-                              |vpiOpType:11
-                              |vpiOperand:
-                              \_ref_obj: (work@test_program.get_expected_command_for_slave.exp_cmd.Command.data.DATA_W), line:50:14, endln:50:20
-                                |vpiName:DATA_W
-                                |vpiFullName:work@test_program.get_expected_command_for_slave.exp_cmd.Command.data.DATA_W
-                                |vpiActual:
-                                \_parameter: (work@test_program.DATA_W), line:17:14, endln:17:63, parent:work@test_program
-                              |vpiOperand:
-                              \_constant: , line:50:21, endln:50:22
-                                |vpiConstType:9
-                                |vpiDecompile:1
-                                |vpiSize:64
-                                |UINT:1
-                            |vpiRightRange:
-                            \_constant: , line:50:23, endln:50:24
-                              |vpiConstType:9
-                              |vpiDecompile:0
-                              |vpiSize:64
-                              |UINT:0
-                      |vpiTypespecMember:
-                      \_typespec_member: (byteenable), line:51:36, endln:51:46, parent:Command
-                        |vpiName:byteenable
-                        |vpiTypespec:
-                        \_logic_typespec: , line:51:7, endln:51:12, parent:byteenable
-                          |vpiRange:
-                          \_range: , line:51:14, endln:51:29
-                            |vpiLeftRange:
-                            \_operation: , line:51:14, endln:51:25
-                              |vpiOpType:11
-                              |vpiOperand:
-                              \_ref_obj: (work@test_program.get_expected_command_for_slave.exp_cmd.Command.byteenable.NUM_SYMBOLS), line:51:14, endln:51:25
-                                |vpiName:NUM_SYMBOLS
-                                |vpiFullName:work@test_program.get_expected_command_for_slave.exp_cmd.Command.byteenable.NUM_SYMBOLS
-                                |vpiActual:
-                                \_parameter: (work@test_program.NUM_SYMBOLS), line:16:14, endln:16:42, parent:work@test_program
-                              |vpiOperand:
-                              \_constant: , line:51:26, endln:51:27
-                                |vpiConstType:9
-                                |vpiDecompile:1
-                                |vpiSize:64
-                                |UINT:1
-                            |vpiRightRange:
-                            \_constant: , line:51:28, endln:51:29
-                              |vpiConstType:9
-                              |vpiDecompile:0
-                              |vpiSize:64
-                              |UINT:0
-                      |vpiTypespecMember:
-                      \_typespec_member: (cmd_delay), line:52:36, endln:52:45, parent:Command
-                        |vpiName:cmd_delay
-                        |vpiTypespec:
-                        \_bit_typespec: , line:52:7, endln:52:10, parent:cmd_delay
-                          |vpiRange:
-                          \_range: , line:52:12, endln:52:16
-                            |vpiLeftRange:
-                            \_constant: , line:52:12, endln:52:14
-                              |vpiConstType:9
-                              |vpiDecompile:31
-                              |vpiSize:64
-                              |UINT:31
-                            |vpiRightRange:
-                            \_constant: , line:52:15, endln:52:16
-                              |vpiConstType:9
-                              |vpiDecompile:0
-                              |vpiSize:64
-                              |UINT:0
-                      |vpiTypespecMember:
-                      \_typespec_member: (data_idles), line:53:36, endln:53:46, parent:Command
-                        |vpiName:data_idles
-                        |vpiTypespec:
-                        \_bit_typespec: , line:53:7, endln:53:10, parent:data_idles
-                          |vpiRange:
-                          \_range: , line:53:12, endln:53:16
-                            |vpiLeftRange:
-                            \_constant: , line:53:12, endln:53:14
-                              |vpiConstType:9
-                              |vpiDecompile:31
-                              |vpiSize:64
-                              |UINT:31
-                            |vpiRightRange:
-                            \_constant: , line:53:15, endln:53:16
-                              |vpiConstType:9
-                              |vpiDecompile:0
-                              |vpiSize:64
-                              |UINT:0
+                    \_struct_typespec: (Command), line:45:11, endln:45:17
                 |vpiRhs:
                 \_var_select: (work@test_program.get_expected_command_for_slave.write_command_queue_slave), line:692:22, endln:692:60
                   |vpiName:write_command_queue_slave
@@ -27656,10 +22493,6 @@ design: (work@top)
                       |vpiFullName:work@test_program.get_expected_command_for_slave.found
                     |vpiRhs:
                     \_constant: , line:695:23, endln:695:24
-                      |vpiConstType:9
-                      |vpiDecompile:1
-                      |vpiSize:64
-                      |UINT:1
                   |vpiStmt:
                   \_break_stmt: , line:696:15, endln:696:20, parent:work@test_program.get_expected_command_for_slave
           |vpiStmt:
@@ -27673,10 +22506,6 @@ design: (work@top)
                 |vpiFullName:work@test_program.get_expected_command_for_slave.found
               |vpiOperand:
               \_constant: , line:699:22, endln:699:23
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
             |vpiStmt:
             \_begin: (work@test_program.get_expected_command_for_slave), line:699:25, endln:701:12
               |vpiFullName:work@test_program.get_expected_command_for_slave
@@ -27799,10 +22628,6 @@ design: (work@top)
                       |vpiFullName:work@test_program.get_expected_command_for_slave.found
                     |vpiRhs:
                     \_constant: , line:707:23, endln:707:24
-                      |vpiConstType:9
-                      |vpiDecompile:1
-                      |vpiSize:64
-                      |UINT:1
                   |vpiStmt:
                   \_break_stmt: , line:708:15, endln:708:20, parent:work@test_program.get_expected_command_for_slave
           |vpiStmt:
@@ -27816,10 +22641,6 @@ design: (work@top)
                 |vpiFullName:work@test_program.get_expected_command_for_slave.found
               |vpiOperand:
               \_constant: , line:711:22, endln:711:23
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
             |vpiStmt:
             \_begin: (work@test_program.get_expected_command_for_slave), line:711:25, endln:713:12
               |vpiFullName:work@test_program.get_expected_command_for_slave
@@ -27871,409 +22692,13 @@ design: (work@top)
       |vpiName:actual_cmd
       |vpiDirection:1
       |vpiTypedef:
-      \_struct_typespec: (Command), line:45:11, endln:45:17, parent:actual_cmd
-        |vpiName:Command
-        |vpiTypespecMember:
-        \_typespec_member: (trans), line:47:36, endln:47:41, parent:Command
-          |vpiName:trans
-          |vpiTypespec:
-          \_enum_typespec: (Transaction), line:37:5, endln:37:16, parent:trans
-            |vpiName:Transaction
-            |vpiBaseTypespec:
-            \_bit_typespec: , line:33:16, endln:33:19, parent:Transaction
-            |vpiEnumConst:
-            \_enum_const: (WRITE), line:35:7, endln:35:12, parent:Transaction
-              |vpiName:WRITE
-              |vpiDecompile:0
-              |UINT:0
-              |vpiSize:64
-            |vpiEnumConst:
-            \_enum_const: (READ), line:36:7, endln:36:11, parent:Transaction
-              |vpiName:READ
-              |vpiDecompile:1
-              |UINT:1
-              |vpiSize:64
-        |vpiTypespecMember:
-        \_typespec_member: (burstcount), line:48:36, endln:48:46, parent:Command
-          |vpiName:burstcount
-          |vpiTypespec:
-          \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:burstcount
-            |vpiName:Burstcount
-            |vpiRange:
-            \_range: , line:31:18, endln:31:29, parent:Burstcount
-              |vpiLeftRange:
-              \_operation: , line:31:18, endln:31:25
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.verify_command.actual_cmd.Command.burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                  |vpiName:BURST_W
-                  |vpiFullName:work@test_program.verify_command.actual_cmd.Command.burstcount.Burstcount.BURST_W
-                  |vpiActual:
-                  \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:31:26, endln:31:27
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:31:28, endln:31:29
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-            |vpiTypedefAlias:
-            \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:Burstcount
-              |vpiName:Burstcount
-              |vpiRange:
-              \_range: , line:31:18, endln:31:29, parent:Burstcount
-                |vpiLeftRange:
-                \_operation: , line:31:18, endln:31:25
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (work@test_program.verify_command.actual_cmd.Command.burstcount.Burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                    |vpiName:BURST_W
-                    |vpiFullName:work@test_program.verify_command.actual_cmd.Command.burstcount.Burstcount.Burstcount.BURST_W
-                    |vpiActual:
-                    \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                  |vpiOperand:
-                  \_constant: , line:31:26, endln:31:27
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:31:28, endln:31:29
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (addr), line:49:36, endln:49:40, parent:Command
-          |vpiName:addr
-          |vpiTypespec:
-          \_logic_typespec: , line:49:7, endln:49:12, parent:addr
-            |vpiRange:
-            \_range: , line:49:14, endln:49:25
-              |vpiLeftRange:
-              \_operation: , line:49:14, endln:49:20
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.verify_command.actual_cmd.Command.addr.ADDR_W), line:49:14, endln:49:20
-                  |vpiName:ADDR_W
-                  |vpiFullName:work@test_program.verify_command.actual_cmd.Command.addr.ADDR_W
-                  |vpiActual:
-                  \_parameter: (work@test_program.ADDR_W), line:13:14, endln:13:43, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:49:21, endln:49:22
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:49:24, endln:49:25
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (data), line:50:36, endln:50:40, parent:Command
-          |vpiName:data
-          |vpiTypespec:
-          \_logic_typespec: , line:50:7, endln:50:12, parent:data
-            |vpiRange:
-            \_range: , line:50:14, endln:50:24
-              |vpiLeftRange:
-              \_operation: , line:50:14, endln:50:20
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.verify_command.actual_cmd.Command.data.DATA_W), line:50:14, endln:50:20
-                  |vpiName:DATA_W
-                  |vpiFullName:work@test_program.verify_command.actual_cmd.Command.data.DATA_W
-                  |vpiActual:
-                  \_parameter: (work@test_program.DATA_W), line:17:14, endln:17:63, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:50:21, endln:50:22
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:50:23, endln:50:24
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (byteenable), line:51:36, endln:51:46, parent:Command
-          |vpiName:byteenable
-          |vpiTypespec:
-          \_logic_typespec: , line:51:7, endln:51:12, parent:byteenable
-            |vpiRange:
-            \_range: , line:51:14, endln:51:29
-              |vpiLeftRange:
-              \_operation: , line:51:14, endln:51:25
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.verify_command.actual_cmd.Command.byteenable.NUM_SYMBOLS), line:51:14, endln:51:25
-                  |vpiName:NUM_SYMBOLS
-                  |vpiFullName:work@test_program.verify_command.actual_cmd.Command.byteenable.NUM_SYMBOLS
-                  |vpiActual:
-                  \_parameter: (work@test_program.NUM_SYMBOLS), line:16:14, endln:16:42, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:51:26, endln:51:27
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:51:28, endln:51:29
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (cmd_delay), line:52:36, endln:52:45, parent:Command
-          |vpiName:cmd_delay
-          |vpiTypespec:
-          \_bit_typespec: , line:52:7, endln:52:10, parent:cmd_delay
-            |vpiRange:
-            \_range: , line:52:12, endln:52:16
-              |vpiLeftRange:
-              \_constant: , line:52:12, endln:52:14
-                |vpiConstType:9
-                |vpiDecompile:31
-                |vpiSize:64
-                |UINT:31
-              |vpiRightRange:
-              \_constant: , line:52:15, endln:52:16
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (data_idles), line:53:36, endln:53:46, parent:Command
-          |vpiName:data_idles
-          |vpiTypespec:
-          \_bit_typespec: , line:53:7, endln:53:10, parent:data_idles
-            |vpiRange:
-            \_range: , line:53:12, endln:53:16
-              |vpiLeftRange:
-              \_constant: , line:53:12, endln:53:14
-                |vpiConstType:9
-                |vpiDecompile:31
-                |vpiSize:64
-                |UINT:31
-              |vpiRightRange:
-              \_constant: , line:53:15, endln:53:16
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
+      \_struct_typespec: (Command), line:45:11, endln:45:17
     |vpiIODecl:
     \_io_decl: (exp_cmd), parent:work@test_program.verify_command
       |vpiName:exp_cmd
       |vpiDirection:1
       |vpiTypedef:
-      \_struct_typespec: (Command), line:45:11, endln:45:17, parent:exp_cmd
-        |vpiName:Command
-        |vpiTypespecMember:
-        \_typespec_member: (trans), line:47:36, endln:47:41, parent:Command
-          |vpiName:trans
-          |vpiTypespec:
-          \_enum_typespec: (Transaction), line:37:5, endln:37:16, parent:trans
-            |vpiName:Transaction
-            |vpiBaseTypespec:
-            \_bit_typespec: , line:33:16, endln:33:19, parent:Transaction
-            |vpiEnumConst:
-            \_enum_const: (WRITE), line:35:7, endln:35:12, parent:Transaction
-              |vpiName:WRITE
-              |vpiDecompile:0
-              |UINT:0
-              |vpiSize:64
-            |vpiEnumConst:
-            \_enum_const: (READ), line:36:7, endln:36:11, parent:Transaction
-              |vpiName:READ
-              |vpiDecompile:1
-              |UINT:1
-              |vpiSize:64
-        |vpiTypespecMember:
-        \_typespec_member: (burstcount), line:48:36, endln:48:46, parent:Command
-          |vpiName:burstcount
-          |vpiTypespec:
-          \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:burstcount
-            |vpiName:Burstcount
-            |vpiRange:
-            \_range: , line:31:18, endln:31:29, parent:Burstcount
-              |vpiLeftRange:
-              \_operation: , line:31:18, endln:31:25
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.verify_command.exp_cmd.Command.burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                  |vpiName:BURST_W
-                  |vpiFullName:work@test_program.verify_command.exp_cmd.Command.burstcount.Burstcount.BURST_W
-                  |vpiActual:
-                  \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:31:26, endln:31:27
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:31:28, endln:31:29
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-            |vpiTypedefAlias:
-            \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:Burstcount
-              |vpiName:Burstcount
-              |vpiRange:
-              \_range: , line:31:18, endln:31:29, parent:Burstcount
-                |vpiLeftRange:
-                \_operation: , line:31:18, endln:31:25
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (work@test_program.verify_command.exp_cmd.Command.burstcount.Burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                    |vpiName:BURST_W
-                    |vpiFullName:work@test_program.verify_command.exp_cmd.Command.burstcount.Burstcount.Burstcount.BURST_W
-                    |vpiActual:
-                    \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                  |vpiOperand:
-                  \_constant: , line:31:26, endln:31:27
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:31:28, endln:31:29
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (addr), line:49:36, endln:49:40, parent:Command
-          |vpiName:addr
-          |vpiTypespec:
-          \_logic_typespec: , line:49:7, endln:49:12, parent:addr
-            |vpiRange:
-            \_range: , line:49:14, endln:49:25
-              |vpiLeftRange:
-              \_operation: , line:49:14, endln:49:20
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.verify_command.exp_cmd.Command.addr.ADDR_W), line:49:14, endln:49:20
-                  |vpiName:ADDR_W
-                  |vpiFullName:work@test_program.verify_command.exp_cmd.Command.addr.ADDR_W
-                  |vpiActual:
-                  \_parameter: (work@test_program.ADDR_W), line:13:14, endln:13:43, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:49:21, endln:49:22
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:49:24, endln:49:25
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (data), line:50:36, endln:50:40, parent:Command
-          |vpiName:data
-          |vpiTypespec:
-          \_logic_typespec: , line:50:7, endln:50:12, parent:data
-            |vpiRange:
-            \_range: , line:50:14, endln:50:24
-              |vpiLeftRange:
-              \_operation: , line:50:14, endln:50:20
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.verify_command.exp_cmd.Command.data.DATA_W), line:50:14, endln:50:20
-                  |vpiName:DATA_W
-                  |vpiFullName:work@test_program.verify_command.exp_cmd.Command.data.DATA_W
-                  |vpiActual:
-                  \_parameter: (work@test_program.DATA_W), line:17:14, endln:17:63, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:50:21, endln:50:22
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:50:23, endln:50:24
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (byteenable), line:51:36, endln:51:46, parent:Command
-          |vpiName:byteenable
-          |vpiTypespec:
-          \_logic_typespec: , line:51:7, endln:51:12, parent:byteenable
-            |vpiRange:
-            \_range: , line:51:14, endln:51:29
-              |vpiLeftRange:
-              \_operation: , line:51:14, endln:51:25
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.verify_command.exp_cmd.Command.byteenable.NUM_SYMBOLS), line:51:14, endln:51:25
-                  |vpiName:NUM_SYMBOLS
-                  |vpiFullName:work@test_program.verify_command.exp_cmd.Command.byteenable.NUM_SYMBOLS
-                  |vpiActual:
-                  \_parameter: (work@test_program.NUM_SYMBOLS), line:16:14, endln:16:42, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:51:26, endln:51:27
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:51:28, endln:51:29
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (cmd_delay), line:52:36, endln:52:45, parent:Command
-          |vpiName:cmd_delay
-          |vpiTypespec:
-          \_bit_typespec: , line:52:7, endln:52:10, parent:cmd_delay
-            |vpiRange:
-            \_range: , line:52:12, endln:52:16
-              |vpiLeftRange:
-              \_constant: , line:52:12, endln:52:14
-                |vpiConstType:9
-                |vpiDecompile:31
-                |vpiSize:64
-                |UINT:31
-              |vpiRightRange:
-              \_constant: , line:52:15, endln:52:16
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (data_idles), line:53:36, endln:53:46, parent:Command
-          |vpiName:data_idles
-          |vpiTypespec:
-          \_bit_typespec: , line:53:7, endln:53:10, parent:data_idles
-            |vpiRange:
-            \_range: , line:53:12, endln:53:16
-              |vpiLeftRange:
-              \_constant: , line:53:12, endln:53:14
-                |vpiConstType:9
-                |vpiDecompile:31
-                |vpiSize:64
-                |UINT:31
-              |vpiRightRange:
-              \_constant: , line:53:15, endln:53:16
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
+      \_struct_typespec: (Command), line:45:11, endln:45:17
     |vpiStmt:
     \_begin: (work@test_program.verify_command), parent:work@test_program.verify_command
       |vpiFullName:work@test_program.verify_command
@@ -28283,11 +22708,7 @@ design: (work@top)
         |vpiTask:
         \_task: (work@test_program.assert_equals), line:735:3, endln:757:10, parent:work@test_program
         |vpiArgument:
-        \_constant: , line:723:20, endln:723:35, parent:assert_equals
-          |vpiConstType:6
-          |vpiDecompile:wrong address
-          |vpiSize:13
-          |STRING:wrong address
+        \_constant: , line:723:20, endln:723:35
         |vpiArgument:
         \_hier_path: (exp_cmd.addr), line:723:37, endln:723:49, parent:assert_equals
           |vpiName:exp_cmd.addr
@@ -28316,11 +22737,7 @@ design: (work@top)
         |vpiTask:
         \_task: (work@test_program.assert_equals), line:735:3, endln:757:10, parent:work@test_program
         |vpiArgument:
-        \_constant: , line:724:20, endln:724:38, parent:assert_equals
-          |vpiConstType:6
-          |vpiDecompile:wrong burstcount
-          |vpiSize:16
-          |STRING:wrong burstcount
+        \_constant: , line:724:20, endln:724:38
         |vpiArgument:
         \_hier_path: (exp_cmd.burstcount), line:724:40, endln:724:58, parent:assert_equals
           |vpiName:exp_cmd.burstcount
@@ -28393,10 +22810,6 @@ design: (work@top)
             \_assign_stmt: , parent:work@test_program.verify_command
               |vpiRhs:
               \_constant: , line:727:22, endln:727:23
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
               |vpiLhs:
               \_int_var: (work@test_program.verify_command.i), line:727:14, endln:727:17
                 |vpiName:i
@@ -28417,11 +22830,7 @@ design: (work@top)
                 |vpiTask:
                 \_task: (work@test_program.assert_equals), line:735:3, endln:757:10, parent:work@test_program
                 |vpiArgument:
-                \_constant: , line:728:26, endln:728:44, parent:assert_equals
-                  |vpiConstType:6
-                  |vpiDecompile:wrong write data
-                  |vpiSize:16
-                  |STRING:wrong write data
+                \_constant: , line:728:26, endln:728:44
                 |vpiArgument:
                 \_hier_path: (exp_cmd.data[i]), line:728:46, endln:728:61, parent:assert_equals
                   |vpiName:exp_cmd.data[i]
@@ -28458,11 +22867,7 @@ design: (work@top)
                 |vpiTask:
                 \_task: (work@test_program.assert_equals), line:735:3, endln:757:10, parent:work@test_program
                 |vpiArgument:
-                \_constant: , line:729:26, endln:729:44, parent:assert_equals
-                  |vpiConstType:6
-                  |vpiDecompile:wrong byteenable
-                  |vpiSize:16
-                  |STRING:wrong byteenable
+                \_constant: , line:729:26, endln:729:44
                 |vpiArgument:
                 \_hier_path: (exp_cmd.byteenable[i]), line:729:46, endln:729:67, parent:assert_equals
                   |vpiName:exp_cmd.byteenable[i]
@@ -28506,47 +22911,19 @@ design: (work@top)
       |vpiName:message
       |vpiDirection:1
       |vpiTypedef:
-      \_string_typespec: , line:736:6, endln:736:12, parent:message
+      \_string_typespec: , line:736:6, endln:736:12
     |vpiIODecl:
     \_io_decl: (expected_obj), parent:work@test_program.assert_equals
       |vpiName:expected_obj
       |vpiDirection:1
       |vpiTypedef:
-      \_logic_typespec: , line:737:6, endln:737:11, parent:expected_obj
-        |vpiRange:
-        \_range: , line:737:13, endln:737:19
-          |vpiLeftRange:
-          \_constant: , line:737:13, endln:737:17
-            |vpiConstType:9
-            |vpiDecompile:1023
-            |vpiSize:64
-            |UINT:1023
-          |vpiRightRange:
-          \_constant: , line:737:18, endln:737:19
-            |vpiConstType:9
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
+      \_logic_typespec: , line:737:6, endln:737:11
     |vpiIODecl:
     \_io_decl: (actual_obj), parent:work@test_program.assert_equals
       |vpiName:actual_obj
       |vpiDirection:1
       |vpiTypedef:
-      \_logic_typespec: , line:738:6, endln:738:11, parent:actual_obj
-        |vpiRange:
-        \_range: , line:738:13, endln:738:19
-          |vpiLeftRange:
-          \_constant: , line:738:13, endln:738:17
-            |vpiConstType:9
-            |vpiDecompile:1023
-            |vpiSize:64
-            |UINT:1023
-          |vpiRightRange:
-          \_constant: , line:738:18, endln:738:19
-            |vpiConstType:9
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
+      \_logic_typespec: , line:738:6, endln:738:11
     |vpiStmt:
     \_begin: (work@test_program.assert_equals), parent:work@test_program.assert_equals
       |vpiFullName:work@test_program.assert_equals
@@ -28586,11 +22963,7 @@ design: (work@top)
                 |vpiActual:
                 \_string_var: (work@test_program.assert_equals.data_comparison_msg), line:740:6, endln:740:12
               |vpiArgument:
-              \_constant: , line:748:42, endln:748:68, parent:$sformat
-                |vpiConstType:6
-                |vpiDecompile:%s, expected %0x got %0x
-                |vpiSize:24
-                |STRING:%s, expected %0x got %0x
+              \_constant: , line:748:42, endln:748:68
               |vpiArgument:
               \_ref_obj: (work@test_program.assert_equals.message), line:749:15, endln:749:22, parent:$sformat
                 |vpiName:message
@@ -28634,10 +23007,6 @@ design: (work@top)
                 \_bit_var: (work@test_program.test_success), line:511:4, endln:511:16, parent:work@test_program
               |vpiRhs:
               \_constant: , line:753:27, endln:753:28
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
             |vpiStmt:
             \_event_stmt: (assert_fail), line:754:12, endln:754:27, parent:work@test_program.assert_equals
               |vpiBlocking:1
@@ -28661,57 +23030,7 @@ design: (work@top)
       |vpiName:burstcount
       |vpiDirection:1
       |vpiTypedef:
-      \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:burstcount
-        |vpiName:Burstcount
-        |vpiRange:
-        \_range: , line:31:18, endln:31:29, parent:Burstcount
-          |vpiLeftRange:
-          \_operation: , line:31:18, endln:31:25
-            |vpiOpType:11
-            |vpiOperand:
-            \_ref_obj: (work@test_program.create_response.burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-              |vpiName:BURST_W
-              |vpiFullName:work@test_program.create_response.burstcount.Burstcount.BURST_W
-              |vpiActual:
-              \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-            |vpiOperand:
-            \_constant: , line:31:26, endln:31:27
-              |vpiConstType:9
-              |vpiDecompile:1
-              |vpiSize:64
-              |UINT:1
-          |vpiRightRange:
-          \_constant: , line:31:28, endln:31:29
-            |vpiConstType:9
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
-        |vpiTypedefAlias:
-        \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:Burstcount
-          |vpiName:Burstcount
-          |vpiRange:
-          \_range: , line:31:18, endln:31:29, parent:Burstcount
-            |vpiLeftRange:
-            \_operation: , line:31:18, endln:31:25
-              |vpiOpType:11
-              |vpiOperand:
-              \_ref_obj: (work@test_program.create_response.burstcount.Burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                |vpiName:BURST_W
-                |vpiFullName:work@test_program.create_response.burstcount.Burstcount.Burstcount.BURST_W
-                |vpiActual:
-                \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-              |vpiOperand:
-              \_constant: , line:31:26, endln:31:27
-                |vpiConstType:9
-                |vpiDecompile:1
-                |vpiSize:64
-                |UINT:1
-            |vpiRightRange:
-            \_constant: , line:31:28, endln:31:29
-              |vpiConstType:9
-              |vpiDecompile:0
-              |vpiSize:64
-              |UINT:0
+      \_logic_typespec: (Burstcount), line:31:11, endln:31:16
     |vpiStmt:
     \_begin: (work@test_program.create_response), parent:work@test_program.create_response
       |vpiFullName:work@test_program.create_response
@@ -28749,10 +23068,6 @@ design: (work@top)
         \_assign_stmt: , parent:work@test_program.create_response
           |vpiRhs:
           \_constant: , line:766:19, endln:766:20
-            |vpiConstType:9
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
           |vpiLhs:
           \_int_var: (work@test_program.create_response.i), line:766:11, endln:766:14
             |vpiName:i
@@ -28798,11 +23113,7 @@ design: (work@top)
             \_sys_func_call: ($urandom_range), line:768:29, endln:768:61
               |vpiName:$urandom_range
               |vpiArgument:
-              \_constant: , line:768:44, endln:768:45, parent:$urandom_range
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
+              \_constant: , line:768:44, endln:768:45
               |vpiArgument:
               \_ref_obj: (work@test_program.create_response.MAX_DATA_IDLE), line:768:47, endln:768:60, parent:$urandom_range
                 |vpiName:MAX_DATA_IDLE
@@ -28820,110 +23131,7 @@ design: (work@top)
             |vpiName:rsp
             |vpiFullName:work@test_program.create_response.rsp
             |vpiTypespec:
-            \_struct_typespec: (Response), line:56:11, endln:56:17, parent:work@test_program.create_response.rsp
-              |vpiName:Response
-              |vpiTypespecMember:
-              \_typespec_member: (burstcount), line:58:36, endln:58:46, parent:Response
-                |vpiName:burstcount
-                |vpiTypespec:
-                \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:burstcount
-                  |vpiName:Burstcount
-                  |vpiRange:
-                  \_range: , line:31:18, endln:31:29, parent:Burstcount
-                    |vpiLeftRange:
-                    \_operation: , line:31:18, endln:31:25
-                      |vpiOpType:11
-                      |vpiOperand:
-                      \_ref_obj: (work@test_program.create_response.rsp.Response.burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                        |vpiName:BURST_W
-                        |vpiFullName:work@test_program.create_response.rsp.Response.burstcount.Burstcount.BURST_W
-                        |vpiActual:
-                        \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                      |vpiOperand:
-                      \_constant: , line:31:26, endln:31:27
-                        |vpiConstType:9
-                        |vpiDecompile:1
-                        |vpiSize:64
-                        |UINT:1
-                    |vpiRightRange:
-                    \_constant: , line:31:28, endln:31:29
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-                  |vpiTypedefAlias:
-                  \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:Burstcount
-                    |vpiName:Burstcount
-                    |vpiRange:
-                    \_range: , line:31:18, endln:31:29, parent:Burstcount
-                      |vpiLeftRange:
-                      \_operation: , line:31:18, endln:31:25
-                        |vpiOpType:11
-                        |vpiOperand:
-                        \_ref_obj: (work@test_program.create_response.rsp.Response.burstcount.Burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                          |vpiName:BURST_W
-                          |vpiFullName:work@test_program.create_response.rsp.Response.burstcount.Burstcount.Burstcount.BURST_W
-                          |vpiActual:
-                          \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                        |vpiOperand:
-                        \_constant: , line:31:26, endln:31:27
-                          |vpiConstType:9
-                          |vpiDecompile:1
-                          |vpiSize:64
-                          |UINT:1
-                      |vpiRightRange:
-                      \_constant: , line:31:28, endln:31:29
-                        |vpiConstType:9
-                        |vpiDecompile:0
-                        |vpiSize:64
-                        |UINT:0
-              |vpiTypespecMember:
-              \_typespec_member: (data), line:59:36, endln:59:40, parent:Response
-                |vpiName:data
-                |vpiTypespec:
-                \_logic_typespec: , line:59:6, endln:59:11, parent:data
-                  |vpiRange:
-                  \_range: , line:59:13, endln:59:23
-                    |vpiLeftRange:
-                    \_operation: , line:59:13, endln:59:19
-                      |vpiOpType:11
-                      |vpiOperand:
-                      \_ref_obj: (work@test_program.create_response.rsp.Response.data.DATA_W), line:59:13, endln:59:19
-                        |vpiName:DATA_W
-                        |vpiFullName:work@test_program.create_response.rsp.Response.data.DATA_W
-                        |vpiActual:
-                        \_parameter: (work@test_program.DATA_W), line:17:14, endln:17:63, parent:work@test_program
-                      |vpiOperand:
-                      \_constant: , line:59:20, endln:59:21
-                        |vpiConstType:9
-                        |vpiDecompile:1
-                        |vpiSize:64
-                        |UINT:1
-                    |vpiRightRange:
-                    \_constant: , line:59:22, endln:59:23
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-              |vpiTypespecMember:
-              \_typespec_member: (latency), line:60:36, endln:60:43, parent:Response
-                |vpiName:latency
-                |vpiTypespec:
-                \_bit_typespec: , line:60:6, endln:60:9, parent:latency
-                  |vpiRange:
-                  \_range: , line:60:11, endln:60:15
-                    |vpiLeftRange:
-                    \_constant: , line:60:11, endln:60:13
-                      |vpiConstType:9
-                      |vpiDecompile:31
-                      |vpiSize:64
-                      |UINT:31
-                    |vpiRightRange:
-                    \_constant: , line:60:14, endln:60:15
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
+            \_struct_typespec: (Response), line:56:11, endln:56:17
     |vpiVariables:
     \_struct_var: (work@test_program.create_response.rsp), line:763:6, endln:763:14, parent:work@test_program.create_response
   |vpiTaskFunc:
@@ -28941,205 +23149,7 @@ design: (work@top)
       |vpiName:cmd
       |vpiDirection:1
       |vpiTypedef:
-      \_struct_typespec: (Command), line:45:11, endln:45:17, parent:cmd
-        |vpiName:Command
-        |vpiTypespecMember:
-        \_typespec_member: (trans), line:47:36, endln:47:41, parent:Command
-          |vpiName:trans
-          |vpiTypespec:
-          \_enum_typespec: (Transaction), line:37:5, endln:37:16, parent:trans
-            |vpiName:Transaction
-            |vpiBaseTypespec:
-            \_bit_typespec: , line:33:16, endln:33:19, parent:Transaction
-            |vpiEnumConst:
-            \_enum_const: (WRITE), line:35:7, endln:35:12, parent:Transaction
-              |vpiName:WRITE
-              |vpiDecompile:0
-              |UINT:0
-              |vpiSize:64
-            |vpiEnumConst:
-            \_enum_const: (READ), line:36:7, endln:36:11, parent:Transaction
-              |vpiName:READ
-              |vpiDecompile:1
-              |UINT:1
-              |vpiSize:64
-        |vpiTypespecMember:
-        \_typespec_member: (burstcount), line:48:36, endln:48:46, parent:Command
-          |vpiName:burstcount
-          |vpiTypespec:
-          \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:burstcount
-            |vpiName:Burstcount
-            |vpiRange:
-            \_range: , line:31:18, endln:31:29, parent:Burstcount
-              |vpiLeftRange:
-              \_operation: , line:31:18, endln:31:25
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.get_expected_read_response.cmd.Command.burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                  |vpiName:BURST_W
-                  |vpiFullName:work@test_program.get_expected_read_response.cmd.Command.burstcount.Burstcount.BURST_W
-                  |vpiActual:
-                  \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:31:26, endln:31:27
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:31:28, endln:31:29
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-            |vpiTypedefAlias:
-            \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:Burstcount
-              |vpiName:Burstcount
-              |vpiRange:
-              \_range: , line:31:18, endln:31:29, parent:Burstcount
-                |vpiLeftRange:
-                \_operation: , line:31:18, endln:31:25
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (work@test_program.get_expected_read_response.cmd.Command.burstcount.Burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                    |vpiName:BURST_W
-                    |vpiFullName:work@test_program.get_expected_read_response.cmd.Command.burstcount.Burstcount.Burstcount.BURST_W
-                    |vpiActual:
-                    \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                  |vpiOperand:
-                  \_constant: , line:31:26, endln:31:27
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:31:28, endln:31:29
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (addr), line:49:36, endln:49:40, parent:Command
-          |vpiName:addr
-          |vpiTypespec:
-          \_logic_typespec: , line:49:7, endln:49:12, parent:addr
-            |vpiRange:
-            \_range: , line:49:14, endln:49:25
-              |vpiLeftRange:
-              \_operation: , line:49:14, endln:49:20
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.get_expected_read_response.cmd.Command.addr.ADDR_W), line:49:14, endln:49:20
-                  |vpiName:ADDR_W
-                  |vpiFullName:work@test_program.get_expected_read_response.cmd.Command.addr.ADDR_W
-                  |vpiActual:
-                  \_parameter: (work@test_program.ADDR_W), line:13:14, endln:13:43, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:49:21, endln:49:22
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:49:24, endln:49:25
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (data), line:50:36, endln:50:40, parent:Command
-          |vpiName:data
-          |vpiTypespec:
-          \_logic_typespec: , line:50:7, endln:50:12, parent:data
-            |vpiRange:
-            \_range: , line:50:14, endln:50:24
-              |vpiLeftRange:
-              \_operation: , line:50:14, endln:50:20
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.get_expected_read_response.cmd.Command.data.DATA_W), line:50:14, endln:50:20
-                  |vpiName:DATA_W
-                  |vpiFullName:work@test_program.get_expected_read_response.cmd.Command.data.DATA_W
-                  |vpiActual:
-                  \_parameter: (work@test_program.DATA_W), line:17:14, endln:17:63, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:50:21, endln:50:22
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:50:23, endln:50:24
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (byteenable), line:51:36, endln:51:46, parent:Command
-          |vpiName:byteenable
-          |vpiTypespec:
-          \_logic_typespec: , line:51:7, endln:51:12, parent:byteenable
-            |vpiRange:
-            \_range: , line:51:14, endln:51:29
-              |vpiLeftRange:
-              \_operation: , line:51:14, endln:51:25
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.get_expected_read_response.cmd.Command.byteenable.NUM_SYMBOLS), line:51:14, endln:51:25
-                  |vpiName:NUM_SYMBOLS
-                  |vpiFullName:work@test_program.get_expected_read_response.cmd.Command.byteenable.NUM_SYMBOLS
-                  |vpiActual:
-                  \_parameter: (work@test_program.NUM_SYMBOLS), line:16:14, endln:16:42, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:51:26, endln:51:27
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:51:28, endln:51:29
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (cmd_delay), line:52:36, endln:52:45, parent:Command
-          |vpiName:cmd_delay
-          |vpiTypespec:
-          \_bit_typespec: , line:52:7, endln:52:10, parent:cmd_delay
-            |vpiRange:
-            \_range: , line:52:12, endln:52:16
-              |vpiLeftRange:
-              \_constant: , line:52:12, endln:52:14
-                |vpiConstType:9
-                |vpiDecompile:31
-                |vpiSize:64
-                |UINT:31
-              |vpiRightRange:
-              \_constant: , line:52:15, endln:52:16
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (data_idles), line:53:36, endln:53:46, parent:Command
-          |vpiName:data_idles
-          |vpiTypespec:
-          \_bit_typespec: , line:53:7, endln:53:10, parent:data_idles
-            |vpiRange:
-            \_range: , line:53:12, endln:53:16
-              |vpiLeftRange:
-              \_constant: , line:53:12, endln:53:14
-                |vpiConstType:9
-                |vpiDecompile:31
-                |vpiSize:64
-                |UINT:31
-              |vpiRightRange:
-              \_constant: , line:53:15, endln:53:16
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
+      \_struct_typespec: (Command), line:45:11, endln:45:17
     |vpiStmt:
     \_begin: (work@test_program.get_expected_read_response), parent:work@test_program.get_expected_read_response
       |vpiFullName:work@test_program.get_expected_read_response
@@ -29182,110 +23192,7 @@ design: (work@top)
             |vpiName:rsp
             |vpiFullName:work@test_program.get_expected_read_response.rsp
             |vpiTypespec:
-            \_struct_typespec: (Response), line:56:11, endln:56:17, parent:work@test_program.get_expected_read_response.rsp
-              |vpiName:Response
-              |vpiTypespecMember:
-              \_typespec_member: (burstcount), line:58:36, endln:58:46, parent:Response
-                |vpiName:burstcount
-                |vpiTypespec:
-                \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:burstcount
-                  |vpiName:Burstcount
-                  |vpiRange:
-                  \_range: , line:31:18, endln:31:29, parent:Burstcount
-                    |vpiLeftRange:
-                    \_operation: , line:31:18, endln:31:25
-                      |vpiOpType:11
-                      |vpiOperand:
-                      \_ref_obj: (work@test_program.get_expected_read_response.rsp.Response.burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                        |vpiName:BURST_W
-                        |vpiFullName:work@test_program.get_expected_read_response.rsp.Response.burstcount.Burstcount.BURST_W
-                        |vpiActual:
-                        \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                      |vpiOperand:
-                      \_constant: , line:31:26, endln:31:27
-                        |vpiConstType:9
-                        |vpiDecompile:1
-                        |vpiSize:64
-                        |UINT:1
-                    |vpiRightRange:
-                    \_constant: , line:31:28, endln:31:29
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-                  |vpiTypedefAlias:
-                  \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:Burstcount
-                    |vpiName:Burstcount
-                    |vpiRange:
-                    \_range: , line:31:18, endln:31:29, parent:Burstcount
-                      |vpiLeftRange:
-                      \_operation: , line:31:18, endln:31:25
-                        |vpiOpType:11
-                        |vpiOperand:
-                        \_ref_obj: (work@test_program.get_expected_read_response.rsp.Response.burstcount.Burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                          |vpiName:BURST_W
-                          |vpiFullName:work@test_program.get_expected_read_response.rsp.Response.burstcount.Burstcount.Burstcount.BURST_W
-                          |vpiActual:
-                          \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                        |vpiOperand:
-                        \_constant: , line:31:26, endln:31:27
-                          |vpiConstType:9
-                          |vpiDecompile:1
-                          |vpiSize:64
-                          |UINT:1
-                      |vpiRightRange:
-                      \_constant: , line:31:28, endln:31:29
-                        |vpiConstType:9
-                        |vpiDecompile:0
-                        |vpiSize:64
-                        |UINT:0
-              |vpiTypespecMember:
-              \_typespec_member: (data), line:59:36, endln:59:40, parent:Response
-                |vpiName:data
-                |vpiTypespec:
-                \_logic_typespec: , line:59:6, endln:59:11, parent:data
-                  |vpiRange:
-                  \_range: , line:59:13, endln:59:23
-                    |vpiLeftRange:
-                    \_operation: , line:59:13, endln:59:19
-                      |vpiOpType:11
-                      |vpiOperand:
-                      \_ref_obj: (work@test_program.get_expected_read_response.rsp.Response.data.DATA_W), line:59:13, endln:59:19
-                        |vpiName:DATA_W
-                        |vpiFullName:work@test_program.get_expected_read_response.rsp.Response.data.DATA_W
-                        |vpiActual:
-                        \_parameter: (work@test_program.DATA_W), line:17:14, endln:17:63, parent:work@test_program
-                      |vpiOperand:
-                      \_constant: , line:59:20, endln:59:21
-                        |vpiConstType:9
-                        |vpiDecompile:1
-                        |vpiSize:64
-                        |UINT:1
-                    |vpiRightRange:
-                    \_constant: , line:59:22, endln:59:23
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-              |vpiTypespecMember:
-              \_typespec_member: (latency), line:60:36, endln:60:43, parent:Response
-                |vpiName:latency
-                |vpiTypespec:
-                \_bit_typespec: , line:60:6, endln:60:9, parent:latency
-                  |vpiRange:
-                  \_range: , line:60:11, endln:60:15
-                    |vpiLeftRange:
-                    \_constant: , line:60:11, endln:60:13
-                      |vpiConstType:9
-                      |vpiDecompile:31
-                      |vpiSize:64
-                      |UINT:31
-                    |vpiRightRange:
-                    \_constant: , line:60:14, endln:60:15
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
+            \_struct_typespec: (Response), line:56:11, endln:56:17
         |vpiRhs:
         \_hier_path: (read_response_queue_slave[slave_id].pop_front), line:781:12, endln:781:59
           |vpiName:read_response_queue_slave[slave_id].pop_front
@@ -29322,219 +23229,13 @@ design: (work@top)
       |vpiName:actual_rsp
       |vpiDirection:1
       |vpiTypedef:
-      \_struct_typespec: (Response), line:56:11, endln:56:17, parent:actual_rsp
-        |vpiName:Response
-        |vpiTypespecMember:
-        \_typespec_member: (burstcount), line:58:36, endln:58:46, parent:Response
-          |vpiName:burstcount
-          |vpiTypespec:
-          \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:burstcount
-            |vpiName:Burstcount
-            |vpiRange:
-            \_range: , line:31:18, endln:31:29, parent:Burstcount
-              |vpiLeftRange:
-              \_operation: , line:31:18, endln:31:25
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.verify_response.actual_rsp.Response.burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                  |vpiName:BURST_W
-                  |vpiFullName:work@test_program.verify_response.actual_rsp.Response.burstcount.Burstcount.BURST_W
-                  |vpiActual:
-                  \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:31:26, endln:31:27
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:31:28, endln:31:29
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-            |vpiTypedefAlias:
-            \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:Burstcount
-              |vpiName:Burstcount
-              |vpiRange:
-              \_range: , line:31:18, endln:31:29, parent:Burstcount
-                |vpiLeftRange:
-                \_operation: , line:31:18, endln:31:25
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (work@test_program.verify_response.actual_rsp.Response.burstcount.Burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                    |vpiName:BURST_W
-                    |vpiFullName:work@test_program.verify_response.actual_rsp.Response.burstcount.Burstcount.Burstcount.BURST_W
-                    |vpiActual:
-                    \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                  |vpiOperand:
-                  \_constant: , line:31:26, endln:31:27
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:31:28, endln:31:29
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (data), line:59:36, endln:59:40, parent:Response
-          |vpiName:data
-          |vpiTypespec:
-          \_logic_typespec: , line:59:6, endln:59:11, parent:data
-            |vpiRange:
-            \_range: , line:59:13, endln:59:23
-              |vpiLeftRange:
-              \_operation: , line:59:13, endln:59:19
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.verify_response.actual_rsp.Response.data.DATA_W), line:59:13, endln:59:19
-                  |vpiName:DATA_W
-                  |vpiFullName:work@test_program.verify_response.actual_rsp.Response.data.DATA_W
-                  |vpiActual:
-                  \_parameter: (work@test_program.DATA_W), line:17:14, endln:17:63, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:59:20, endln:59:21
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:59:22, endln:59:23
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (latency), line:60:36, endln:60:43, parent:Response
-          |vpiName:latency
-          |vpiTypespec:
-          \_bit_typespec: , line:60:6, endln:60:9, parent:latency
-            |vpiRange:
-            \_range: , line:60:11, endln:60:15
-              |vpiLeftRange:
-              \_constant: , line:60:11, endln:60:13
-                |vpiConstType:9
-                |vpiDecompile:31
-                |vpiSize:64
-                |UINT:31
-              |vpiRightRange:
-              \_constant: , line:60:14, endln:60:15
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
+      \_struct_typespec: (Response), line:56:11, endln:56:17
     |vpiIODecl:
     \_io_decl: (exp_rsp), parent:work@test_program.verify_response
       |vpiName:exp_rsp
       |vpiDirection:1
       |vpiTypedef:
-      \_struct_typespec: (Response), line:56:11, endln:56:17, parent:exp_rsp
-        |vpiName:Response
-        |vpiTypespecMember:
-        \_typespec_member: (burstcount), line:58:36, endln:58:46, parent:Response
-          |vpiName:burstcount
-          |vpiTypespec:
-          \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:burstcount
-            |vpiName:Burstcount
-            |vpiRange:
-            \_range: , line:31:18, endln:31:29, parent:Burstcount
-              |vpiLeftRange:
-              \_operation: , line:31:18, endln:31:25
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.verify_response.exp_rsp.Response.burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                  |vpiName:BURST_W
-                  |vpiFullName:work@test_program.verify_response.exp_rsp.Response.burstcount.Burstcount.BURST_W
-                  |vpiActual:
-                  \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:31:26, endln:31:27
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:31:28, endln:31:29
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-            |vpiTypedefAlias:
-            \_logic_typespec: (Burstcount), line:31:11, endln:31:16, parent:Burstcount
-              |vpiName:Burstcount
-              |vpiRange:
-              \_range: , line:31:18, endln:31:29, parent:Burstcount
-                |vpiLeftRange:
-                \_operation: , line:31:18, endln:31:25
-                  |vpiOpType:11
-                  |vpiOperand:
-                  \_ref_obj: (work@test_program.verify_response.exp_rsp.Response.burstcount.Burstcount.Burstcount.BURST_W), line:31:18, endln:31:25
-                    |vpiName:BURST_W
-                    |vpiFullName:work@test_program.verify_response.exp_rsp.Response.burstcount.Burstcount.Burstcount.BURST_W
-                    |vpiActual:
-                    \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
-                  |vpiOperand:
-                  \_constant: , line:31:26, endln:31:27
-                    |vpiConstType:9
-                    |vpiDecompile:1
-                    |vpiSize:64
-                    |UINT:1
-                |vpiRightRange:
-                \_constant: , line:31:28, endln:31:29
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (data), line:59:36, endln:59:40, parent:Response
-          |vpiName:data
-          |vpiTypespec:
-          \_logic_typespec: , line:59:6, endln:59:11, parent:data
-            |vpiRange:
-            \_range: , line:59:13, endln:59:23
-              |vpiLeftRange:
-              \_operation: , line:59:13, endln:59:19
-                |vpiOpType:11
-                |vpiOperand:
-                \_ref_obj: (work@test_program.verify_response.exp_rsp.Response.data.DATA_W), line:59:13, endln:59:19
-                  |vpiName:DATA_W
-                  |vpiFullName:work@test_program.verify_response.exp_rsp.Response.data.DATA_W
-                  |vpiActual:
-                  \_parameter: (work@test_program.DATA_W), line:17:14, endln:17:63, parent:work@test_program
-                |vpiOperand:
-                \_constant: , line:59:20, endln:59:21
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
-              |vpiRightRange:
-              \_constant: , line:59:22, endln:59:23
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-        |vpiTypespecMember:
-        \_typespec_member: (latency), line:60:36, endln:60:43, parent:Response
-          |vpiName:latency
-          |vpiTypespec:
-          \_bit_typespec: , line:60:6, endln:60:9, parent:latency
-            |vpiRange:
-            \_range: , line:60:11, endln:60:15
-              |vpiLeftRange:
-              \_constant: , line:60:11, endln:60:13
-                |vpiConstType:9
-                |vpiDecompile:31
-                |vpiSize:64
-                |UINT:31
-              |vpiRightRange:
-              \_constant: , line:60:14, endln:60:15
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
+      \_struct_typespec: (Response), line:56:11, endln:56:17
     |vpiStmt:
     \_begin: (work@test_program.verify_response), parent:work@test_program.verify_response
       |vpiFullName:work@test_program.verify_response
@@ -29544,11 +23245,7 @@ design: (work@top)
         |vpiTask:
         \_task: (work@test_program.assert_equals), line:735:3, endln:757:10, parent:work@test_program
         |vpiArgument:
-        \_constant: , line:790:20, endln:790:38, parent:assert_equals
-          |vpiConstType:6
-          |vpiDecompile:wrong burstcount
-          |vpiSize:16
-          |STRING:wrong burstcount
+        \_constant: , line:790:20, endln:790:38
         |vpiArgument:
         \_hier_path: (exp_rsp.burstcount), line:790:40, endln:790:58, parent:assert_equals
           |vpiName:exp_rsp.burstcount
@@ -29596,10 +23293,6 @@ design: (work@top)
         \_assign_stmt: , parent:work@test_program.verify_response
           |vpiRhs:
           \_constant: , line:791:19, endln:791:20
-            |vpiConstType:9
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
           |vpiLhs:
           \_int_var: (work@test_program.verify_response.i), line:791:11, endln:791:14
             |vpiName:i
@@ -29620,11 +23313,7 @@ design: (work@top)
             |vpiTask:
             \_task: (work@test_program.assert_equals), line:735:3, endln:757:10, parent:work@test_program
             |vpiArgument:
-            \_constant: , line:792:23, endln:792:40, parent:assert_equals
-              |vpiConstType:6
-              |vpiDecompile:wrong read data
-              |vpiSize:15
-              |STRING:wrong read data
+            \_constant: , line:792:23, endln:792:40
             |vpiArgument:
             \_hier_path: (exp_rsp.data[i]), line:792:42, endln:792:57, parent:assert_equals
               |vpiName:exp_rsp.data[i]
@@ -29739,6 +23428,10 @@ design: (work@top)
       |UINT:4
     |vpiLhs:
     \_parameter: (work@test_program.BURST_W), line:19:14, endln:19:42, parent:work@test_program
+      |vpiName:BURST_W
+      |vpiFullName:work@test_program.BURST_W
+      |vpiLocalParam:1
+      |UINT:4
   |vpiParamAssign:
   \_param_assign: , line:20:14, endln:20:42, parent:work@test_program
     |vpiRhs:
@@ -29838,7 +23531,7 @@ design: (work@top)
         \_bit_select: (work@test_program1.$root.tb.dut.master_0[2].signal_write_response_complete), parent:work@test_program1.$root.tb.dut.master_0[2].signal_write_response_complete
           |vpiFullName:work@test_program1.$root.tb.dut.master_0[2].signal_write_response_complete
           |vpiIndex:
-          \_constant: , line:802:34, endln:802:35, parent:work@test_program1.$root.tb.dut.master_0[2].signal_write_response_complete
+          \_constant: , line:802:34, endln:802:35
             |vpiConstType:9
             |vpiDecompile:2
             |vpiSize:64
@@ -29853,7 +23546,7 @@ design: (work@top)
         \_func_call: ($root.tb.dut.master_0[3].pop_response), line:803:6, endln:803:52, parent:work@test_program1
           |vpiName:$root.tb.dut.master_0[3].pop_response
           |vpiArgument:
-          \_constant: , line:803:44, endln:803:50, parent:$root.tb.dut.master_0[3].pop_response
+          \_constant: , line:803:44, endln:803:50
             |vpiConstType:6
             |vpiDecompile:blah
             |vpiSize:4

--- a/tests/DoublePres/DoublePres.log
+++ b/tests/DoublePres/DoublePres.log
@@ -2398,13 +2398,9 @@ design: (work@top)
               |vpiName:incr_d
               |vpiFullName:work@top.d.incr_d.incr_d
               |vpiTypespec:
-              \_int_typespec: , line:47:3, endln:47:10, parent:work@top.d.incr_d.incr_d
+              \_int_typespec: , line:47:3, endln:47:10
           |vpiRhs:
           \_constant: , line:48:12, endln:48:16
-            |vpiConstType:2
-            |vpiDecompile:10.1
-            |vpiSize:64
-            |REAL:t.ttts
         |vpiStmt:
         \_operation: , line:49:3, endln:49:11, parent:work@top.d.incr_d
           |vpiOpType:62

--- a/tests/DpiChandle/DpiChandle.log
+++ b/tests/DpiChandle/DpiChandle.log
@@ -123,9 +123,9 @@ design: (work@top)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -342,9 +342,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -360,9 +360,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -378,9 +378,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -398,9 +398,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/DpiFunc/DpiFunc.log
+++ b/tests/DpiFunc/DpiFunc.log
@@ -126,9 +126,9 @@ design: (work@top)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -345,9 +345,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -363,9 +363,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -381,9 +381,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -401,9 +401,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -471,10 +471,6 @@ design: (work@top)
     \_return_stmt: , line:4:4, endln:4:10, parent:work@top.func_1
       |vpiCondition:
       \_constant: , line:4:11, endln:4:12
-        |vpiConstType:9
-        |vpiDecompile:1
-        |vpiSize:64
-        |UINT:1
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/DpiTask/DpiTask.log
+++ b/tests/DpiTask/DpiTask.log
@@ -135,9 +135,9 @@ design: (work@top)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -354,9 +354,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -372,9 +372,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -390,9 +390,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -410,9 +410,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -503,7 +503,7 @@ design: (work@top)
       |vpiName:ret
       |vpiDirection:2
       |vpiTypedef:
-      \_int_typespec: , line:4:21, endln:4:24, parent:ret
+      \_int_typespec: , line:4:21, endln:4:24
     |vpiStmt:
     \_assignment: , line:5:4, endln:5:11, parent:work@top.task_1
       |vpiOpType:82
@@ -516,10 +516,6 @@ design: (work@top)
         \_io_decl: (ret), parent:work@top.task_1
       |vpiRhs:
       \_constant: , line:5:10, endln:5:11
-        |vpiConstType:9
-        |vpiDecompile:2
-        |vpiSize:64
-        |UINT:2
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/ElabCParam/ElabCParam.log
+++ b/tests/ElabCParam/ElabCParam.log
@@ -668,9 +668,9 @@ design: (work@socket_1n)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -887,9 +887,9 @@ design: (work@socket_1n)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -905,9 +905,9 @@ design: (work@socket_1n)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -923,9 +923,9 @@ design: (work@socket_1n)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -943,9 +943,9 @@ design: (work@socket_1n)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -1346,10 +1346,6 @@ design: (work@socket_1n)
                   \_cont_assign: , line:11:11, endln:11:23, parent:work@socket_1n.gen_dfifo[0].fifo_d.reqfifo.gen_passthru
                     |vpiRhs:
                     \_constant: , line:11:19, endln:11:23
-                      |vpiConstType:3
-                      |vpiDecompile:1'b0
-                      |vpiSize:1
-                      |BIN:0
                     |vpiLhs:
                     \_ref_obj: (work@socket_1n.gen_dfifo[0].fifo_d.reqfifo.gen_passthru.depth), line:11:11, endln:11:16
                       |vpiName:depth
@@ -1396,10 +1392,6 @@ design: (work@socket_1n)
           \_param_assign: , line:3:25, endln:3:40, parent:work@socket_1n.gen_dfifo[0].fifo_d.reqfifo
             |vpiRhs:
             \_constant: , line:3:39, endln:3:40
-              |vpiConstType:9
-              |vpiDecompile:0
-              |vpiSize:64
-              |UINT:0
             |vpiLhs:
             \_parameter: (work@socket_1n.gen_dfifo[0].fifo_d.reqfifo.Depth), line:3:25, endln:3:40
               |vpiName:Depth
@@ -1407,7 +1399,6 @@ design: (work@socket_1n)
               |UINT:0
               |vpiTypespec:
               \_int_typespec: (Depth), line:3:12, endln:3:15, parent:work@socket_1n.gen_dfifo[0].fifo_d.reqfifo.Depth
-                |vpiName:Depth
           |vpiParameter:
           \_parameter: (work@socket_1n.gen_dfifo[0].fifo_d.reqfifo.Depth), line:3:25, endln:3:40, parent:work@socket_1n.gen_dfifo[0].fifo_d.reqfifo
             |vpiName:Depth
@@ -1415,15 +1406,10 @@ design: (work@socket_1n)
             |UINT:0
             |vpiTypespec:
             \_int_typespec: (Depth), line:3:12, endln:3:15, parent:work@socket_1n.gen_dfifo[0].fifo_d.reqfifo.Depth
-              |vpiName:Depth
         |vpiParamAssign:
         \_param_assign: , line:25:25, endln:25:37, parent:work@socket_1n.gen_dfifo[0].fifo_d
           |vpiRhs:
           \_constant: , line:25:36, endln:25:37
-            |vpiConstType:9
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
           |vpiLhs:
           \_parameter: (work@socket_1n.gen_dfifo[0].fifo_d.ReqDepth), line:25:25, endln:25:37
             |vpiName:ReqDepth
@@ -1431,7 +1417,6 @@ design: (work@socket_1n)
             |UINT:0
             |vpiTypespec:
             \_int_typespec: (ReqDepth), line:25:12, endln:25:15, parent:work@socket_1n.gen_dfifo[0].fifo_d.ReqDepth
-              |vpiName:ReqDepth
         |vpiParameter:
         \_parameter: (work@socket_1n.gen_dfifo[0].fifo_d.ReqDepth), line:25:25, endln:25:37, parent:work@socket_1n.gen_dfifo[0].fifo_d
           |vpiName:ReqDepth
@@ -1439,7 +1424,6 @@ design: (work@socket_1n)
           |UINT:0
           |vpiTypespec:
           \_int_typespec: (ReqDepth), line:25:12, endln:25:15, parent:work@socket_1n.gen_dfifo[0].fifo_d.ReqDepth
-            |vpiName:ReqDepth
       |vpiParameter:
       \_parameter: (work@socket_1n.gen_dfifo[0].i), line:44, parent:work@socket_1n.gen_dfifo[0]
         |vpiName:i
@@ -1494,7 +1478,6 @@ design: (work@socket_1n)
                 |INT:1
                 |vpiTypespec:
                 \_int_typespec: (PTRV_W), line:18:15, endln:18:18, parent:work@socket_1n.gen_dfifo[1].fifo_d.reqfifo.gen_normal.PTRV_W
-                  |vpiName:PTRV_W
           |vpiInstance:
           \_module: work@fifo_sync (work@socket_1n.gen_dfifo[1].fifo_d) dut.sv:45: , parent:work@socket_1n.gen_dfifo[1]
             |vpiDefName:work@fifo_sync
@@ -1516,10 +1499,6 @@ design: (work@socket_1n)
                   \_param_assign: , line:18:28, endln:18:71, parent:work@socket_1n.gen_dfifo[1].fifo_d.reqfifo.gen_normal
                     |vpiRhs:
                     \_constant: , line:18:40, endln:18:71
-                      |vpiConstType:7
-                      |vpiDecompile:1
-                      |vpiSize:64
-                      |INT:1
                     |vpiLhs:
                     \_parameter: (work@socket_1n.gen_dfifo[1].fifo_d.reqfifo.gen_normal.PTRV_W), line:18:28, endln:18:71, parent:work@socket_1n.gen_dfifo[1].fifo_d.reqfifo.gen_normal
                       |vpiName:PTRV_W
@@ -1528,7 +1507,6 @@ design: (work@socket_1n)
                       |INT:1
                       |vpiTypespec:
                       \_int_typespec: (PTRV_W), line:18:15, endln:18:18, parent:work@socket_1n.gen_dfifo[1].fifo_d.reqfifo.gen_normal.PTRV_W
-                        |vpiName:PTRV_W
                   |vpiParameter:
                   \_parameter: (work@socket_1n.gen_dfifo[1].fifo_d.reqfifo.gen_normal.PTRV_W), line:18:28, endln:18:71, parent:work@socket_1n.gen_dfifo[1].fifo_d.reqfifo.gen_normal
               |vpiInstance:
@@ -1573,10 +1551,6 @@ design: (work@socket_1n)
           \_param_assign: , line:3:25, endln:3:40, parent:work@socket_1n.gen_dfifo[1].fifo_d.reqfifo
             |vpiRhs:
             \_constant: , line:3:39, endln:3:40
-              |vpiConstType:9
-              |vpiDecompile:2
-              |vpiSize:64
-              |UINT:2
             |vpiLhs:
             \_parameter: (work@socket_1n.gen_dfifo[1].fifo_d.reqfifo.Depth), line:3:25, endln:3:40
               |vpiName:Depth
@@ -1584,7 +1558,6 @@ design: (work@socket_1n)
               |UINT:2
               |vpiTypespec:
               \_int_typespec: (Depth), line:3:12, endln:3:15, parent:work@socket_1n.gen_dfifo[1].fifo_d.reqfifo.Depth
-                |vpiName:Depth
           |vpiParameter:
           \_parameter: (work@socket_1n.gen_dfifo[1].fifo_d.reqfifo.Depth), line:3:25, endln:3:40, parent:work@socket_1n.gen_dfifo[1].fifo_d.reqfifo
             |vpiName:Depth
@@ -1592,15 +1565,10 @@ design: (work@socket_1n)
             |UINT:2
             |vpiTypespec:
             \_int_typespec: (Depth), line:3:12, endln:3:15, parent:work@socket_1n.gen_dfifo[1].fifo_d.reqfifo.Depth
-              |vpiName:Depth
         |vpiParamAssign:
         \_param_assign: , line:25:25, endln:25:37, parent:work@socket_1n.gen_dfifo[1].fifo_d
           |vpiRhs:
           \_constant: , line:25:36, endln:25:37
-            |vpiConstType:9
-            |vpiDecompile:2
-            |vpiSize:64
-            |UINT:2
           |vpiLhs:
           \_parameter: (work@socket_1n.gen_dfifo[1].fifo_d.ReqDepth), line:25:25, endln:25:37
             |vpiName:ReqDepth
@@ -1608,7 +1576,6 @@ design: (work@socket_1n)
             |UINT:2
             |vpiTypespec:
             \_int_typespec: (ReqDepth), line:25:12, endln:25:15, parent:work@socket_1n.gen_dfifo[1].fifo_d.ReqDepth
-              |vpiName:ReqDepth
         |vpiParameter:
         \_parameter: (work@socket_1n.gen_dfifo[1].fifo_d.ReqDepth), line:25:25, endln:25:37, parent:work@socket_1n.gen_dfifo[1].fifo_d
           |vpiName:ReqDepth
@@ -1616,7 +1583,6 @@ design: (work@socket_1n)
           |UINT:2
           |vpiTypespec:
           \_int_typespec: (ReqDepth), line:25:12, endln:25:15, parent:work@socket_1n.gen_dfifo[1].fifo_d.ReqDepth
-            |vpiName:ReqDepth
       |vpiParameter:
       \_parameter: (work@socket_1n.gen_dfifo[1].i), line:44, parent:work@socket_1n.gen_dfifo[1]
         |vpiName:i
@@ -1821,10 +1787,6 @@ design: (work@socket_1n)
                   \_cont_assign: , line:11:11, endln:11:23, parent:work@all_zero.gen_dfifo[0].fifo_d.reqfifo.gen_passthru
                     |vpiRhs:
                     \_constant: , line:11:19, endln:11:23
-                      |vpiConstType:3
-                      |vpiDecompile:1'b0
-                      |vpiSize:1
-                      |BIN:0
                     |vpiLhs:
                     \_ref_obj: (work@all_zero.gen_dfifo[0].fifo_d.reqfifo.gen_passthru.depth), line:11:11, endln:11:16
                       |vpiName:depth
@@ -1871,10 +1833,6 @@ design: (work@socket_1n)
           \_param_assign: , line:3:25, endln:3:40, parent:work@all_zero.gen_dfifo[0].fifo_d.reqfifo
             |vpiRhs:
             \_constant: , line:3:39, endln:3:40
-              |vpiConstType:9
-              |vpiDecompile:0
-              |vpiSize:64
-              |UINT:0
             |vpiLhs:
             \_parameter: (work@all_zero.gen_dfifo[0].fifo_d.reqfifo.Depth), line:3:25, endln:3:40
               |vpiName:Depth
@@ -1882,7 +1840,6 @@ design: (work@socket_1n)
               |UINT:0
               |vpiTypespec:
               \_int_typespec: (Depth), line:3:12, endln:3:15, parent:work@all_zero.gen_dfifo[0].fifo_d.reqfifo.Depth
-                |vpiName:Depth
           |vpiParameter:
           \_parameter: (work@all_zero.gen_dfifo[0].fifo_d.reqfifo.Depth), line:3:25, endln:3:40, parent:work@all_zero.gen_dfifo[0].fifo_d.reqfifo
             |vpiName:Depth
@@ -1890,15 +1847,10 @@ design: (work@socket_1n)
             |UINT:0
             |vpiTypespec:
             \_int_typespec: (Depth), line:3:12, endln:3:15, parent:work@all_zero.gen_dfifo[0].fifo_d.reqfifo.Depth
-              |vpiName:Depth
         |vpiParamAssign:
         \_param_assign: , line:25:25, endln:25:37, parent:work@all_zero.gen_dfifo[0].fifo_d
           |vpiRhs:
           \_constant: , line:25:36, endln:25:37
-            |vpiConstType:9
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
           |vpiLhs:
           \_parameter: (work@all_zero.gen_dfifo[0].fifo_d.ReqDepth), line:25:25, endln:25:37
             |vpiName:ReqDepth
@@ -1906,7 +1858,6 @@ design: (work@socket_1n)
             |UINT:0
             |vpiTypespec:
             \_int_typespec: (ReqDepth), line:25:12, endln:25:15, parent:work@all_zero.gen_dfifo[0].fifo_d.ReqDepth
-              |vpiName:ReqDepth
         |vpiParameter:
         \_parameter: (work@all_zero.gen_dfifo[0].fifo_d.ReqDepth), line:25:25, endln:25:37, parent:work@all_zero.gen_dfifo[0].fifo_d
           |vpiName:ReqDepth
@@ -1914,7 +1865,6 @@ design: (work@socket_1n)
           |UINT:0
           |vpiTypespec:
           \_int_typespec: (ReqDepth), line:25:12, endln:25:15, parent:work@all_zero.gen_dfifo[0].fifo_d.ReqDepth
-            |vpiName:ReqDepth
       |vpiParameter:
       \_parameter: (work@all_zero.gen_dfifo[0].i), line:60, parent:work@all_zero.gen_dfifo[0]
         |vpiName:i
@@ -1977,10 +1927,6 @@ design: (work@socket_1n)
                   \_cont_assign: , line:11:11, endln:11:23, parent:work@all_zero.gen_dfifo[1].fifo_d.reqfifo.gen_passthru
                     |vpiRhs:
                     \_constant: , line:11:19, endln:11:23
-                      |vpiConstType:3
-                      |vpiDecompile:1'b0
-                      |vpiSize:1
-                      |BIN:0
                     |vpiLhs:
                     \_ref_obj: (work@all_zero.gen_dfifo[1].fifo_d.reqfifo.gen_passthru.depth), line:11:11, endln:11:16
                       |vpiName:depth
@@ -2027,10 +1973,6 @@ design: (work@socket_1n)
           \_param_assign: , line:3:25, endln:3:40, parent:work@all_zero.gen_dfifo[1].fifo_d.reqfifo
             |vpiRhs:
             \_constant: , line:3:39, endln:3:40
-              |vpiConstType:9
-              |vpiDecompile:0
-              |vpiSize:64
-              |UINT:0
             |vpiLhs:
             \_parameter: (work@all_zero.gen_dfifo[1].fifo_d.reqfifo.Depth), line:3:25, endln:3:40
               |vpiName:Depth
@@ -2038,7 +1980,6 @@ design: (work@socket_1n)
               |UINT:0
               |vpiTypespec:
               \_int_typespec: (Depth), line:3:12, endln:3:15, parent:work@all_zero.gen_dfifo[1].fifo_d.reqfifo.Depth
-                |vpiName:Depth
           |vpiParameter:
           \_parameter: (work@all_zero.gen_dfifo[1].fifo_d.reqfifo.Depth), line:3:25, endln:3:40, parent:work@all_zero.gen_dfifo[1].fifo_d.reqfifo
             |vpiName:Depth
@@ -2046,15 +1987,10 @@ design: (work@socket_1n)
             |UINT:0
             |vpiTypespec:
             \_int_typespec: (Depth), line:3:12, endln:3:15, parent:work@all_zero.gen_dfifo[1].fifo_d.reqfifo.Depth
-              |vpiName:Depth
         |vpiParamAssign:
         \_param_assign: , line:25:25, endln:25:37, parent:work@all_zero.gen_dfifo[1].fifo_d
           |vpiRhs:
           \_constant: , line:25:36, endln:25:37
-            |vpiConstType:9
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
           |vpiLhs:
           \_parameter: (work@all_zero.gen_dfifo[1].fifo_d.ReqDepth), line:25:25, endln:25:37
             |vpiName:ReqDepth
@@ -2062,7 +1998,6 @@ design: (work@socket_1n)
             |UINT:0
             |vpiTypespec:
             \_int_typespec: (ReqDepth), line:25:12, endln:25:15, parent:work@all_zero.gen_dfifo[1].fifo_d.ReqDepth
-              |vpiName:ReqDepth
         |vpiParameter:
         \_parameter: (work@all_zero.gen_dfifo[1].fifo_d.ReqDepth), line:25:25, endln:25:37, parent:work@all_zero.gen_dfifo[1].fifo_d
           |vpiName:ReqDepth
@@ -2070,7 +2005,6 @@ design: (work@socket_1n)
           |UINT:0
           |vpiTypespec:
           \_int_typespec: (ReqDepth), line:25:12, endln:25:15, parent:work@all_zero.gen_dfifo[1].fifo_d.ReqDepth
-            |vpiName:ReqDepth
       |vpiParameter:
       \_parameter: (work@all_zero.gen_dfifo[1].i), line:60, parent:work@all_zero.gen_dfifo[1]
         |vpiName:i

--- a/tests/ElabParam/ElabParam.log
+++ b/tests/ElabParam/ElabParam.log
@@ -343,9 +343,9 @@ design: (work@dut)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -562,9 +562,9 @@ design: (work@dut)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -580,9 +580,9 @@ design: (work@dut)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -598,9 +598,9 @@ design: (work@dut)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -618,9 +618,9 @@ design: (work@dut)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/EvalFunc/EvalFunc.log
+++ b/tests/EvalFunc/EvalFunc.log
@@ -987,9 +987,9 @@ design: (work@top)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -1206,9 +1206,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -1224,9 +1224,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -1242,9 +1242,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -1262,9 +1262,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -2244,7 +2244,7 @@ design: (work@top)
       |vpiName:value
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:24:33, endln:24:40, parent:value
+      \_int_typespec: , line:24:33, endln:24:40
     |vpiStmt:
     \_return_stmt: , line:25:2, endln:25:8, parent:work@top.vbits
       |vpiCondition:
@@ -2261,16 +2261,8 @@ design: (work@top)
             \_io_decl: (value), parent:work@top.vbits
           |vpiOperand:
           \_constant: , line:25:19, endln:25:20
-            |vpiConstType:9
-            |vpiDecompile:1
-            |vpiSize:64
-            |UINT:1
         |vpiOperand:
         \_constant: , line:25:24, endln:25:25
-          |vpiConstType:9
-          |vpiDecompile:1
-          |vpiSize:64
-          |UINT:1
         |vpiOperand:
         \_sys_func_call: ($clog2), line:25:28, endln:25:41
           |vpiName:$clog2
@@ -2330,10 +2322,6 @@ design: (work@top)
             \_io_decl: (value), line:34:14, endln:34:19, parent:work@top.log2
           |vpiOperand:
           \_constant: , line:38:13, endln:38:14
-            |vpiConstType:9
-            |vpiDecompile:2
-            |vpiSize:64
-            |UINT:2
         |vpiStmt:
         \_assignment: , line:39:2, endln:39:14
           |vpiOpType:82
@@ -2367,32 +2355,10 @@ design: (work@top)
                 \_range: , line:35:5, endln:35:9, parent:work@top.log2.shifted
                   |vpiLeftRange:
                   \_constant: , line:35:5, endln:35:7
-                    |vpiConstType:9
-                    |vpiDecompile:31
-                    |vpiSize:64
-                    |UINT:31
                   |vpiRightRange:
                   \_constant: , line:35:8, endln:35:9
-                    |vpiConstType:9
-                    |vpiDecompile:0
-                    |vpiSize:64
-                    |UINT:0
                 |vpiTypespec:
-                \_logic_typespec: , line:35, endln:35:3, parent:work@top.log2.shifted
-                  |vpiRange:
-                  \_range: , line:35:5, endln:35:9
-                    |vpiLeftRange:
-                    \_constant: , line:35:5, endln:35:7
-                      |vpiConstType:9
-                      |vpiDecompile:31
-                      |vpiSize:64
-                      |UINT:31
-                    |vpiRightRange:
-                    \_constant: , line:35:8, endln:35:9
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
+                \_logic_typespec: , line:35, endln:35:3
             |vpiRhs:
             \_operation: , line:42:12, endln:42:17
               |vpiOpType:11
@@ -2404,10 +2370,6 @@ design: (work@top)
                 \_io_decl: (value), line:34:14, endln:34:19, parent:work@top.log2
               |vpiOperand:
               \_constant: , line:42:18, endln:42:19
-                |vpiConstType:9
-                |vpiDecompile:1
-                |vpiSize:64
-                |UINT:1
           |vpiStmt:
           \_for_stmt: (work@top.log2), line:43:2, endln:43:5, parent:work@top.log2
             |vpiFullName:work@top.log2
@@ -2422,18 +2384,10 @@ design: (work@top)
                 \_logic_var: (work@top.log2.shifted), line:35, endln:35:3, parent:work@top.log2
               |vpiOperand:
               \_constant: , line:43:22, endln:43:23
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
             |vpiForInitStmt:
             \_assign_stmt: , parent:work@top.log2
               |vpiRhs:
               \_constant: , line:43:11, endln:43:12
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
               |vpiLhs:
               \_int_var: (work@top.log2.res), line:43:7, endln:43:10
                 |vpiName:res
@@ -2451,7 +2405,7 @@ design: (work@top)
                   |vpiName:res
                   |vpiFullName:work@top.log2.res
                   |vpiTypespec:
-                  \_int_typespec: , line:36, endln:36:7, parent:work@top.log2.res
+                  \_int_typespec: , line:36, endln:36:7
               |vpiRhs:
               \_operation: , line:43:29, endln:43:32
                 |vpiOpType:24
@@ -2463,10 +2417,6 @@ design: (work@top)
                   \_int_var: (work@top.log2.res), line:36, endln:36:7, parent:work@top.log2
                 |vpiOperand:
                 \_constant: , line:43:33, endln:43:34
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
             |vpiStmt:
             \_assignment: , line:44:3, endln:44:23, parent:work@top.log2
               |vpiOpType:82
@@ -2488,10 +2438,6 @@ design: (work@top)
                   \_logic_var: (work@top.log2.shifted), line:35, endln:35:3, parent:work@top.log2
                 |vpiOperand:
                 \_constant: , line:44:22, endln:44:23
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
           |vpiStmt:
           \_assignment: , line:45:2, endln:45:12, parent:work@top.log2
             |vpiOpType:82
@@ -2536,10 +2482,6 @@ design: (work@top)
           |vpiFullName:work@top.log2_2.log2_2
         |vpiRhs:
         \_constant: , line:54:9, endln:54:10
-          |vpiConstType:9
-          |vpiDecompile:0
-          |vpiSize:64
-          |UINT:0
       |vpiStmt:
       \_if_stmt: , line:55, endln:59:3, parent:work@top.log2_2
         |vpiCondition:
@@ -2577,10 +2519,6 @@ design: (work@top)
                   \_io_decl: (value), line:52:14, endln:52:19, parent:work@top.log2_2
               |vpiOperand:
               \_constant: , line:56:25, endln:56:26
-                |vpiConstType:9
-                |vpiDecompile:1
-                |vpiSize:64
-                |UINT:1
           |vpiStmt:
           \_for_stmt: (work@top.log2_2), line:57:4, endln:57:7, parent:work@top.log2_2
             |vpiFullName:work@top.log2_2
@@ -2595,10 +2533,6 @@ design: (work@top)
                 \_io_decl: (value), line:52:14, endln:52:19, parent:work@top.log2_2
               |vpiOperand:
               \_constant: , line:57:19, endln:57:20
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
             |vpiForIncStmt:
             \_assignment: , line:57:22, endln:57:41, parent:work@top.log2_2
               |vpiOpType:82
@@ -2616,10 +2550,6 @@ design: (work@top)
                   |vpiFullName:work@top.log2_2.log2_2
                 |vpiOperand:
                 \_constant: , line:57:40, endln:57:41
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
             |vpiStmt:
             \_assignment: , line:58:5, endln:58:23, parent:work@top.log2_2
               |vpiOpType:82
@@ -2641,10 +2571,6 @@ design: (work@top)
                   \_io_decl: (value), line:52:14, endln:52:19, parent:work@top.log2_2
                 |vpiOperand:
                 \_constant: , line:58:22, endln:58:23
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
   |vpiParamAssign:
   \_param_assign: , line:63:11, endln:63:21, parent:work@top
     |vpiRhs:

--- a/tests/EvalFuncArray/EvalFuncArray.log
+++ b/tests/EvalFuncArray/EvalFuncArray.log
@@ -444,9 +444,9 @@ design: (unnamed)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -663,9 +663,9 @@ design: (unnamed)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -681,9 +681,9 @@ design: (unnamed)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -699,9 +699,9 @@ design: (unnamed)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -719,9 +719,9 @@ design: (unnamed)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/EvalFuncCont/EvalFuncCont.log
+++ b/tests/EvalFuncCont/EvalFuncCont.log
@@ -377,9 +377,9 @@ design: (work@t)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -596,9 +596,9 @@ design: (work@t)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -614,9 +614,9 @@ design: (work@t)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -632,9 +632,9 @@ design: (work@t)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -652,9 +652,9 @@ design: (work@t)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -987,7 +987,7 @@ design: (work@t)
       \_sys_func_call: ($write), line:32:6, endln:32:39, parent:work@t
         |vpiName:$write
         |vpiArgument:
-        \_constant: , line:32:13, endln:32:37, parent:$write
+        \_constant: , line:32:13, endln:32:37
           |vpiConstType:6
           |vpiDecompile:*-* All Finished *-*\n
           |vpiSize:22
@@ -1034,10 +1034,6 @@ design: (work@t)
                 \_parameter: (work@t.NUM_OUT), line:16:14, endln:16:38, parent:work@t
               |vpiOperand:
               \_constant: , line:30:21, endln:30:22
-                |vpiConstType:9
-                |vpiDecompile:4
-                |vpiSize:64
-                |UINT:4
             |vpiStmt:
             \_sys_func_call: ($stop), line:30:24, endln:30:30
               |vpiName:$stop
@@ -1057,10 +1053,6 @@ design: (work@t)
                   \_logic_net: (work@t.z), line:18:22, endln:18:23, parent:work@t
               |vpiOperand:
               \_constant: , line:31:22, endln:31:23
-                |vpiConstType:9
-                |vpiDecompile:4
-                |vpiSize:64
-                |UINT:4
             |vpiStmt:
             \_sys_func_call: ($stop), line:31:25, endln:31:31
               |vpiName:$stop
@@ -1069,10 +1061,6 @@ design: (work@t)
             |vpiName:$write
             |vpiArgument:
             \_constant: , line:32:13, endln:32:37
-              |vpiConstType:6
-              |vpiDecompile:*-* All Finished *-*\n
-              |vpiSize:22
-              |STRING:*-* All Finished *-*\n
           |vpiStmt:
           \_sys_func_call: ($finish), line:33:6, endln:33:14, parent:work@t
             |vpiName:$finish
@@ -1259,10 +1247,6 @@ design: (work@t)
           |vpiFullName:work@t.num_out.num_out
         |vpiRhs:
         \_constant: , line:22:16, endln:22:17
-          |vpiConstType:9
-          |vpiDecompile:1
-          |vpiSize:64
-          |UINT:1
       |vpiStmt:
       \_while_stmt: , line:23:6, endln:23:11, parent:work@t.num_out
         |vpiCondition:
@@ -1289,10 +1273,6 @@ design: (work@t)
                   |vpiFullName:work@t.num_out.num_out
               |vpiOperand:
               \_constant: , line:23:32, endln:23:33
-                |vpiConstType:9
-                |vpiDecompile:1
-                |vpiSize:64
-                |UINT:1
             |vpiOperand:
             \_ref_obj: (work@t.num_out.num_out), line:23:37, endln:23:44
               |vpiName:num_out
@@ -1323,10 +1303,6 @@ design: (work@t)
                 |vpiFullName:work@t.num_out.num_out
               |vpiOperand:
               \_constant: , line:24:28, endln:24:29
-                |vpiConstType:9
-                |vpiDecompile:2
-                |vpiSize:64
-                |UINT:2
           |vpiStmt:
           \_continue_stmt: , line:25:8, endln:25:16, parent:work@t.num_out
   |vpiNet:

--- a/tests/EvalFuncNamed/EvalFuncNamed.log
+++ b/tests/EvalFuncNamed/EvalFuncNamed.log
@@ -458,9 +458,9 @@ design: (work@t)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -677,9 +677,9 @@ design: (work@t)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -695,9 +695,9 @@ design: (work@t)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -713,9 +713,9 @@ design: (work@t)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -733,9 +733,9 @@ design: (work@t)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -1193,17 +1193,13 @@ design: (work@t)
       |vpiName:value1
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:3:46, endln:3:49, parent:value1
-        |vpiInstance:
-        \_package: my_funcs (my_funcs::) dut.sv:1: , endln:14:10, parent:work@t
+      \_int_typespec: , line:3:46, endln:3:49
     |vpiIODecl:
     \_io_decl: (value2), parent:my_module_types::simple_minus
       |vpiName:value2
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:3:64, endln:3:67, parent:value2
-        |vpiInstance:
-        \_package: my_funcs (my_funcs::) dut.sv:1: , endln:14:10, parent:work@t
+      \_int_typespec: , line:3:64, endln:3:67
     |vpiStmt:
     \_begin: (work@t.simple_minus), line:4:6, endln:6:9, parent:my_module_types::simple_minus
       |vpiFullName:work@t.simple_minus
@@ -1245,17 +1241,13 @@ design: (work@t)
       |vpiName:value1
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:9:45, endln:9:48, parent:value1
-        |vpiInstance:
-        \_package: my_funcs (my_funcs::) dut.sv:1: , endln:14:10, parent:work@t
+      \_int_typespec: , line:9:45, endln:9:48
     |vpiIODecl:
     \_io_decl: (value2), parent:my_module_types::simple_func
       |vpiName:value2
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:9:63, endln:9:66, parent:value2
-        |vpiInstance:
-        \_package: my_funcs (my_funcs::) dut.sv:1: , endln:14:10, parent:work@t
+      \_int_typespec: , line:9:63, endln:9:66
     |vpiStmt:
     \_begin: (work@t.simple_func), line:10:6, endln:12:9, parent:my_module_types::simple_func
       |vpiFullName:work@t.simple_func

--- a/tests/EvalFuncPack/EvalFuncPack.log
+++ b/tests/EvalFuncPack/EvalFuncPack.log
@@ -972,9 +972,9 @@ design: (work@flash_ctrl_info_cfg)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -1191,9 +1191,9 @@ design: (work@flash_ctrl_info_cfg)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -1209,9 +1209,9 @@ design: (work@flash_ctrl_info_cfg)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -1227,9 +1227,9 @@ design: (work@flash_ctrl_info_cfg)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -1247,9 +1247,9 @@ design: (work@flash_ctrl_info_cfg)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -1770,17 +1770,11 @@ design: (work@flash_ctrl_info_cfg)
       |vpiName:infos
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:35:42, endln:35:45, parent:infos
-        |vpiInstance:
-        \_package: flash_ctrl_pkg (flash_ctrl_pkg::) dut.sv:24: , endln:45:10, parent:work@flash_ctrl_info_cfg
+      \_int_typespec: , line:35:42, endln:35:45
       |vpiRange:
       \_range: , line:35:52, endln:35:61, parent:infos
         |vpiLeftRange:
         \_constant: , line:35:52, endln:35:53
-          |vpiConstType:9
-          |vpiDecompile:0
-          |vpiSize:64
-          |UINT:0
         |vpiRightRange:
         \_operation: 
           |vpiOpType:11
@@ -1792,9 +1786,6 @@ design: (work@flash_ctrl_info_cfg)
             \_parameter: (work@flash_ctrl_info_cfg.InfoTypes), line:26:14, endln:26:27, parent:work@flash_ctrl_info_cfg
           |vpiOperand:
           \_constant: 
-            |vpiConstType:7
-            |vpiSize:64
-            |INT:1
     |vpiStmt:
     \_begin: (work@flash_ctrl_info_cfg.max_info_pages), parent:flash_ctrl_pkg::max_info_pages
       |vpiFullName:work@flash_ctrl_info_cfg.max_info_pages
@@ -1802,10 +1793,6 @@ design: (work@flash_ctrl_info_cfg)
       \_assign_stmt: , parent:work@flash_ctrl_info_cfg.max_info_pages
         |vpiRhs:
         \_constant: , line:36:22, endln:36:23
-          |vpiConstType:9
-          |vpiDecompile:0
-          |vpiSize:64
-          |UINT:0
         |vpiLhs:
         \_int_var: (work@flash_ctrl_info_cfg.max_info_pages.current_max), line:36:4, endln:36:7
           |vpiName:current_max
@@ -1830,10 +1817,6 @@ design: (work@flash_ctrl_info_cfg)
         \_assign_stmt: , parent:work@flash_ctrl_info_cfg.max_info_pages
           |vpiRhs:
           \_constant: , line:37:17, endln:37:18
-            |vpiConstType:9
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
           |vpiLhs:
           \_int_var: (work@flash_ctrl_info_cfg.max_info_pages.i), line:37:9, endln:37:12
             |vpiName:i

--- a/tests/FSM2Always/FSM2Always.log
+++ b/tests/FSM2Always/FSM2Always.log
@@ -918,9 +918,9 @@ design: (work@fsm_using_always)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -1137,9 +1137,9 @@ design: (work@fsm_using_always)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -1155,9 +1155,9 @@ design: (work@fsm_using_always)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -1173,9 +1173,9 @@ design: (work@fsm_using_always)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -1193,9 +1193,9 @@ design: (work@fsm_using_always)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/FSMBsp13/FSMBsp13.log
+++ b/tests/FSMBsp13/FSMBsp13.log
@@ -6056,9 +6056,9 @@ design: (work@top)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -6275,9 +6275,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -6293,9 +6293,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -6311,9 +6311,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -6331,9 +6331,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -14537,7 +14537,7 @@ design: (work@top)
       \_sys_func_call: ($vtDumpvars), line:121:2, endln:121:24, parent:work@top
         |vpiName:$vtDumpvars
         |vpiArgument:
-        \_constant: , line:121:14, endln:121:15, parent:$vtDumpvars
+        \_constant: , line:121:14, endln:121:15
           |vpiConstType:9
           |vpiDecompile:1
           |vpiSize:64
@@ -18923,10 +18923,6 @@ design: (work@top)
                 \_logic_net: (work@top.F2.Ctrl1), line:10:4, endln:10:9, parent:work@top.F2
               |vpiRhs:
               \_constant: , line:13:10, endln:13:11
-                |vpiConstType:9
-                |vpiDecompile:1
-                |vpiSize:64
-                |UINT:1
             |vpiStmt:
             \_assignment: , line:14:2, endln:14:11, parent:work@FSM2
               |vpiOpType:82
@@ -18939,10 +18935,6 @@ design: (work@top)
                 \_logic_net: (work@top.F2.Ctrl2), line:10:10, endln:10:15, parent:work@top.F2
               |vpiRhs:
               \_constant: , line:14:10, endln:14:11
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
             |vpiStmt:
             \_assignment: , line:15:2, endln:15:11, parent:work@FSM2
               |vpiOpType:82
@@ -18955,10 +18947,6 @@ design: (work@top)
                 \_logic_net: (work@top.F2.Ctrl3), line:10:16, endln:10:21, parent:work@top.F2
               |vpiRhs:
               \_constant: , line:15:10, endln:15:11
-                |vpiConstType:9
-                |vpiDecompile:1
-                |vpiSize:64
-                |UINT:1
             |vpiStmt:
             \_assignment: , line:16:2, endln:16:11, parent:work@FSM2
               |vpiOpType:82
@@ -18971,10 +18959,6 @@ design: (work@top)
                 \_logic_net: (work@top.F2.Ctrl4), line:10:22, endln:10:27, parent:work@top.F2
               |vpiRhs:
               \_constant: , line:16:10, endln:16:11
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
             |vpiStmt:
             \_assignment: , line:17:2, endln:17:11, parent:work@FSM2
               |vpiOpType:82
@@ -18987,10 +18971,6 @@ design: (work@top)
                 \_logic_net: (work@top.F2.Ctrl5), line:10:28, endln:10:33, parent:work@top.F2
               |vpiRhs:
               \_constant: , line:17:10, endln:17:11
-                |vpiConstType:9
-                |vpiDecompile:1
-                |vpiSize:64
-                |UINT:1
             |vpiStmt:
             \_assignment: , line:18:2, endln:18:11, parent:work@FSM2
               |vpiOpType:82
@@ -19003,10 +18983,6 @@ design: (work@top)
                 \_logic_net: (work@top.F2.Ctrl6), line:10:34, endln:10:39, parent:work@top.F2
               |vpiRhs:
               \_constant: , line:18:10, endln:18:11
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
             |vpiStmt:
             \_assignment: , line:19:2, endln:19:11, parent:work@FSM2
               |vpiOpType:82
@@ -19019,10 +18995,6 @@ design: (work@top)
                 \_logic_net: (work@top.F2.Ctrl7), line:10:40, endln:10:45, parent:work@top.F2
               |vpiRhs:
               \_constant: , line:19:10, endln:19:11
-                |vpiConstType:9
-                |vpiDecompile:1
-                |vpiSize:64
-                |UINT:1
         |vpiProcess:
         \_always: , line:36, endln:113:3, parent:work@FSM2
           |vpiAlwaysType:1
@@ -19940,10 +19912,6 @@ design: (work@top)
                       \_logic_net: (work@top.F2.y), line:4:10, endln:4:11, parent:work@top.F2
                     |vpiRhs:
                     \_constant: , line:126:11, endln:126:12
-                      |vpiConstType:9
-                      |vpiDecompile:1
-                      |vpiSize:64
-                      |UINT:1
                 |vpiCaseItem:
                 \_case_item: , line:127:4, endln:127:13
                   |vpiExpr:
@@ -19964,10 +19932,6 @@ design: (work@top)
                       \_logic_net: (work@top.F2.y), line:4:10, endln:4:11, parent:work@top.F2
                     |vpiRhs:
                     \_constant: , line:127:11, endln:127:12
-                      |vpiConstType:9
-                      |vpiDecompile:2
-                      |vpiSize:64
-                      |UINT:2
                 |vpiCaseItem:
                 \_case_item: , line:128:4, endln:128:13
                   |vpiExpr:
@@ -19988,10 +19952,6 @@ design: (work@top)
                       \_logic_net: (work@top.F2.y), line:4:10, endln:4:11, parent:work@top.F2
                     |vpiRhs:
                     \_constant: , line:128:11, endln:128:12
-                      |vpiConstType:9
-                      |vpiDecompile:3
-                      |vpiSize:64
-                      |UINT:3
                 |vpiCaseItem:
                 \_case_item: , line:129:4, endln:129:13
                   |vpiExpr:
@@ -20012,10 +19972,6 @@ design: (work@top)
                       \_logic_net: (work@top.F2.y), line:4:10, endln:4:11, parent:work@top.F2
                     |vpiRhs:
                     \_constant: , line:129:11, endln:129:12
-                      |vpiConstType:9
-                      |vpiDecompile:4
-                      |vpiSize:64
-                      |UINT:4
                 |vpiCaseItem:
                 \_case_item: , line:130:4, endln:130:17
                   |vpiStmt:
@@ -20030,10 +19986,6 @@ design: (work@top)
                       \_logic_net: (work@top.F2.y), line:4:10, endln:4:11, parent:work@top.F2
                     |vpiRhs:
                     \_constant: , line:130:15, endln:130:16
-                      |vpiConstType:9
-                      |vpiDecompile:1
-                      |vpiSize:64
-                      |UINT:1
         |vpiPort:
         \_port: (clock), line:1:12, parent:work@FSM2
           |vpiName:clock

--- a/tests/FSMFunction/FSMFunction.log
+++ b/tests/FSMFunction/FSMFunction.log
@@ -956,9 +956,9 @@ design: (work@fsm_using_function)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -1175,9 +1175,9 @@ design: (work@fsm_using_function)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -1193,9 +1193,9 @@ design: (work@fsm_using_function)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -1211,9 +1211,9 @@ design: (work@fsm_using_function)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -1231,9 +1231,9 @@ design: (work@fsm_using_function)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -2651,10 +2651,6 @@ design: (work@fsm_using_function)
                   \_logic_net: (work@fsm_using_function.reset), line:19:14, endln:19:19, parent:work@fsm_using_function
                 |vpiOperand:
                 \_constant: , line:59:15, endln:59:19
-                  |vpiConstType:3
-                  |vpiDecompile:1'b1
-                  |vpiSize:1
-                  |BIN:1
               |vpiStmt:
               \_begin: (work@fsm_using_function.FSM_SEQ), line:59:21, endln:61:5
                 |vpiFullName:work@fsm_using_function.FSM_SEQ
@@ -2728,10 +2724,6 @@ design: (work@fsm_using_function)
                   \_logic_net: (work@fsm_using_function.reset), line:19:14, endln:19:19, parent:work@fsm_using_function
                 |vpiOperand:
                 \_constant: , line:68:13, endln:68:17
-                  |vpiConstType:3
-                  |vpiDecompile:1'b1
-                  |vpiSize:1
-                  |BIN:1
               |vpiStmt:
               \_begin: (work@fsm_using_function.OUTPUT_LOGIC), line:68:19, endln:71:3
                 |vpiFullName:work@fsm_using_function.OUTPUT_LOGIC
@@ -2749,10 +2741,6 @@ design: (work@fsm_using_function)
                     |#1
                   |vpiRhs:
                   \_constant: , line:69:14, endln:69:18
-                    |vpiConstType:3
-                    |vpiDecompile:1'b0
-                    |vpiSize:1
-                    |BIN:0
                 |vpiStmt:
                 \_assignment: , line:70:2, endln:70:18, parent:work@fsm_using_function.OUTPUT_LOGIC
                   |vpiOpType:82
@@ -2767,10 +2755,6 @@ design: (work@fsm_using_function)
                     |#1
                   |vpiRhs:
                   \_constant: , line:70:14, endln:70:18
-                    |vpiConstType:3
-                    |vpiDecompile:1'b0
-                    |vpiSize:1
-                    |BIN:0
               |vpiElseStmt:
               \_begin: (work@fsm_using_function.OUTPUT_LOGIC), line:72:5, endln:91:3
                 |vpiFullName:work@fsm_using_function.OUTPUT_LOGIC
@@ -2808,10 +2792,6 @@ design: (work@fsm_using_function)
                           |#1
                         |vpiRhs:
                         \_constant: , line:75:30, endln:75:34
-                          |vpiConstType:3
-                          |vpiDecompile:1'b0
-                          |vpiSize:1
-                          |BIN:0
                       |vpiStmt:
                       \_assignment: , line:76:18, endln:76:34, parent:work@fsm_using_function.OUTPUT_LOGIC
                         |vpiOpType:82
@@ -2826,10 +2806,6 @@ design: (work@fsm_using_function)
                           |#1
                         |vpiRhs:
                         \_constant: , line:76:30, endln:76:34
-                          |vpiConstType:3
-                          |vpiDecompile:1'b0
-                          |vpiSize:1
-                          |BIN:0
                   |vpiCaseItem:
                   \_case_item: , line:78:3, endln:81:19
                     |vpiExpr:
@@ -2855,10 +2831,6 @@ design: (work@fsm_using_function)
                           |#1
                         |vpiRhs:
                         \_constant: , line:79:31, endln:79:35
-                          |vpiConstType:3
-                          |vpiDecompile:1'b1
-                          |vpiSize:1
-                          |BIN:1
                       |vpiStmt:
                       \_assignment: , line:80:19, endln:80:35, parent:work@fsm_using_function.OUTPUT_LOGIC
                         |vpiOpType:82
@@ -2873,10 +2845,6 @@ design: (work@fsm_using_function)
                           |#1
                         |vpiRhs:
                         \_constant: , line:80:31, endln:80:35
-                          |vpiConstType:3
-                          |vpiDecompile:1'b0
-                          |vpiSize:1
-                          |BIN:0
                   |vpiCaseItem:
                   \_case_item: , line:82:3, endln:85:19
                     |vpiExpr:
@@ -2902,10 +2870,6 @@ design: (work@fsm_using_function)
                           |#1
                         |vpiRhs:
                         \_constant: , line:83:31, endln:83:35
-                          |vpiConstType:3
-                          |vpiDecompile:1'b0
-                          |vpiSize:1
-                          |BIN:0
                       |vpiStmt:
                       \_assignment: , line:84:19, endln:84:35, parent:work@fsm_using_function.OUTPUT_LOGIC
                         |vpiOpType:82
@@ -2920,10 +2884,6 @@ design: (work@fsm_using_function)
                           |#1
                         |vpiRhs:
                         \_constant: , line:84:31, endln:84:35
-                          |vpiConstType:3
-                          |vpiDecompile:1'b1
-                          |vpiSize:1
-                          |BIN:1
                   |vpiCaseItem:
                   \_case_item: , line:86:3, endln:89:21
                     |vpiStmt:
@@ -2943,10 +2903,6 @@ design: (work@fsm_using_function)
                           |#1
                         |vpiRhs:
                         \_constant: , line:87:32, endln:87:36
-                          |vpiConstType:3
-                          |vpiDecompile:1'b0
-                          |vpiSize:1
-                          |BIN:0
                       |vpiStmt:
                       \_assignment: , line:88:20, endln:88:36, parent:work@fsm_using_function.OUTPUT_LOGIC
                         |vpiOpType:82
@@ -2961,10 +2917,6 @@ design: (work@fsm_using_function)
                           |#1
                         |vpiRhs:
                         \_constant: , line:88:32, endln:88:36
-                          |vpiConstType:3
-                          |vpiDecompile:1'b0
-                          |vpiSize:1
-                          |BIN:0
       |vpiPort:
       \_port: (clock), line:7, parent:work@fsm_using_function
         |vpiName:clock
@@ -3417,16 +3369,8 @@ design: (work@fsm_using_function)
       \_range: , line:32:10, endln:32:18, parent:state
         |vpiLeftRange:
         \_constant: , line:32:10, endln:32:14
-          |vpiConstType:7
-          |vpiDecompile:2
-          |vpiSize:64
-          |INT:2
         |vpiRightRange:
         \_constant: , line:32:17, endln:32:18
-          |vpiConstType:9
-          |vpiDecompile:0
-          |vpiSize:64
-          |UINT:0
     |vpiIODecl:
     \_io_decl: (req_0), line:33:11, endln:33:16, parent:work@fsm_using_function.fsm_function
       |vpiName:req_0
@@ -3465,10 +3409,6 @@ design: (work@fsm_using_function)
               \_io_decl: (req_0), line:33:11, endln:33:16, parent:work@fsm_using_function.fsm_function
             |vpiOperand:
             \_constant: , line:36:23, endln:36:27
-              |vpiConstType:3
-              |vpiDecompile:1'b1
-              |vpiSize:1
-              |BIN:1
           |vpiStmt:
           \_begin: (work@fsm_using_function.fsm_function), line:36:29, endln:38:17
             |vpiFullName:work@fsm_using_function.fsm_function
@@ -3499,10 +3439,6 @@ design: (work@fsm_using_function)
                 \_io_decl: (req_1), line:34:11, endln:34:16, parent:work@fsm_using_function.fsm_function
               |vpiOperand:
               \_constant: , line:38:36, endln:38:40
-                |vpiConstType:3
-                |vpiDecompile:1'b1
-                |vpiSize:1
-                |BIN:1
             |vpiStmt:
             \_begin: (work@fsm_using_function.fsm_function), line:38:42, endln:40:17
               |vpiFullName:work@fsm_using_function.fsm_function
@@ -3558,10 +3494,6 @@ design: (work@fsm_using_function)
               \_io_decl: (req_0), line:33:11, endln:33:16, parent:work@fsm_using_function.fsm_function
             |vpiOperand:
             \_constant: , line:43:23, endln:43:27
-              |vpiConstType:3
-              |vpiDecompile:1'b1
-              |vpiSize:1
-              |BIN:1
           |vpiStmt:
           \_begin: (work@fsm_using_function.fsm_function), line:43:29, endln:45:17
             |vpiFullName:work@fsm_using_function.fsm_function
@@ -3617,10 +3549,6 @@ design: (work@fsm_using_function)
               \_io_decl: (req_1), line:34:11, endln:34:16, parent:work@fsm_using_function.fsm_function
             |vpiOperand:
             \_constant: , line:48:23, endln:48:27
-              |vpiConstType:3
-              |vpiDecompile:1'b1
-              |vpiSize:1
-              |BIN:1
           |vpiStmt:
           \_begin: (work@fsm_using_function.fsm_function), line:48:29, endln:50:13
             |vpiFullName:work@fsm_using_function.fsm_function

--- a/tests/FSMSingleAlways/FSMSingleAlways.log
+++ b/tests/FSMSingleAlways/FSMSingleAlways.log
@@ -676,9 +676,9 @@ design: (work@fsm_using_single_always)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -895,9 +895,9 @@ design: (work@fsm_using_single_always)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -913,9 +913,9 @@ design: (work@fsm_using_single_always)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -931,9 +931,9 @@ design: (work@fsm_using_single_always)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -951,9 +951,9 @@ design: (work@fsm_using_single_always)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/ForLoop/ForLoop.log
+++ b/tests/ForLoop/ForLoop.log
@@ -873,9 +873,9 @@ design: (work@t)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -1092,9 +1092,9 @@ design: (work@t)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -1110,9 +1110,9 @@ design: (work@t)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -1128,9 +1128,9 @@ design: (work@t)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -1148,9 +1148,9 @@ design: (work@t)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -3001,7 +3001,7 @@ design: (work@t)
       \_sys_func_call: ($write), line:24:5, endln:24:38, parent:work@t
         |vpiName:$write
         |vpiArgument:
-        \_constant: , line:24:12, endln:24:36, parent:$write
+        \_constant: , line:24:12, endln:24:36
           |vpiConstType:6
           |vpiDecompile:*-* All Finished *-*\n
           |vpiSize:22

--- a/tests/FuncArgDirection/FuncArgDirection.log
+++ b/tests/FuncArgDirection/FuncArgDirection.log
@@ -291,9 +291,9 @@ design: (work@dut)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -510,9 +510,9 @@ design: (work@dut)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -528,9 +528,9 @@ design: (work@dut)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -546,9 +546,9 @@ design: (work@dut)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -566,9 +566,9 @@ design: (work@dut)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -871,10 +871,6 @@ design: (work@dut)
       \_cont_assign: , line:12:7, endln:12:33, parent:work@dut
         |vpiRhs:
         \_constant: , line:12:22, endln:12:33
-          |vpiConstType:3
-          |vpiDecompile:8'b00001111
-          |vpiSize:8
-          |BIN:00001111
         |vpiLhs:
         \_ref_obj: (work@dut.ctr_we_o_rev), line:12:7, endln:12:19
           |vpiName:ctr_we_o_rev
@@ -1034,21 +1030,7 @@ design: (work@dut)
       |vpiName:in
       |vpiDirection:1
       |vpiTypedef:
-      \_logic_typespec: , line:2:49, endln:2:54, parent:in
-        |vpiRange:
-        \_range: , line:2:56, endln:2:59
-          |vpiLeftRange:
-          \_constant: , line:2:56, endln:2:57
-            |vpiConstType:9
-            |vpiDecompile:7
-            |vpiSize:64
-            |UINT:7
-          |vpiRightRange:
-          \_constant: , line:2:58, endln:2:59
-            |vpiConstType:9
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
+      \_logic_typespec: , line:2:49, endln:2:54
     |vpiStmt:
     \_begin: (work@dut.aes_rev_order_bit), parent:work@dut.aes_rev_order_bit
       |vpiFullName:work@dut.aes_rev_order_bit
@@ -1064,18 +1046,10 @@ design: (work@dut)
             |vpiFullName:work@dut.aes_rev_order_bit.i
           |vpiOperand:
           \_constant: , line:4:18, endln:4:19
-            |vpiConstType:9
-            |vpiDecompile:8
-            |vpiSize:64
-            |UINT:8
         |vpiForInitStmt:
         \_assign_stmt: , parent:work@dut.aes_rev_order_bit
           |vpiRhs:
           \_constant: , line:4:13, endln:4:14
-            |vpiConstType:9
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
           |vpiLhs:
           \_int_var: (work@dut.aes_rev_order_bit.i), line:4:7, endln:4:10
             |vpiName:i
@@ -1111,10 +1085,6 @@ design: (work@dut)
                 |vpiOpType:11
                 |vpiOperand:
                 \_constant: , line:5:16, endln:5:17
-                  |vpiConstType:9
-                  |vpiDecompile:7
-                  |vpiSize:64
-                  |UINT:7
                 |vpiOperand:
                 \_ref_obj: (work@dut.aes_rev_order_bit.in.i), line:5:18, endln:5:19
                   |vpiName:i
@@ -1133,16 +1103,8 @@ design: (work@dut)
             \_range: , line:3:9, endln:3:12, parent:work@dut.aes_rev_order_bit.out
               |vpiLeftRange:
               \_constant: , line:3:9, endln:3:10
-                |vpiConstType:9
-                |vpiDecompile:7
-                |vpiSize:64
-                |UINT:7
               |vpiRightRange:
               \_constant: , line:3:11, endln:3:12
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
     |vpiVariables:
     \_logic_var: (work@dut.aes_rev_order_bit.out), line:3:2, endln:3:7, parent:work@dut.aes_rev_order_bit
   |vpiNet:

--- a/tests/FuncArgsByName/FuncArgsByName.log
+++ b/tests/FuncArgsByName/FuncArgsByName.log
@@ -178,9 +178,9 @@ design: (work@top)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -397,9 +397,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -415,9 +415,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -433,9 +433,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -453,9 +453,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -648,13 +648,13 @@ design: (work@top)
       |vpiName:match_type_pair
       |vpiDirection:1
       |vpiTypedef:
-      \_string_typespec: , line:3:36, endln:3:42, parent:match_type_pair
+      \_string_typespec: , line:3:36, endln:3:42
     |vpiIODecl:
     \_io_decl: (requested_type), parent:work@top.m_matches_type_pair
       |vpiName:requested_type
       |vpiDirection:1
       |vpiTypedef:
-      \_string_typespec: , line:4:6, endln:4:12, parent:requested_type
+      \_string_typespec: , line:4:6, endln:4:12
   |vpiTaskFunc:
   \_function: (work@top.func), line:7:3, endln:16:14, parent:work@top
     |vpiVisibility:1
@@ -671,51 +671,27 @@ design: (work@top)
         |vpiFunction:
         \_function: (work@top.m_matches_type_pair), line:3:3, endln:5:14, parent:work@top
         |vpiArgument:
-        \_constant: , line:8:43, endln:8:46, parent:m_matches_type_pair
-          |vpiConstType:6
-          |vpiDecompile:a
-          |vpiSize:1
-          |STRING:a
+        \_constant: , line:8:43, endln:8:46
         |vpiArgument:
-        \_constant: , line:9:45, endln:9:48, parent:m_matches_type_pair
-          |vpiConstType:6
-          |vpiDecompile:b
-          |vpiSize:1
-          |STRING:b
+        \_constant: , line:9:45, endln:9:48
       |vpiStmt:
       \_func_call: (m_matches_type_pair), line:11:6, endln:11:36, parent:work@top.func
         |vpiName:m_matches_type_pair
         |vpiFunction:
         \_function: (work@top.m_matches_type_pair), line:3:3, endln:5:14, parent:work@top
         |vpiArgument:
-        \_constant: , line:11:26, endln:11:29, parent:m_matches_type_pair
-          |vpiConstType:6
-          |vpiDecompile:c
-          |vpiSize:1
-          |STRING:c
+        \_constant: , line:11:26, endln:11:29
         |vpiArgument:
-        \_constant: , line:11:31, endln:11:34, parent:m_matches_type_pair
-          |vpiConstType:6
-          |vpiDecompile:d
-          |vpiSize:1
-          |STRING:d
+        \_constant: , line:11:31, endln:11:34
       |vpiStmt:
       \_func_call: (m_matches_type_pair), line:13:6, endln:14:52, parent:work@top.func
         |vpiName:m_matches_type_pair
         |vpiFunction:
         \_function: (work@top.m_matches_type_pair), line:3:3, endln:5:14, parent:work@top
         |vpiArgument:
-        \_constant: , line:14:46, endln:14:49, parent:m_matches_type_pair
-          |vpiConstType:6
-          |vpiDecompile:f
-          |vpiSize:1
-          |STRING:f
+        \_constant: , line:14:46, endln:14:49
         |vpiArgument:
-        \_constant: , line:13:42, endln:13:45, parent:m_matches_type_pair
-          |vpiConstType:6
-          |vpiDecompile:e
-          |vpiSize:1
-          |STRING:e
+        \_constant: , line:13:42, endln:13:45
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/FuncBinding/FuncBinding.log
+++ b/tests/FuncBinding/FuncBinding.log
@@ -958,10 +958,6 @@ design: (work@fsm_using_function)
                   \_bit_var: (work@fsm_using_function.reset), line:3:10, endln:3:15, parent:work@fsm_using_function
                 |vpiOperand:
                 \_constant: , line:47:14, endln:47:18
-                  |vpiConstType:3
-                  |vpiDecompile:1'b1
-                  |vpiSize:1
-                  |BIN:1
               |vpiStmt:
               \_begin: (work@fsm_using_function.FSM_SEQ), line:47:20, endln:49:4
                 |vpiFullName:work@fsm_using_function.FSM_SEQ
@@ -1386,53 +1382,25 @@ design: (work@fsm_using_function)
       |vpiName:state
       |vpiDirection:1
       |vpiTypedef:
-      \_logic_typespec: , line:21:28, endln:21:33, parent:state
-        |vpiRange:
-        \_range: , line:21:35, endln:21:38
-          |vpiLeftRange:
-          \_constant: , line:21:35, endln:21:36
-            |vpiConstType:9
-            |vpiDecompile:1
-            |vpiSize:64
-            |UINT:1
-          |vpiRightRange:
-          \_constant: , line:21:37, endln:21:38
-            |vpiConstType:9
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
+      \_logic_typespec: , line:21:28, endln:21:33
     |vpiIODecl:
     \_io_decl: (req_0), parent:work@fsm_using_function.fsm_function
       |vpiName:req_0
       |vpiDirection:1
       |vpiTypedef:
-      \_bit_typespec: , line:21:53, endln:21:56, parent:req_0
+      \_bit_typespec: , line:21:53, endln:21:56
     |vpiIODecl:
     \_io_decl: (req_1), parent:work@fsm_using_function.fsm_function
       |vpiName:req_1
       |vpiDirection:1
       |vpiTypedef:
-      \_bit_typespec: , line:21:69, endln:21:72, parent:req_1
+      \_bit_typespec: , line:21:69, endln:21:72
     |vpiIODecl:
     \_io_decl: (future_state), parent:work@fsm_using_function.fsm_function
       |vpiName:future_state
       |vpiDirection:2
       |vpiTypedef:
-      \_logic_typespec: , line:21:87, endln:21:92, parent:future_state
-        |vpiRange:
-        \_range: , line:21:94, endln:21:97
-          |vpiLeftRange:
-          \_constant: , line:21:94, endln:21:95
-            |vpiConstType:9
-            |vpiDecompile:1
-            |vpiSize:64
-            |UINT:1
-          |vpiRightRange:
-          \_constant: , line:21:96, endln:21:97
-            |vpiConstType:9
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
+      \_logic_typespec: , line:21:87, endln:21:92
     |vpiStmt:
     \_case_stmt: , line:22, endln:41:7, parent:work@fsm_using_function.fsm_function
       |vpiCaseType:1
@@ -1463,10 +1431,6 @@ design: (work@fsm_using_function)
               \_io_decl: (req_0), parent:work@fsm_using_function.fsm_function
             |vpiOperand:
             \_constant: , line:23:22, endln:23:26
-              |vpiConstType:3
-              |vpiDecompile:1'b1
-              |vpiSize:1
-              |BIN:1
           |vpiStmt:
           \_begin: (work@fsm_using_function.fsm_function), line:23:28, endln:25:12
             |vpiFullName:work@fsm_using_function.fsm_function
@@ -1499,10 +1463,6 @@ design: (work@fsm_using_function)
                 \_io_decl: (req_1), parent:work@fsm_using_function.fsm_function
               |vpiOperand:
               \_constant: , line:25:31, endln:25:35
-                |vpiConstType:3
-                |vpiDecompile:1'b1
-                |vpiSize:1
-                |BIN:1
             |vpiStmt:
             \_begin: (work@fsm_using_function.fsm_function), line:25:37, endln:27:12
               |vpiFullName:work@fsm_using_function.fsm_function
@@ -1562,10 +1522,6 @@ design: (work@fsm_using_function)
               \_io_decl: (req_0), parent:work@fsm_using_function.fsm_function
             |vpiOperand:
             \_constant: , line:30:22, endln:30:26
-              |vpiConstType:3
-              |vpiDecompile:1'b1
-              |vpiSize:1
-              |BIN:1
           |vpiStmt:
           \_begin: (work@fsm_using_function.fsm_function), line:30:28, endln:32:12
             |vpiFullName:work@fsm_using_function.fsm_function
@@ -1625,10 +1581,6 @@ design: (work@fsm_using_function)
               \_io_decl: (req_1), parent:work@fsm_using_function.fsm_function
             |vpiOperand:
             \_constant: , line:35:22, endln:35:26
-              |vpiConstType:3
-              |vpiDecompile:1'b1
-              |vpiSize:1
-              |BIN:1
           |vpiStmt:
           \_begin: (work@fsm_using_function.fsm_function), line:35:28, endln:37:12
             |vpiFullName:work@fsm_using_function.fsm_function

--- a/tests/FuncDefaultVal/FuncDefaultVal.log
+++ b/tests/FuncDefaultVal/FuncDefaultVal.log
@@ -473,11 +473,7 @@ design: (work@top)
       |vpiName:tid
       |vpiDirection:1
       |vpiExpr:
-      \_constant: , line:5:32, endln:5:33, parent:tid
-        |vpiConstType:9
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
+      \_constant: , line:5:32, endln:5:33
     |vpiStmt:
     \_begin: (work@top.dasm), parent:work@top.dasm
       |vpiFullName:work@top.dasm
@@ -502,22 +498,10 @@ design: (work@top)
               \_ref_obj: (work@top.dasm.opcode)
               |vpiLeftRange:
               \_constant: , line:6:19, endln:6:20
-                |vpiConstType:9
-                |vpiDecompile:1
-                |vpiSize:64
-                |UINT:1
               |vpiRightRange:
               \_constant: , line:6:21, endln:6:22
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
             |vpiOperand:
             \_constant: , line:6:27, endln:6:32
-              |vpiConstType:3
-              |vpiDecompile:2'b11
-              |vpiSize:2
-              |BIN:11
           |vpiOperand:
           \_func_call: (dasm32), line:6:36, endln:6:59
             |vpiName:dasm32

--- a/tests/FuncNoArgs/FuncNoArgs.log
+++ b/tests/FuncNoArgs/FuncNoArgs.log
@@ -332,9 +332,9 @@ design: (work@my_opt_reduce_or)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -551,9 +551,9 @@ design: (work@my_opt_reduce_or)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -569,9 +569,9 @@ design: (work@my_opt_reduce_or)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -587,9 +587,9 @@ design: (work@my_opt_reduce_or)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -607,9 +607,9 @@ design: (work@my_opt_reduce_or)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -1052,10 +1052,6 @@ design: (work@my_opt_reduce_or)
           |vpiFullName:work@my_opt_reduce_or.count_nonconst_bits.count_nonconst_bits
         |vpiRhs:
         \_constant: , line:10:34, endln:10:35
-          |vpiConstType:9
-          |vpiDecompile:0
-          |vpiSize:64
-          |UINT:0
       |vpiStmt:
       \_for_stmt: (work@my_opt_reduce_or.count_nonconst_bits), line:11:12, endln:11:15, parent:work@my_opt_reduce_or.count_nonconst_bits
         |vpiFullName:work@my_opt_reduce_or.count_nonconst_bits
@@ -1071,7 +1067,7 @@ design: (work@my_opt_reduce_or)
               |vpiName:i
               |vpiFullName:work@my_opt_reduce_or.count_nonconst_bits.i
               |vpiTypespec:
-              \_int_typespec: , line:8:8, endln:8:15, parent:work@my_opt_reduce_or.count_nonconst_bits.i
+              \_int_typespec: , line:8:8, endln:8:15
           |vpiOperand:
           \_ref_obj: (work@my_opt_reduce_or.count_nonconst_bits.A_WIDTH), line:11:28, endln:11:35
             |vpiName:A_WIDTH
@@ -1082,10 +1078,6 @@ design: (work@my_opt_reduce_or)
         \_assign_stmt: , parent:work@my_opt_reduce_or.count_nonconst_bits
           |vpiRhs:
           \_constant: , line:11:21, endln:11:22
-            |vpiConstType:9
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
           |vpiLhs:
           \_int_var: (work@my_opt_reduce_or.count_nonconst_bits.i), line:11:17, endln:11:18
             |vpiName:i
@@ -1111,10 +1103,6 @@ design: (work@my_opt_reduce_or)
               \_int_var: (work@my_opt_reduce_or.count_nonconst_bits.i), line:8:8, endln:8:15, parent:work@my_opt_reduce_or.count_nonconst_bits
             |vpiOperand:
             \_constant: , line:11:41, endln:11:42
-              |vpiConstType:9
-              |vpiDecompile:1
-              |vpiSize:64
-              |UINT:1
         |vpiStmt:
         \_if_stmt: , line:12:16, endln:13:64, parent:work@my_opt_reduce_or.count_nonconst_bits
           |vpiCondition:
@@ -1147,10 +1135,6 @@ design: (work@my_opt_reduce_or)
                 |vpiFullName:work@my_opt_reduce_or.count_nonconst_bits.count_nonconst_bits
               |vpiOperand:
               \_constant: , line:13:62, endln:13:63
-                |vpiConstType:9
-                |vpiDecompile:1
-                |vpiSize:64
-                |UINT:1
     |vpiVariables:
     \_int_var: (work@my_opt_reduce_or.count_nonconst_bits.i), line:8:8, endln:8:15, parent:work@my_opt_reduce_or.count_nonconst_bits
   |vpiNet:

--- a/tests/FuncStruct/FuncStruct.log
+++ b/tests/FuncStruct/FuncStruct.log
@@ -718,7 +718,7 @@ design: (work@dut)
         |vpiName:w
         |vpiFullName:work@dut.w
         |vpiIndex:
-        \_constant: , line:17:25, endln:17:26, parent:work@dut.w
+        \_constant: , line:17:25, endln:17:26, parent:w
           |vpiConstType:9
           |vpiDecompile:0
           |vpiSize:64
@@ -937,109 +937,15 @@ design: (work@dut)
       |vpiName:w
       |vpiDirection:1
       |vpiTypedef:
-      \_logic_typespec: (sha_word_t), line:2:8, endln:2:13, parent:w
-        |vpiName:sha_word_t
-        |vpiRange:
-        \_range: , line:2:15, endln:2:19, parent:sha_word_t
-          |vpiLeftRange:
-          \_constant: , line:2:15, endln:2:17
-            |vpiConstType:9
-            |vpiDecompile:31
-            |vpiSize:64
-            |UINT:31
-          |vpiRightRange:
-          \_constant: , line:2:18, endln:2:19
-            |vpiConstType:9
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
-        |vpiTypedefAlias:
-        \_logic_typespec: (hmac_pkg::sha_word_t), line:2:8, endln:2:13, parent:sha_word_t
-          |vpiName:hmac_pkg::sha_word_t
-          |vpiRange:
-          \_range: , line:2:15, endln:2:19, parent:hmac_pkg::sha_word_t
-            |vpiLeftRange:
-            \_constant: , line:2:15, endln:2:17
-              |vpiConstType:9
-              |vpiDecompile:31
-              |vpiSize:64
-              |UINT:31
-            |vpiRightRange:
-            \_constant: , line:2:18, endln:2:19
-              |vpiConstType:9
-              |vpiDecompile:0
-              |vpiSize:64
-              |UINT:0
-          |vpiInstance:
-          \_package: hmac_pkg (hmac_pkg::) dut.sv:1: , endln:9:10, parent:work@dut
-        |vpiInstance:
-        \_package: hmac_pkg (hmac_pkg::) dut.sv:1: , endln:9:10, parent:work@dut
+      \_logic_typespec: (sha_word_t), line:2:8, endln:2:13
     |vpiIODecl:
     \_io_decl: (h_i), parent:hmac_pkg::compress
       |vpiName:h_i
       |vpiDirection:1
       |vpiTypedef:
-      \_logic_typespec: , parent:h_i
-        |vpiElemTypespec:
-        \_logic_typespec: (sha_word_t), line:2:8, endln:2:13
-          |vpiName:sha_word_t
-          |vpiRange:
-          \_range: , line:2:15, endln:2:19, parent:sha_word_t
-            |vpiLeftRange:
-            \_constant: , line:2:15, endln:2:17
-              |vpiConstType:9
-              |vpiDecompile:31
-              |vpiSize:64
-              |UINT:31
-            |vpiRightRange:
-            \_constant: , line:2:18, endln:2:19
-              |vpiConstType:9
-              |vpiDecompile:0
-              |vpiSize:64
-              |UINT:0
-          |vpiTypedefAlias:
-          \_logic_typespec: (hmac_pkg::sha_word_t), line:2:8, endln:2:13, parent:sha_word_t
-            |vpiName:hmac_pkg::sha_word_t
-            |vpiRange:
-            \_range: , line:2:15, endln:2:19, parent:hmac_pkg::sha_word_t
-              |vpiLeftRange:
-              \_constant: , line:2:15, endln:2:17
-                |vpiConstType:9
-                |vpiDecompile:31
-                |vpiSize:64
-                |UINT:31
-              |vpiRightRange:
-              \_constant: , line:2:18, endln:2:19
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-            |vpiInstance:
-            \_package: hmac_pkg (hmac_pkg::) dut.sv:1: , endln:9:10, parent:work@dut
-          |vpiInstance:
-          \_package: hmac_pkg (hmac_pkg::) dut.sv:1: , endln:9:10, parent:work@dut
-        |vpiRange:
-        \_range: , line:3:84, endln:3:87
-          |vpiLeftRange:
-          \_constant: , line:3:84, endln:3:85
-            |vpiConstType:9
-            |vpiDecompile:7
-            |vpiSize:64
-            |UINT:7
-          |vpiRightRange:
-          \_constant: , line:3:86, endln:3:87
-            |vpiConstType:9
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
-        |vpiInstance:
-        \_package: hmac_pkg (hmac_pkg::) dut.sv:1: , endln:9:10, parent:work@dut
+      \_logic_typespec: 
       |vpiExpr:
-      \_constant: , line:3:95, endln:3:96, parent:h_i
-        |vpiConstType:9
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
+      \_constant: , line:3:95, endln:3:96
     |vpiStmt:
     \_begin: (work@dut.compress), parent:hmac_pkg::compress
       |vpiFullName:work@dut.compress
@@ -1057,30 +963,9 @@ design: (work@dut)
             |vpiFullName:work@dut.compress.sigma_0
             |vpiAutomatic:1
             |vpiTypespec:
-            \_logic_typespec: (hmac_pkg::sha_word_t), line:2:8, endln:2:13, parent:work@dut.compress.sigma_0
-              |vpiName:hmac_pkg::sha_word_t
-              |vpiRange:
-              \_range: , line:2:15, endln:2:19, parent:hmac_pkg::sha_word_t
-                |vpiLeftRange:
-                \_constant: , line:2:15, endln:2:17
-                  |vpiConstType:9
-                  |vpiDecompile:31
-                  |vpiSize:64
-                  |UINT:31
-                |vpiRightRange:
-                \_constant: , line:2:18, endln:2:19
-                  |vpiConstType:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
-              |vpiInstance:
-              \_package: hmac_pkg (hmac_pkg::) dut.sv:1: , endln:9:10, parent:work@dut
+            \_logic_typespec: (hmac_pkg::sha_word_t), line:2:8, endln:2:13
         |vpiRhs:
         \_constant: , line:6:12, endln:6:24
-          |vpiConstType:5
-          |vpiDecompile:32'h11111111
-          |vpiSize:32
-          |HEX:11111111
       |vpiStmt:
       \_assignment: , line:7:2, endln:7:25, parent:work@dut.compress
         |vpiOpType:82
@@ -1090,11 +975,7 @@ design: (work@dut)
           |vpiName:compress
           |vpiFullName:work@dut.compress.compress
           |vpiIndex:
-          \_constant: , line:7:11, endln:7:12, parent:work@dut.compress.compress
-            |vpiConstType:9
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
+          \_constant: , line:7:11, endln:7:12, parent:hmac_pkg::compress::compress
         |vpiRhs:
         \_ref_obj: (work@dut.compress.sigma_0), line:7:17, endln:7:24
           |vpiName:sigma_0

--- a/tests/GateLevel/GateLevel.log
+++ b/tests/GateLevel/GateLevel.log
@@ -569,9 +569,9 @@ design: (work@LogicGates)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -788,9 +788,9 @@ design: (work@LogicGates)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -806,9 +806,9 @@ design: (work@LogicGates)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -824,9 +824,9 @@ design: (work@LogicGates)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -844,9 +844,9 @@ design: (work@LogicGates)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/Gates/Gates.log
+++ b/tests/Gates/Gates.log
@@ -2897,9 +2897,9 @@ design: (work@gates)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -3116,9 +3116,9 @@ design: (work@gates)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -3134,9 +3134,9 @@ design: (work@gates)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -3152,9 +3152,9 @@ design: (work@gates)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -3172,9 +3172,9 @@ design: (work@gates)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -4983,7 +4983,7 @@ design: (work@gates)
       \_sys_func_call: ($monitor), line:13:2, endln:15:35, parent:work@gates
         |vpiName:$monitor
         |vpiArgument:
-        \_constant: , line:14:2, endln:14:55, parent:$monitor
+        \_constant: , line:14:2, endln:14:55
           |vpiConstType:6
           |vpiDecompile:in1=%b in2=%b in3=%b in4=%b out0=%b out1=%b out2=%b
           |vpiSize:51
@@ -5338,7 +5338,7 @@ design: (work@gates)
       \_sys_func_call: ($monitor), line:39:2, endln:41:54, parent:work@transmission_gates
         |vpiName:$monitor
         |vpiArgument:
-        \_constant: , line:40:4, endln:40:62, parent:$monitor
+        \_constant: , line:40:4, endln:40:62
           |vpiConstType:6
           |vpiDecompile:@%g in=%b data_enable_low=%b out1=%b out2= b data_bus=%b
           |vpiSize:56
@@ -5672,7 +5672,7 @@ design: (work@gates)
       \_sys_func_call: ($monitor), line:73:2, endln:73:65, parent:work@dff_from_nand
         |vpiName:$monitor
         |vpiArgument:
-        \_constant: , line:73:11, endln:73:46, parent:$monitor
+        \_constant: , line:73:11, endln:73:46
           |vpiConstType:6
           |vpiDecompile:CLK = %b D = %b Q = %b Q_BAR = %b
           |vpiSize:33
@@ -5953,7 +5953,7 @@ design: (work@gates)
       \_sys_func_call: ($monitor), line:101:2, endln:103:28, parent:work@mux_from_gates
         |vpiName:$monitor
         |vpiArgument:
-        \_constant: , line:102:3, endln:102:57, parent:$monitor
+        \_constant: , line:102:3, endln:102:57
           |vpiConstType:6
           |vpiDecompile:c0 = %b c1 = %b c2 = %b c3 = %b A = %b B = %b Y = %b
           |vpiSize:52
@@ -6532,7 +6532,7 @@ design: (work@gates)
       \_sys_func_call: ($monitor), line:134:2, endln:134:45, parent:work@and_from_nand
         |vpiName:$monitor
         |vpiArgument:
-        \_constant: , line:134:12, endln:134:34, parent:$monitor
+        \_constant: , line:134:12, endln:134:34
           |vpiConstType:6
           |vpiDecompile:X = %b Y = %b F = %b
           |vpiSize:20
@@ -6747,7 +6747,7 @@ design: (work@gates)
       \_sys_func_call: ($monitor), line:165:2, endln:167:54, parent:work@delay_example
         |vpiName:$monitor
         |vpiArgument:
-        \_constant: , line:166:2, endln:166:70, parent:$monitor
+        \_constant: , line:166:2, endln:166:70
           |vpiConstType:6
           |vpiDecompile:Time=%g b=%b c=%b  out1=%b out2=%b out3=%b out4=%b out5=%b out6=%b
           |vpiSize:66
@@ -7322,7 +7322,7 @@ design: (work@gates)
       \_sys_func_call: ($monitor), line:192:2, endln:194:40, parent:work@n_in_primitive
         |vpiName:$monitor
         |vpiArgument:
-        \_constant: , line:193:2, endln:193:69, parent:$monitor
+        \_constant: , line:193:2, endln:193:69
           |vpiConstType:6
           |vpiDecompile:in1 = %b in2 = %b in3 = %b in4 = %b out1 = %b out2 = %b out3 = %b
           |vpiSize:65

--- a/tests/GenBlockVar/GenBlockVar.log
+++ b/tests/GenBlockVar/GenBlockVar.log
@@ -144,9 +144,9 @@ design: (work@top)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -363,9 +363,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -381,9 +381,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -399,9 +399,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -419,9 +419,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/GenIf/GenIf.log
+++ b/tests/GenIf/GenIf.log
@@ -188,9 +188,9 @@ design: (work@gen_test4)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -407,9 +407,9 @@ design: (work@gen_test4)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -425,9 +425,9 @@ design: (work@gen_test4)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -443,9 +443,9 @@ design: (work@gen_test4)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -463,9 +463,9 @@ design: (work@gen_test4)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/HierPathSelect/HierPathSelect.log
+++ b/tests/HierPathSelect/HierPathSelect.log
@@ -209,7 +209,7 @@ design: (work@dut2)
       \_bit_select: (q), line:8:16, endln:8:17, parent:read_buf
         |vpiName:q
         |vpiIndex:
-        \_constant: , line:8:18, endln:8:19, parent:q
+        \_constant: , line:8:18, endln:8:19
           |vpiConstType:9
           |vpiDecompile:1
           |vpiSize:64

--- a/tests/IfGenTypeBinding/IfGenTypeBinding.log
+++ b/tests/IfGenTypeBinding/IfGenTypeBinding.log
@@ -261,9 +261,9 @@ design: (work@top)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -480,9 +480,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -498,9 +498,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -516,9 +516,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -536,9 +536,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -645,14 +645,14 @@ design: (work@top)
         \_struct_net: (work@top.g_pmp_registers.pmp_cfg2), line:21:35, endln:21:43, parent:work@top.g_pmp_registers.pmp_cfg2
           |vpiFullName:work@top.g_pmp_registers.pmp_cfg2
           |vpiTypespec:
-          \_struct_typespec: (ibex_pkg::pmp_cfg_t), line:3:10, endln:3:16, parent:work@top.g_pmp_registers.pmp_cfg2
+          \_struct_typespec: (ibex_pkg::pmp_cfg_t), line:3:10, endln:3:16
             |vpiPacked:1
             |vpiName:ibex_pkg::pmp_cfg_t
             |vpiTypespecMember:
-            \_typespec_member: (lock), line:4:19, endln:4:23, parent:ibex_pkg::pmp_cfg_t
+            \_typespec_member: (lock), line:4:19, endln:4:23
               |vpiName:lock
               |vpiTypespec:
-              \_logic_typespec: , line:4:4, endln:4:9, parent:lock
+              \_logic_typespec: , line:4:4, endln:4:9
                 |vpiInstance:
                 \_package: ibex_pkg (ibex_pkg::) dut.sv:1: , endln:11:10, parent:work@top
                   |vpiDefName:ibex_pkg
@@ -660,55 +660,25 @@ design: (work@top)
                   |vpiFullName:ibex_pkg::
                   |vpiTypedef:
                   \_struct_typespec: (ibex_pkg::pmp_cfg_t), line:3:10, endln:3:16
-                    |vpiPacked:1
-                    |vpiName:ibex_pkg::pmp_cfg_t
-                    |vpiTypespecMember:
-                    \_typespec_member: (lock), line:4:19, endln:4:23
-                      |vpiName:lock
-                      |vpiTypespec:
-                      \_logic_typespec: , line:4:4, endln:4:9
-                        |vpiInstance:
-                        \_package: ibex_pkg (ibex_pkg::) dut.sv:1: , endln:11:10, parent:work@top
-                    |vpiTypespecMember:
-                    \_typespec_member: (exec), line:5:19, endln:5:23
-                      |vpiName:exec
-                      |vpiTypespec:
-                      \_logic_typespec: , line:5:4, endln:5:9
-                        |vpiInstance:
-                        \_package: ibex_pkg (ibex_pkg::) dut.sv:1: , endln:11:10, parent:work@top
-                    |vpiTypespecMember:
-                    \_typespec_member: (write), line:6:19, endln:6:24
-                      |vpiName:write
-                      |vpiTypespec:
-                      \_logic_typespec: , line:6:4, endln:6:9
-                        |vpiInstance:
-                        \_package: ibex_pkg (ibex_pkg::) dut.sv:1: , endln:11:10, parent:work@top
-                    |vpiTypespecMember:
-                    \_typespec_member: (read), line:7:19, endln:7:23
-                      |vpiName:read
-                      |vpiTypespec:
-                      \_logic_typespec: , line:7:4, endln:7:9
-                        |vpiInstance:
-                        \_package: ibex_pkg (ibex_pkg::) dut.sv:1: , endln:11:10, parent:work@top
             |vpiTypespecMember:
-            \_typespec_member: (exec), line:5:19, endln:5:23, parent:ibex_pkg::pmp_cfg_t
+            \_typespec_member: (exec), line:5:19, endln:5:23
               |vpiName:exec
               |vpiTypespec:
-              \_logic_typespec: , line:5:4, endln:5:9, parent:exec
+              \_logic_typespec: , line:5:4, endln:5:9
                 |vpiInstance:
                 \_package: ibex_pkg (ibex_pkg::) dut.sv:1: , endln:11:10, parent:work@top
             |vpiTypespecMember:
-            \_typespec_member: (write), line:6:19, endln:6:24, parent:ibex_pkg::pmp_cfg_t
+            \_typespec_member: (write), line:6:19, endln:6:24
               |vpiName:write
               |vpiTypespec:
-              \_logic_typespec: , line:6:4, endln:6:9, parent:write
+              \_logic_typespec: , line:6:4, endln:6:9
                 |vpiInstance:
                 \_package: ibex_pkg (ibex_pkg::) dut.sv:1: , endln:11:10, parent:work@top
             |vpiTypespecMember:
-            \_typespec_member: (read), line:7:19, endln:7:23, parent:ibex_pkg::pmp_cfg_t
+            \_typespec_member: (read), line:7:19, endln:7:23
               |vpiName:read
               |vpiTypespec:
-              \_logic_typespec: , line:7:4, endln:7:9, parent:read
+              \_logic_typespec: , line:7:4, endln:7:9
                 |vpiInstance:
                 \_package: ibex_pkg (ibex_pkg::) dut.sv:1: , endln:11:10, parent:work@top
         |vpiRange:

--- a/tests/ImplFuncArg/ImplFuncArg.log
+++ b/tests/ImplFuncArg/ImplFuncArg.log
@@ -137,9 +137,9 @@ design: (work@fsm_2_always_block)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -356,9 +356,9 @@ design: (work@fsm_2_always_block)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -374,9 +374,9 @@ design: (work@fsm_2_always_block)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -392,9 +392,9 @@ design: (work@fsm_2_always_block)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -412,9 +412,9 @@ design: (work@fsm_2_always_block)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -539,41 +539,13 @@ design: (work@fsm_2_always_block)
       |vpiName:curr_state
       |vpiDirection:1
       |vpiTypedef:
-      \_logic_typespec: , line:4:19, endln:4:22, parent:curr_state
-        |vpiRange:
-        \_range: , line:4:24, endln:4:27
-          |vpiLeftRange:
-          \_constant: , line:4:24, endln:4:25
-            |vpiConstType:9
-            |vpiDecompile:1
-            |vpiSize:64
-            |UINT:1
-          |vpiRightRange:
-          \_constant: , line:4:26, endln:4:27
-            |vpiConstType:9
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
+      \_logic_typespec: , line:4:19, endln:4:22
     |vpiIODecl:
     \_io_decl: (next_state), parent:work@fsm_2_always_block.stateAsmt
       |vpiName:next_state
       |vpiDirection:1
       |vpiTypedef:
-      \_logic_typespec: , line:4:19, endln:4:22, parent:next_state
-        |vpiRange:
-        \_range: , line:4:24, endln:4:27
-          |vpiLeftRange:
-          \_constant: , line:4:24, endln:4:25
-            |vpiConstType:9
-            |vpiDecompile:1
-            |vpiSize:64
-            |UINT:1
-          |vpiRightRange:
-          \_constant: , line:4:26, endln:4:27
-            |vpiConstType:9
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
+      \_logic_typespec: , line:4:19, endln:4:22
     |vpiStmt:
     \_assignment: , line:5:5, endln:5:28, parent:work@fsm_2_always_block.stateAsmt
       |vpiOpType:82

--- a/tests/ImplicitPort/ImplicitPort.log
+++ b/tests/ImplicitPort/ImplicitPort.log
@@ -152,9 +152,9 @@ design: (work@add)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -371,9 +371,9 @@ design: (work@add)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -389,9 +389,9 @@ design: (work@add)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -407,9 +407,9 @@ design: (work@add)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -427,9 +427,9 @@ design: (work@add)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/JKFlipflop/JKFlipflop.log
+++ b/tests/JKFlipflop/JKFlipflop.log
@@ -88,9 +88,9 @@ design: (work@JKFlipflop)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -307,9 +307,9 @@ design: (work@JKFlipflop)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -325,9 +325,9 @@ design: (work@JKFlipflop)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -343,9 +343,9 @@ design: (work@JKFlipflop)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -363,9 +363,9 @@ design: (work@JKFlipflop)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/LargeHex/LargeHex.log
+++ b/tests/LargeHex/LargeHex.log
@@ -338,9 +338,9 @@ design: (work@tlul_socket_1n)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -557,9 +557,9 @@ design: (work@tlul_socket_1n)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -575,9 +575,9 @@ design: (work@tlul_socket_1n)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -593,9 +593,9 @@ design: (work@tlul_socket_1n)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -613,9 +613,9 @@ design: (work@tlul_socket_1n)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/LocalParam/LocalParam.log
+++ b/tests/LocalParam/LocalParam.log
@@ -295,9 +295,9 @@ design: (work@top)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -514,9 +514,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -532,9 +532,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -550,9 +550,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -570,9 +570,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/LogicCast/LogicCast.log
+++ b/tests/LogicCast/LogicCast.log
@@ -144,9 +144,9 @@ design: (work@top)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -363,9 +363,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -381,9 +381,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -399,9 +399,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -419,9 +419,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/MBAdder/MBadder.log
+++ b/tests/MBAdder/MBadder.log
@@ -85,9 +85,9 @@ design: (work@MultibitAdder)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -304,9 +304,9 @@ design: (work@MultibitAdder)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -322,9 +322,9 @@ design: (work@MultibitAdder)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -340,9 +340,9 @@ design: (work@MultibitAdder)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -360,9 +360,9 @@ design: (work@MultibitAdder)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/OneAnd/OneAnd.log
+++ b/tests/OneAnd/OneAnd.log
@@ -1099,7 +1099,7 @@ design: (work@and_tb)
       \_sys_func_call: ($monitor), line:5:4, endln:5:53, parent:work@and_tb
         |vpiName:$monitor
         |vpiArgument:
-        \_constant: , line:5:13, endln:5:37, parent:$monitor
+        \_constant: , line:5:13, endln:5:37
           |vpiConstType:6
           |vpiDecompile:@%0dns %0d & %0d = %0d
           |vpiSize:22
@@ -1210,7 +1210,7 @@ design: (work@and_tb)
           \_sys_func_call: ($display), line:13:29, endln:13:45
             |vpiName:$display
             |vpiArgument:
-            \_constant: , line:13:38, endln:13:43, parent:$display
+            \_constant: , line:13:38, endln:13:43
               |vpiConstType:6
               |vpiDecompile:OK!
               |vpiSize:3
@@ -1219,13 +1219,13 @@ design: (work@and_tb)
           \_sys_func_call: ($fatal), line:13:51, endln:13:78
             |vpiName:$fatal
             |vpiArgument:
-            \_constant: , line:13:58, endln:13:59, parent:$fatal
+            \_constant: , line:13:58, endln:13:59
               |vpiConstType:9
               |vpiDecompile:1
               |vpiSize:64
               |UINT:1
             |vpiArgument:
-            \_constant: , line:13:61, endln:13:76, parent:$fatal
+            \_constant: , line:13:61, endln:13:76
               |vpiConstType:6
               |vpiDecompile:o != (a & b)!
               |vpiSize:13
@@ -1298,7 +1298,7 @@ design: (work@and_tb)
           \_sys_func_call: ($display), line:17:29, endln:17:45
             |vpiName:$display
             |vpiArgument:
-            \_constant: , line:17:38, endln:17:43, parent:$display
+            \_constant: , line:17:38, endln:17:43
               |vpiConstType:6
               |vpiDecompile:OK!
               |vpiSize:3
@@ -1307,13 +1307,13 @@ design: (work@and_tb)
           \_sys_func_call: ($fatal), line:17:51, endln:17:78
             |vpiName:$fatal
             |vpiArgument:
-            \_constant: , line:17:58, endln:17:59, parent:$fatal
+            \_constant: , line:17:58, endln:17:59
               |vpiConstType:9
               |vpiDecompile:1
               |vpiSize:64
               |UINT:1
             |vpiArgument:
-            \_constant: , line:17:61, endln:17:76, parent:$fatal
+            \_constant: , line:17:61, endln:17:76
               |vpiConstType:6
               |vpiDecompile:o != (a & b)!
               |vpiSize:13
@@ -1386,7 +1386,7 @@ design: (work@and_tb)
           \_sys_func_call: ($display), line:21:29, endln:21:45
             |vpiName:$display
             |vpiArgument:
-            \_constant: , line:21:38, endln:21:43, parent:$display
+            \_constant: , line:21:38, endln:21:43
               |vpiConstType:6
               |vpiDecompile:OK!
               |vpiSize:3
@@ -1395,13 +1395,13 @@ design: (work@and_tb)
           \_sys_func_call: ($fatal), line:21:51, endln:21:78
             |vpiName:$fatal
             |vpiArgument:
-            \_constant: , line:21:58, endln:21:59, parent:$fatal
+            \_constant: , line:21:58, endln:21:59
               |vpiConstType:9
               |vpiDecompile:1
               |vpiSize:64
               |UINT:1
             |vpiArgument:
-            \_constant: , line:21:61, endln:21:76, parent:$fatal
+            \_constant: , line:21:61, endln:21:76
               |vpiConstType:6
               |vpiDecompile:o != (a & b)!
               |vpiSize:13
@@ -1474,7 +1474,7 @@ design: (work@and_tb)
           \_sys_func_call: ($display), line:25:29, endln:25:45
             |vpiName:$display
             |vpiArgument:
-            \_constant: , line:25:38, endln:25:43, parent:$display
+            \_constant: , line:25:38, endln:25:43
               |vpiConstType:6
               |vpiDecompile:OK!
               |vpiSize:3
@@ -1483,13 +1483,13 @@ design: (work@and_tb)
           \_sys_func_call: ($fatal), line:25:51, endln:25:78
             |vpiName:$fatal
             |vpiArgument:
-            \_constant: , line:25:58, endln:25:59, parent:$fatal
+            \_constant: , line:25:58, endln:25:59
               |vpiConstType:9
               |vpiDecompile:1
               |vpiSize:64
               |UINT:1
             |vpiArgument:
-            \_constant: , line:25:61, endln:25:76, parent:$fatal
+            \_constant: , line:25:61, endln:25:76
               |vpiConstType:6
               |vpiDecompile:o != (a & b)!
               |vpiSize:13

--- a/tests/PackDataType/PackDataType.log
+++ b/tests/PackDataType/PackDataType.log
@@ -340,9 +340,9 @@ design: (work@kmac_keymgr)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -559,9 +559,9 @@ design: (work@kmac_keymgr)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -577,9 +577,9 @@ design: (work@kmac_keymgr)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -595,9 +595,9 @@ design: (work@kmac_keymgr)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -615,9 +615,9 @@ design: (work@kmac_keymgr)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/PackageDpi/PackageDpi.log
+++ b/tests/PackageDpi/PackageDpi.log
@@ -74,7 +74,7 @@ design: (unnamed)
       |vpiConstantVariable:1
       |vpiVisibility:1
       |vpiExpr:
-      \_constant: , line:21:37, endln:21:38, parent:pack::toto::DO_NOT_CATCH
+      \_constant: , line:21:37, endln:21:38
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/PackageFuncCall/PackageFuncCall.log
+++ b/tests/PackageFuncCall/PackageFuncCall.log
@@ -980,9 +980,9 @@ design: (work@top)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -1199,9 +1199,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -1217,9 +1217,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -1235,9 +1235,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -1255,9 +1255,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -1844,7 +1844,7 @@ design: (work@top)
           \_var_select: (work@top.p_post_round_xor), line:33:21, endln:35:36
             |vpiFullName:work@top.p_post_round_xor
             |vpiIndex:
-            \_constant: , line:34:22, endln:34:24, parent:work@top.p_post_round_xor
+            \_constant: , line:34:22, endln:34:24, parent:prim_cipher_pkg::PRINCE_ROUND_CONST
               |vpiConstType:9
               |vpiDecompile:11
               |vpiSize:64
@@ -1916,7 +1916,7 @@ design: (work@top)
         \_logic_typespec: (PRESENT_SBOX4), line:3:12, endln:3:17, parent:prim_cipher_pkg::PRESENT_SBOX4
           |vpiName:PRESENT_SBOX4
           |vpiRange:
-          \_range: , line:3:19, endln:3:23, parent:PRESENT_SBOX4
+          \_range: , line:3:19, endln:3:23
             |vpiLeftRange:
             \_constant: , line:3:19, endln:3:21
               |vpiConstType:9
@@ -1930,7 +1930,7 @@ design: (work@top)
               |vpiSize:64
               |UINT:0
           |vpiRange:
-          \_range: , line:3:25, endln:3:28, parent:PRESENT_SBOX4
+          \_range: , line:3:25, endln:3:28
             |vpiLeftRange:
             \_constant: , line:3:25, endln:3:26
               |vpiConstType:9
@@ -2264,37 +2264,6 @@ design: (work@top)
                 |vpiFullName:prim_cipher_pkg::PRESENT_SBOX4
                 |vpiTypespec:
                 \_logic_typespec: (PRESENT_SBOX4), line:3:12, endln:3:17, parent:prim_cipher_pkg::PRESENT_SBOX4
-                  |vpiName:PRESENT_SBOX4
-                  |vpiRange:
-                  \_range: , line:3:19, endln:3:23
-                    |vpiLeftRange:
-                    \_constant: , line:3:19, endln:3:21
-                      |vpiConstType:9
-                      |vpiDecompile:15
-                      |vpiSize:64
-                      |UINT:15
-                    |vpiRightRange:
-                    \_constant: , line:3:22, endln:3:23
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-                  |vpiRange:
-                  \_range: , line:3:25, endln:3:28
-                    |vpiLeftRange:
-                    \_constant: , line:3:25, endln:3:26
-                      |vpiConstType:9
-                      |vpiDecompile:3
-                      |vpiSize:64
-                      |UINT:3
-                    |vpiRightRange:
-                    \_constant: , line:3:27, endln:3:28
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-                  |vpiInstance:
-                  \_package: prim_cipher_pkg (prim_cipher_pkg::) dut.sv:1: , endln:23:28, parent:work@top
             |vpiParamAssign:
             \_param_assign: , line:18:31, endln:19:77, parent:prim_cipher_pkg::
               |vpiRhs:

--- a/tests/PackageParam/PackageParam.log
+++ b/tests/PackageParam/PackageParam.log
@@ -605,9 +605,9 @@ design: (unnamed)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -824,9 +824,9 @@ design: (unnamed)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -842,9 +842,9 @@ design: (unnamed)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -860,9 +860,9 @@ design: (unnamed)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -880,9 +880,9 @@ design: (unnamed)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/PackageType/PackageType.log
+++ b/tests/PackageType/PackageType.log
@@ -313,9 +313,9 @@ design: (unnamed)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -532,9 +532,9 @@ design: (unnamed)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -550,9 +550,9 @@ design: (unnamed)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -568,9 +568,9 @@ design: (unnamed)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -588,9 +588,9 @@ design: (unnamed)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/PackageValue/PackageValue.log
+++ b/tests/PackageValue/PackageValue.log
@@ -1258,9 +1258,9 @@ design: (work@prim_diff_decode)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -1477,9 +1477,9 @@ design: (work@prim_diff_decode)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -1495,9 +1495,9 @@ design: (work@prim_diff_decode)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -1513,9 +1513,9 @@ design: (work@prim_diff_decode)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -1533,9 +1533,9 @@ design: (work@prim_diff_decode)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/ParamArray/ParamArray.log
+++ b/tests/ParamArray/ParamArray.log
@@ -500,9 +500,9 @@ design: (work@top)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -719,9 +719,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -737,9 +737,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -755,9 +755,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -775,9 +775,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/ParamArraySelect/ParamArraySelect.log
+++ b/tests/ParamArraySelect/ParamArraySelect.log
@@ -767,9 +767,9 @@ design: (work@top)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -986,9 +986,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -1004,9 +1004,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -1022,9 +1022,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -1042,9 +1042,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -1680,21 +1680,6 @@ design: (work@top)
         |INT:4
         |vpiTypespec:
         \_logic_typespec: (PartEnd), line:61:15, endln:61:20, parent:work@top.gen_part_sel[0].PartEnd
-          |vpiName:PartEnd
-          |vpiRange:
-          \_range: , line:61:22, endln:61:40, parent:PartEnd
-            |vpiLeftRange:
-            \_constant: , line:61:22, endln:61:38
-              |vpiConstType:9
-              |vpiDecompile:3
-              |vpiSize:64
-              |UINT:3
-            |vpiRightRange:
-            \_constant: , line:61:39, endln:61:40
-              |vpiConstType:9
-              |vpiDecompile:0
-              |vpiSize:64
-              |UINT:0
       |vpiParameter:
       \_parameter: (work@top.gen_part_sel[0].DigestOffset), line:64:44, endln:65:79, parent:work@top.gen_part_sel[0]
         |vpiName:DigestOffset
@@ -1703,21 +1688,6 @@ design: (work@top)
         |UINT:0
         |vpiTypespec:
         \_logic_typespec: (DigestOffset), line:64:15, endln:64:20, parent:work@top.gen_part_sel[0].DigestOffset
-          |vpiName:DigestOffset
-          |vpiRange:
-          \_range: , line:64:22, endln:64:42, parent:DigestOffset
-            |vpiLeftRange:
-            \_constant: , line:64:22, endln:64:38
-              |vpiConstType:7
-              |vpiDecompile:2
-              |vpiSize:64
-              |INT:2
-            |vpiRightRange:
-            \_constant: , line:64:41, endln:64:42
-              |vpiConstType:9
-              |vpiDecompile:0
-              |vpiSize:64
-              |UINT:0
       |vpiParameter:
       \_parameter: (work@top.gen_part_sel[0].k), line:60, parent:work@top.gen_part_sel[0]
         |vpiName:k
@@ -1800,21 +1770,6 @@ design: (work@top)
         |INT:16
         |vpiTypespec:
         \_logic_typespec: (PartEnd), line:61:15, endln:61:20, parent:work@top.gen_part_sel[1].PartEnd
-          |vpiName:PartEnd
-          |vpiRange:
-          \_range: , line:61:22, endln:61:40, parent:PartEnd
-            |vpiLeftRange:
-            \_constant: , line:61:22, endln:61:38
-              |vpiConstType:9
-              |vpiDecompile:3
-              |vpiSize:64
-              |UINT:3
-            |vpiRightRange:
-            \_constant: , line:61:39, endln:61:40
-              |vpiConstType:9
-              |vpiDecompile:0
-              |vpiSize:64
-              |UINT:0
       |vpiParameter:
       \_parameter: (work@top.gen_part_sel[1].DigestOffset), line:64:44, endln:65:79, parent:work@top.gen_part_sel[1]
         |vpiName:DigestOffset
@@ -1823,21 +1778,6 @@ design: (work@top)
         |UINT:4
         |vpiTypespec:
         \_logic_typespec: (DigestOffset), line:64:15, endln:64:20, parent:work@top.gen_part_sel[1].DigestOffset
-          |vpiName:DigestOffset
-          |vpiRange:
-          \_range: , line:64:22, endln:64:42, parent:DigestOffset
-            |vpiLeftRange:
-            \_constant: , line:64:22, endln:64:38
-              |vpiConstType:7
-              |vpiDecompile:2
-              |vpiSize:64
-              |INT:2
-            |vpiRightRange:
-            \_constant: , line:64:41, endln:64:42
-              |vpiConstType:9
-              |vpiDecompile:0
-              |vpiSize:64
-              |UINT:0
       |vpiParameter:
       \_parameter: (work@top.gen_part_sel[1].k), line:60, parent:work@top.gen_part_sel[1]
         |vpiName:k

--- a/tests/ParamCast/ParamCast.log
+++ b/tests/ParamCast/ParamCast.log
@@ -225,9 +225,9 @@ design: (work@otp_ctrl)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -444,9 +444,9 @@ design: (work@otp_ctrl)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -462,9 +462,9 @@ design: (work@otp_ctrl)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -480,9 +480,9 @@ design: (work@otp_ctrl)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -500,9 +500,9 @@ design: (work@otp_ctrl)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/ParamComplex/ParamComplex.log
+++ b/tests/ParamComplex/ParamComplex.log
@@ -303,9 +303,9 @@ design: (work@top)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -522,9 +522,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -540,9 +540,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -558,9 +558,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -578,9 +578,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/ParamComplexVerilator/ParamComplexVerilator.log
+++ b/tests/ParamComplexVerilator/ParamComplexVerilator.log
@@ -303,9 +303,9 @@ design: (work@top)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -522,9 +522,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -540,9 +540,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -558,9 +558,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -578,9 +578,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/ParamConcat/ParamConcat.log
+++ b/tests/ParamConcat/ParamConcat.log
@@ -213,9 +213,9 @@ design: (work@top)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -432,9 +432,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -450,9 +450,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -468,9 +468,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -488,9 +488,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/ParamElab/ParamElab.log
+++ b/tests/ParamElab/ParamElab.log
@@ -243,9 +243,9 @@ design: (work@dut)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -462,9 +462,9 @@ design: (work@dut)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -480,9 +480,9 @@ design: (work@dut)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -498,9 +498,9 @@ design: (work@dut)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -518,9 +518,9 @@ design: (work@dut)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/PatAssignOp/PatAssignOp.log
+++ b/tests/PatAssignOp/PatAssignOp.log
@@ -320,9 +320,9 @@ design: (work@top)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -539,9 +539,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -557,9 +557,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -575,9 +575,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -595,9 +595,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/PortRanges/PortRanges.log
+++ b/tests/PortRanges/PortRanges.log
@@ -271,9 +271,9 @@ design: (work@DFlipflop8Bit)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -490,9 +490,9 @@ design: (work@DFlipflop8Bit)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -508,9 +508,9 @@ design: (work@DFlipflop8Bit)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -526,9 +526,9 @@ design: (work@DFlipflop8Bit)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -546,9 +546,9 @@ design: (work@DFlipflop8Bit)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/PortWildcard/PortWildcard.log
+++ b/tests/PortWildcard/PortWildcard.log
@@ -246,9 +246,9 @@ design: (work@dut)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -465,9 +465,9 @@ design: (work@dut)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -483,9 +483,9 @@ design: (work@dut)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -501,9 +501,9 @@ design: (work@dut)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -521,9 +521,9 @@ design: (work@dut)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/PreprocFunc/PreprocFunc.log
+++ b/tests/PreprocFunc/PreprocFunc.log
@@ -451,9 +451,9 @@ design: (work@asym_ram)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -670,9 +670,9 @@ design: (work@asym_ram)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -688,9 +688,9 @@ design: (work@asym_ram)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -706,9 +706,9 @@ design: (work@asym_ram)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -726,9 +726,9 @@ design: (work@asym_ram)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -1456,10 +1456,6 @@ design: (work@asym_ram)
             \_io_decl: (value), line:14:14, endln:14:19, parent:work@asym_ram.log2
           |vpiOperand:
           \_constant: , line:18:13, endln:18:14
-            |vpiConstType:9
-            |vpiDecompile:2
-            |vpiSize:64
-            |UINT:2
         |vpiStmt:
         \_assignment: , line:19:2, endln:19:14
           |vpiOpType:82
@@ -1493,32 +1489,10 @@ design: (work@asym_ram)
                 \_range: , line:15:5, endln:15:9, parent:work@asym_ram.log2.shifted
                   |vpiLeftRange:
                   \_constant: , line:15:5, endln:15:7
-                    |vpiConstType:9
-                    |vpiDecompile:31
-                    |vpiSize:64
-                    |UINT:31
                   |vpiRightRange:
                   \_constant: , line:15:8, endln:15:9
-                    |vpiConstType:9
-                    |vpiDecompile:0
-                    |vpiSize:64
-                    |UINT:0
                 |vpiTypespec:
-                \_logic_typespec: , line:15, endln:15:3, parent:work@asym_ram.log2.shifted
-                  |vpiRange:
-                  \_range: , line:15:5, endln:15:9
-                    |vpiLeftRange:
-                    \_constant: , line:15:5, endln:15:7
-                      |vpiConstType:9
-                      |vpiDecompile:31
-                      |vpiSize:64
-                      |UINT:31
-                    |vpiRightRange:
-                    \_constant: , line:15:8, endln:15:9
-                      |vpiConstType:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
+                \_logic_typespec: , line:15, endln:15:3
             |vpiRhs:
             \_operation: , line:22:12, endln:22:17
               |vpiOpType:11
@@ -1530,10 +1504,6 @@ design: (work@asym_ram)
                 \_io_decl: (value), line:14:14, endln:14:19, parent:work@asym_ram.log2
               |vpiOperand:
               \_constant: , line:22:18, endln:22:19
-                |vpiConstType:9
-                |vpiDecompile:1
-                |vpiSize:64
-                |UINT:1
           |vpiStmt:
           \_for_stmt: (work@asym_ram.log2), line:23:2, endln:23:5, parent:work@asym_ram.log2
             |vpiFullName:work@asym_ram.log2
@@ -1548,18 +1518,10 @@ design: (work@asym_ram)
                 \_logic_var: (work@asym_ram.log2.shifted), line:15, endln:15:3, parent:work@asym_ram.log2
               |vpiOperand:
               \_constant: , line:23:22, endln:23:23
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
             |vpiForInitStmt:
             \_assign_stmt: , parent:work@asym_ram.log2
               |vpiRhs:
               \_constant: , line:23:11, endln:23:12
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
               |vpiLhs:
               \_int_var: (work@asym_ram.log2.res), line:23:7, endln:23:10
                 |vpiName:res
@@ -1577,7 +1539,7 @@ design: (work@asym_ram)
                   |vpiName:res
                   |vpiFullName:work@asym_ram.log2.res
                   |vpiTypespec:
-                  \_int_typespec: , line:16, endln:16:7, parent:work@asym_ram.log2.res
+                  \_int_typespec: , line:16, endln:16:7
               |vpiRhs:
               \_operation: , line:23:29, endln:23:32
                 |vpiOpType:24
@@ -1589,10 +1551,6 @@ design: (work@asym_ram)
                   \_int_var: (work@asym_ram.log2.res), line:16, endln:16:7, parent:work@asym_ram.log2
                 |vpiOperand:
                 \_constant: , line:23:33, endln:23:34
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
             |vpiStmt:
             \_assignment: , line:24:3, endln:24:23, parent:work@asym_ram.log2
               |vpiOpType:82
@@ -1614,10 +1572,6 @@ design: (work@asym_ram)
                   \_logic_var: (work@asym_ram.log2.shifted), line:15, endln:15:3, parent:work@asym_ram.log2
                 |vpiOperand:
                 \_constant: , line:24:22, endln:24:23
-                  |vpiConstType:9
-                  |vpiDecompile:1
-                  |vpiSize:64
-                  |UINT:1
           |vpiStmt:
           \_assignment: , line:25:2, endln:25:12, parent:work@asym_ram.log2
             |vpiOpType:82

--- a/tests/PreprocUhdmCov/PreprocUhdmCov.log
+++ b/tests/PreprocUhdmCov/PreprocUhdmCov.log
@@ -305,9 +305,9 @@ design: (work@top)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -524,9 +524,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -542,9 +542,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -560,9 +560,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -580,9 +580,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -1027,55 +1027,13 @@ design: (work@top)
       |vpiName:state_in
       |vpiDirection:1
       |vpiTypedef:
-      \_logic_typespec: , line:45:58, endln:45:63, parent:state_in
-        |vpiRange:
-        \_range: , line:45:65, endln:45:69
-          |vpiLeftRange:
-          \_constant: , line:45:65, endln:45:67
-            |vpiConstType:9
-            |vpiDecompile:31
-            |vpiSize:64
-            |UINT:31
-          |vpiRightRange:
-          \_constant: , line:45:68, endln:45:69
-            |vpiConstType:9
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
+      \_logic_typespec: , line:45:58, endln:45:63
     |vpiIODecl:
     \_io_decl: (shifts), parent:work@top.prince_shiftrows_32bit
       |vpiName:shifts
       |vpiDirection:1
       |vpiTypedef:
-      \_logic_typespec: , line:46:63, endln:46:68, parent:shifts
-        |vpiRange:
-        \_range: , line:46:70, endln:46:74
-          |vpiLeftRange:
-          \_constant: , line:46:70, endln:46:72
-            |vpiConstType:9
-            |vpiDecompile:15
-            |vpiSize:64
-            |UINT:15
-          |vpiRightRange:
-          \_constant: , line:46:73, endln:46:74
-            |vpiConstType:9
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
-        |vpiRange:
-        \_range: , line:46:76, endln:46:79
-          |vpiLeftRange:
-          \_constant: , line:46:76, endln:46:77
-            |vpiConstType:9
-            |vpiDecompile:3
-            |vpiSize:64
-            |UINT:3
-          |vpiRightRange:
-          \_constant: , line:46:78, endln:46:79
-            |vpiConstType:9
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
+      \_logic_typespec: , line:46:63, endln:46:68
     |vpiStmt:
     \_begin: (work@top.prince_shiftrows_32bit), parent:work@top.prince_shiftrows_32bit
       |vpiFullName:work@top.prince_shiftrows_32bit

--- a/tests/ProcForLoop/ProcForLoop.log
+++ b/tests/ProcForLoop/ProcForLoop.log
@@ -219,9 +219,9 @@ design: (work@top)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -438,9 +438,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -456,9 +456,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -474,9 +474,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -494,9 +494,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -783,18 +783,10 @@ design: (work@top)
             |vpiFullName:work@top.foo.i
           |vpiOperand:
           \_constant: , line:3:22, endln:3:23
-            |vpiConstType:9
-            |vpiDecompile:4
-            |vpiSize:64
-            |UINT:4
         |vpiForInitStmt:
         \_assign_stmt: , parent:work@top.foo
           |vpiRhs:
           \_constant: , line:3:18, endln:3:19
-            |vpiConstType:9
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
           |vpiLhs:
           \_int_var: (work@top.foo.i), line:3:12, endln:3:15
             |vpiName:i
@@ -816,10 +808,6 @@ design: (work@top)
               |vpiFullName:work@top.foo.i
             |vpiOperand:
             \_constant: , line:3:31, endln:3:32
-              |vpiConstType:9
-              |vpiDecompile:1
-              |vpiSize:64
-              |UINT:1
         |vpiStmt:
         \_begin: (work@top.foo), line:3:34, endln:5:9, parent:work@top.foo
           |vpiFullName:work@top.foo
@@ -831,11 +819,7 @@ design: (work@top)
               |vpiName:i
               |vpiFullName:work@top.foo.i
             |vpiArgument:
-            \_constant: , line:4:14, endln:4:15, parent:f2
-              |vpiConstType:9
-              |vpiDecompile:0
-              |vpiSize:64
-              |UINT:0
+            \_constant: , line:4:14, endln:4:15
       |vpiStmt:
       \_for_stmt: (work@top.foo), line:6:6, endln:6:9, parent:work@top.foo
         |vpiFullName:work@top.foo
@@ -848,18 +832,10 @@ design: (work@top)
             |vpiFullName:work@top.foo.j
           |vpiOperand:
           \_constant: , line:6:23, endln:6:24
-            |vpiConstType:9
-            |vpiDecompile:4
-            |vpiSize:64
-            |UINT:4
         |vpiForInitStmt:
         \_assign_stmt: , parent:work@top.foo
           |vpiRhs:
           \_constant: , line:6:19, endln:6:20
-            |vpiConstType:9
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
           |vpiLhs:
           \_int_var: (work@top.foo.j), line:6:12, endln:6:15
             |vpiName:j
@@ -882,11 +858,7 @@ design: (work@top)
               |vpiName:j
               |vpiFullName:work@top.foo.j
             |vpiArgument:
-            \_constant: , line:7:14, endln:7:15, parent:f2
-              |vpiConstType:9
-              |vpiDecompile:0
-              |vpiSize:64
-              |UINT:0
+            \_constant: , line:7:14, endln:7:15
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/RangeInf/RangeInf.log
+++ b/tests/RangeInf/RangeInf.log
@@ -272,9 +272,9 @@ design: (work@FullAdder)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -491,9 +491,9 @@ design: (work@FullAdder)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -509,9 +509,9 @@ design: (work@FullAdder)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -527,9 +527,9 @@ design: (work@FullAdder)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -547,9 +547,9 @@ design: (work@FullAdder)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/Rom/Rom.log
+++ b/tests/Rom/Rom.log
@@ -239,9 +239,9 @@ design: (work@top)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -458,9 +458,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -476,9 +476,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -494,9 +494,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -514,9 +514,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/SignedParam/SignedParam.log
+++ b/tests/SignedParam/SignedParam.log
@@ -108,9 +108,9 @@ design: (work@prim_pad_wrapper)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -327,9 +327,9 @@ design: (work@prim_pad_wrapper)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -345,9 +345,9 @@ design: (work@prim_pad_wrapper)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -363,9 +363,9 @@ design: (work@prim_pad_wrapper)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -383,9 +383,9 @@ design: (work@prim_pad_wrapper)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/SignedPort/SignedPort.log
+++ b/tests/SignedPort/SignedPort.log
@@ -173,9 +173,9 @@ design: (work@dut)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -392,9 +392,9 @@ design: (work@dut)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -410,9 +410,9 @@ design: (work@dut)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -428,9 +428,9 @@ design: (work@dut)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -448,9 +448,9 @@ design: (work@dut)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/StructAccess/StructAccess.log
+++ b/tests/StructAccess/StructAccess.log
@@ -319,9 +319,9 @@ design: (work@top)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -538,9 +538,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -556,9 +556,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -574,9 +574,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -594,9 +594,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -794,7 +794,7 @@ design: (work@top)
       \_bit_select: (mode), parent:csr_pmp_cfg_ie.mode[0]
         |vpiName:mode
         |vpiIndex:
-        \_constant: , line:25:36, endln:25:37, parent:mode
+        \_constant: , line:25:36, endln:25:37
           |vpiConstType:9
           |vpiDecompile:0
           |vpiSize:64

--- a/tests/StructTypedef/StructTypedef.log
+++ b/tests/StructTypedef/StructTypedef.log
@@ -259,9 +259,9 @@ design: (work@top)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -478,9 +478,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -496,9 +496,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -514,9 +514,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -534,9 +534,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/StructVarImp/StructVarImp.log
+++ b/tests/StructVarImp/StructVarImp.log
@@ -455,9 +455,9 @@ design: (work@top)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -674,9 +674,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -692,9 +692,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -710,9 +710,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -730,9 +730,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/TaggedPattern/TaggedPattern.log
+++ b/tests/TaggedPattern/TaggedPattern.log
@@ -206,9 +206,9 @@ design: (work@top)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -425,9 +425,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -443,9 +443,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -461,9 +461,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -481,9 +481,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -663,7 +663,7 @@ design: (work@top)
         \_tagged_pattern: (v2), line:9:7, endln:9:13
           |vpiName:v2
           |vpiPattern:
-          \_constant: , line:9:18, endln:9:20, parent:v2
+          \_constant: , line:9:18, endln:9:20
             |vpiConstType:9
             |vpiDecompile:10
             |vpiSize:64
@@ -682,7 +682,7 @@ design: (work@top)
         \_tagged_pattern: (v1), line:10:7, endln:10:13
           |vpiName:v1
           |vpiPattern:
-          \_constant: , line:10:18, endln:10:20, parent:v1
+          \_constant: , line:10:18, endln:10:20
             |vpiConstType:9
             |vpiDecompile:85
             |vpiSize:64
@@ -691,7 +691,7 @@ design: (work@top)
       \_sys_func_call: ($display), line:11:2, endln:11:49, parent:work@top
         |vpiName:$display
         |vpiArgument:
-        \_constant: , line:11:11, endln:11:43, parent:$display
+        \_constant: , line:11:11, endln:11:43
           |vpiConstType:6
           |vpiDecompile::assert: ('%b' == 'v1:1010101'
           |vpiSize:30

--- a/tests/TaskDecls/TaskDecls.log
+++ b/tests/TaskDecls/TaskDecls.log
@@ -364,9 +364,9 @@ design: (work@gen_errors)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -583,9 +583,9 @@ design: (work@gen_errors)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -601,9 +601,9 @@ design: (work@gen_errors)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -619,9 +619,9 @@ design: (work@gen_errors)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -639,9 +639,9 @@ design: (work@gen_errors)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -919,62 +919,32 @@ design: (work@gen_errors)
       \_range: , line:21:12, endln:21:23, parent:l
         |vpiLeftRange:
         \_constant: , line:21:12, endln:21:19
-          |vpiConstType:7
-          |vpiDecompile:7
-          |vpiSize:64
-          |INT:7
         |vpiRightRange:
         \_constant: , line:21:22, endln:21:23
-          |vpiConstType:9
-          |vpiDecompile:0
-          |vpiSize:64
-          |UINT:0
     |vpiIODecl:
     \_io_decl: (B), line:23:12, endln:23:13, parent:work@gen_errors.A
       |vpiName:B
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:24:5, endln:24:12, parent:B
+      \_int_typespec: , line:24:5, endln:24:12
     |vpiIODecl:
     \_io_decl: (C), line:25:13, endln:25:14, parent:work@gen_errors.A
       |vpiName:C
       |vpiDirection:2
       |vpiTypedef:
-      \_int_typespec: , line:26:5, endln:26:12, parent:C
+      \_int_typespec: , line:26:5, endln:26:12
     |vpiIODecl:
     \_io_decl: (E), line:27:18, endln:27:19, parent:work@gen_errors.A
       |vpiName:E
       |vpiDirection:3
       |vpiTypedef:
-      \_logic_typespec: , line:28:5, endln:28:8, parent:E
-        |vpiRange:
-        \_range: , line:28:12, endln:28:16
-          |vpiLeftRange:
-          \_constant: , line:28:12, endln:28:14
-            |vpiConstType:9
-            |vpiDecompile:31
-            |vpiSize:64
-            |UINT:31
-          |vpiRightRange:
-          \_constant: , line:28:15, endln:28:16
-            |vpiConstType:9
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
+      \_logic_typespec: , line:28:5, endln:28:8
       |vpiRange:
       \_range: , line:27:12, endln:27:16, parent:E
         |vpiLeftRange:
         \_constant: , line:27:12, endln:27:14
-          |vpiConstType:9
-          |vpiDecompile:31
-          |vpiSize:64
-          |UINT:31
         |vpiRightRange:
         \_constant: , line:27:15, endln:27:16
-          |vpiConstType:9
-          |vpiDecompile:0
-          |vpiSize:64
-          |UINT:0
     |vpiStmt:
     \_begin: (work@gen_errors.A), parent:work@gen_errors.A
       |vpiFullName:work@gen_errors.A
@@ -1002,15 +972,11 @@ design: (work@gen_errors)
       |vpiName:internal
       |vpiFullName:work@gen_errors.A.internal
       |vpiTypespec:
-      \_int_typespec: , line:29:5, endln:29:12, parent:work@gen_errors.A.internal
+      \_int_typespec: , line:29:5, endln:29:12
     |vpiParamAssign:
     \_param_assign: , line:30:15, endln:30:29, parent:work@gen_errors.A
       |vpiRhs:
       \_constant: , line:30:22, endln:30:29
-        |vpiConstType:9
-        |vpiDecompile:8
-        |vpiSize:64
-        |UINT:8
       |vpiLhs:
       \_parameter: (work@gen_errors.A.llen), line:30:15, endln:30:29
         |vpiName:llen

--- a/tests/Ternary/Ternary.log
+++ b/tests/Ternary/Ternary.log
@@ -953,9 +953,9 @@ design: (work@test)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -1172,9 +1172,9 @@ design: (work@test)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -1190,9 +1190,9 @@ design: (work@test)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -1208,9 +1208,9 @@ design: (work@test)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -1228,9 +1228,9 @@ design: (work@test)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/TypeDefScope/TypeDefScope.log
+++ b/tests/TypeDefScope/TypeDefScope.log
@@ -181,9 +181,9 @@ design: (work@dut)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -400,9 +400,9 @@ design: (work@dut)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -418,9 +418,9 @@ design: (work@dut)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -436,9 +436,9 @@ design: (work@dut)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -456,9 +456,9 @@ design: (work@dut)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -657,32 +657,31 @@ design: (work@dut)
       |vpiName:type_name
       |vpiDirection:1
       |vpiTypedef:
-      \_string_typespec: , line:3:41, endln:3:47, parent:type_name
+      \_string_typespec: , line:3:41, endln:3:47
     |vpiIODecl:
     \_io_decl: (contxt), parent:work@dut.UVMC_set_config_object
       |vpiName:contxt
       |vpiDirection:1
       |vpiTypedef:
-      \_string_typespec: , line:4:6, endln:4:12, parent:contxt
+      \_string_typespec: , line:4:6, endln:4:12
     |vpiIODecl:
     \_io_decl: (inst_name), parent:work@dut.UVMC_set_config_object
       |vpiName:inst_name
       |vpiDirection:1
       |vpiTypedef:
-      \_string_typespec: , line:5:6, endln:5:12, parent:inst_name
+      \_string_typespec: , line:5:6, endln:5:12
     |vpiIODecl:
     \_io_decl: (field_name), parent:work@dut.UVMC_set_config_object
       |vpiName:field_name
       |vpiDirection:1
       |vpiTypedef:
-      \_string_typespec: , line:6:6, endln:6:12, parent:field_name
+      \_string_typespec: , line:6:6, endln:6:12
     |vpiIODecl:
     \_io_decl: (value), parent:work@dut.UVMC_set_config_object
       |vpiName:value
       |vpiDirection:1
       |vpiTypedef:
-      \_unsupported_typespec: (bits_t), line:7:6, endln:7:12, parent:value
-        |vpiName:bits_t
+      \_unsupported_typespec: (bits_t), line:7:6, endln:7:12
     |vpiStmt:
     \_begin: (work@dut.UVMC_set_config_object), parent:work@dut.UVMC_set_config_object
       |vpiFullName:work@dut.UVMC_set_config_object

--- a/tests/Typename/Typename.log
+++ b/tests/Typename/Typename.log
@@ -162,9 +162,9 @@ design: (work@top)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -381,9 +381,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -399,9 +399,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -417,9 +417,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -437,9 +437,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -509,13 +509,13 @@ design: (work@top)
       \_sys_func_call: ($display), line:4:1, endln:4:58, parent:work@top
         |vpiName:$display
         |vpiArgument:
-        \_constant: , line:4:10, endln:4:38, parent:$display
+        \_constant: , line:4:10, endln:4:38
           |vpiConstType:6
           |vpiDecompile::assert: ('%s' == 'logic')
           |vpiSize:26
           |STRING::assert: ('%s' == 'logic')
         |vpiArgument:
-        \_constant: , line:4:40, endln:4:56, parent:$display
+        \_constant: , line:4:40, endln:4:56
           |vpiConstType:6
           |vpiDecompile:logic
           |STRING:logic
@@ -523,13 +523,13 @@ design: (work@top)
       \_sys_func_call: ($display), line:5:1, endln:5:56, parent:work@top
         |vpiName:$display
         |vpiArgument:
-        \_constant: , line:5:10, endln:5:38, parent:$display
+        \_constant: , line:5:10, endln:5:38
           |vpiConstType:6
           |vpiDecompile::assert: ('%s' == 'logic')
           |vpiSize:26
           |STRING::assert: ('%s' == 'logic')
         |vpiArgument:
-        \_constant: , line:5:40, endln:5:54, parent:$display
+        \_constant: , line:5:40, endln:5:54
           |vpiConstType:6
           |vpiDecompile:int
           |STRING:int
@@ -537,7 +537,7 @@ design: (work@top)
       \_sys_func_call: ($display), line:6:1, endln:6:54, parent:work@top
         |vpiName:$display
         |vpiArgument:
-        \_constant: , line:6:10, endln:6:38, parent:$display
+        \_constant: , line:6:10, endln:6:38
           |vpiConstType:6
           |vpiDecompile::assert: ('%s' == 'logic')
           |vpiSize:26

--- a/tests/Udp/Udp.log
+++ b/tests/Udp/Udp.log
@@ -740,9 +740,9 @@ design: (work@udp_body_tb)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -959,9 +959,9 @@ design: (work@udp_body_tb)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -977,9 +977,9 @@ design: (work@udp_body_tb)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -995,9 +995,9 @@ design: (work@udp_body_tb)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -1015,9 +1015,9 @@ design: (work@udp_body_tb)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -1492,7 +1492,7 @@ design: (work@udp_body_tb)
       \_sys_func_call: ($monitor), line:92:2, endln:92:43, parent:work@udp_body_tb
         |vpiName:$monitor
         |vpiArgument:
-        \_constant: , line:92:11, endln:92:35, parent:$monitor
+        \_constant: , line:92:11, endln:92:35
           |vpiConstType:6
           |vpiDecompile: B = %b C = %b  A = %b
           |vpiSize:22

--- a/tests/UndersVal/UndersVal.log
+++ b/tests/UndersVal/UndersVal.log
@@ -150,9 +150,9 @@ design: (work@dut)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -369,9 +369,9 @@ design: (work@dut)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -387,9 +387,9 @@ design: (work@dut)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -405,9 +405,9 @@ design: (work@dut)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -425,9 +425,9 @@ design: (work@dut)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/UnitPackage/UnitPackage.log
+++ b/tests/UnitPackage/UnitPackage.log
@@ -1221,9 +1221,9 @@ design: (work@simple_package)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -1440,9 +1440,9 @@ design: (work@simple_package)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -1458,9 +1458,9 @@ design: (work@simple_package)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -1476,9 +1476,9 @@ design: (work@simple_package)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -1496,9 +1496,9 @@ design: (work@simple_package)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -2102,13 +2102,13 @@ design: (work@simple_package)
         |vpiTask:
         \_task: (msgPkg::initMsgPkg), line:12:2, endln:15:9, parent:msgPkg::
         |vpiArgument:
-        \_constant: , line:20:21, endln:20:31, parent:msgPkg::initMsgPkg
+        \_constant: , line:20:21, endln:20:31
           |vpiConstType:6
           |vpiDecompile:PACKAGES
           |vpiSize:8
           |STRING:PACKAGES
         |vpiArgument:
-        \_constant: , line:20:32, endln:20:33, parent:msgPkg::initMsgPkg
+        \_constant: , line:20:32, endln:20:33
           |vpiConstType:9
           |vpiDecompile:0
           |vpiSize:64
@@ -2119,7 +2119,7 @@ design: (work@simple_package)
         |vpiTask:
         \_task: (msgPkg::msg_info), line:19:2, endln:21:9, parent:msgPkg::
         |vpiArgument:
-        \_constant: , line:21:19, endln:21:37, parent:msgPkg::msg_info
+        \_constant: , line:21:19, endln:21:37
           |vpiConstType:6
           |vpiDecompile:Testing Packages
           |vpiSize:16
@@ -2133,7 +2133,7 @@ design: (work@simple_package)
           |vpiTask:
           \_task: (msgPkg::msg_warn), line:25:2, endln:28:9, parent:msgPkg::
           |vpiArgument:
-          \_constant: , line:22:23, endln:22:41, parent:msgPkg::msg_warn
+          \_constant: , line:22:23, endln:22:41
             |vpiConstType:6
             |vpiDecompile:Testing Packages
             |vpiSize:16
@@ -2147,7 +2147,7 @@ design: (work@simple_package)
           |vpiTask:
           \_task: (msgPkg::msg_error), line:32:2, endln:36:9, parent:msgPkg::
           |vpiArgument:
-          \_constant: , line:23:24, endln:23:42, parent:msgPkg::msg_error
+          \_constant: , line:23:24, endln:23:42
             |vpiConstType:6
             |vpiDecompile:Testing Packages
             |vpiSize:16
@@ -2161,7 +2161,7 @@ design: (work@simple_package)
         \_sys_func_call: ($psprintf), line:24:19, endln:25:45, parent:msgPkg::msg_info
           |vpiName:$psprintf
           |vpiArgument:
-          \_constant: , line:24:29, endln:24:65, parent:$psprintf
+          \_constant: , line:24:29, endln:24:65
             |vpiConstType:6
             |vpiDecompile:Warning Count %0d, Error Count %0d
             |vpiSize:34
@@ -2227,7 +2227,7 @@ design: (work@simple_package)
             |vpiTask:
             \_task: (msgPkg::msg_fatal), line:40:2, endln:43:9, parent:msgPkg::
             |vpiArgument:
-            \_constant: , line:27:26, endln:27:42, parent:msgPkg::msg_fatal
+            \_constant: , line:27:26, endln:27:42
               |vpiConstType:6
               |vpiDecompile:Value is FALSE
               |vpiSize:14
@@ -2675,17 +2675,13 @@ design: (work@simple_package)
       |vpiName:mName
       |vpiDirection:1
       |vpiTypedef:
-      \_string_typespec: , line:12:19, endln:12:25, parent:mName
-        |vpiInstance:
-        \_package: msgPkg (msgPkg::) msgPkg.pkg:4: , endln:57:10, parent:work@simple_package
+      \_string_typespec: , line:12:19, endln:12:25
     |vpiIODecl:
     \_io_decl: (term), parent:msgPkg::initMsgPkg
       |vpiName:term
       |vpiDirection:1
       |vpiTypedef:
-      \_bit_typespec: , line:12:33, endln:12:36, parent:term
-        |vpiInstance:
-        \_package: msgPkg (msgPkg::) msgPkg.pkg:4: , endln:57:10, parent:work@simple_package
+      \_bit_typespec: , line:12:33, endln:12:36
     |vpiStmt:
     \_begin: (work@simple_package.initMsgPkg), parent:msgPkg::initMsgPkg
       |vpiFullName:work@simple_package.initMsgPkg
@@ -2729,18 +2725,12 @@ design: (work@simple_package)
       |vpiName:msg
       |vpiDirection:1
       |vpiTypedef:
-      \_string_typespec: , line:19:18, endln:19:24, parent:msg
-        |vpiInstance:
-        \_package: msgPkg (msgPkg::) msgPkg.pkg:4: , endln:57:10, parent:work@simple_package
+      \_string_typespec: , line:19:18, endln:19:24
     |vpiStmt:
     \_sys_func_call: ($display), line:20:4, endln:20:55, parent:msgPkg::msg_info
       |vpiName:$display
       |vpiArgument:
-      \_constant: , line:20:14, endln:20:35, parent:$display
-        |vpiConstType:6
-        |vpiDecompile:@%0dns %s INFO : %s
-        |vpiSize:19
-        |STRING:@%0dns %s INFO : %s
+      \_constant: , line:20:14, endln:20:35
       |vpiArgument:
       \_sys_func_call: ($time), line:20:36, endln:20:41, parent:$display
         |vpiName:$time
@@ -2766,9 +2756,7 @@ design: (work@simple_package)
       |vpiName:msg
       |vpiDirection:1
       |vpiTypedef:
-      \_string_typespec: , line:25:18, endln:25:24, parent:msg
-        |vpiInstance:
-        \_package: msgPkg (msgPkg::) msgPkg.pkg:4: , endln:57:10, parent:work@simple_package
+      \_string_typespec: , line:25:18, endln:25:24
     |vpiStmt:
     \_begin: (work@simple_package.msg_warn), parent:msgPkg::msg_warn
       |vpiFullName:work@simple_package.msg_warn
@@ -2776,11 +2764,7 @@ design: (work@simple_package)
       \_sys_func_call: ($display), line:26:4, endln:26:55, parent:work@simple_package.msg_warn
         |vpiName:$display
         |vpiArgument:
-        \_constant: , line:26:14, endln:26:35, parent:$display
-          |vpiConstType:6
-          |vpiDecompile:@%0dns %s WARN : %s
-          |vpiSize:19
-          |STRING:@%0dns %s WARN : %s
+        \_constant: , line:26:14, endln:26:35
         |vpiArgument:
         \_sys_func_call: ($time), line:26:36, endln:26:41, parent:$display
           |vpiName:$time
@@ -2813,9 +2797,7 @@ design: (work@simple_package)
       |vpiName:msg
       |vpiDirection:1
       |vpiTypedef:
-      \_string_typespec: , line:32:19, endln:32:25, parent:msg
-        |vpiInstance:
-        \_package: msgPkg (msgPkg::) msgPkg.pkg:4: , endln:57:10, parent:work@simple_package
+      \_string_typespec: , line:32:19, endln:32:25
     |vpiStmt:
     \_begin: (work@simple_package.msg_error), parent:msgPkg::msg_error
       |vpiFullName:work@simple_package.msg_error
@@ -2823,11 +2805,7 @@ design: (work@simple_package)
       \_sys_func_call: ($display), line:33:4, endln:33:56, parent:work@simple_package.msg_error
         |vpiName:$display
         |vpiArgument:
-        \_constant: , line:33:14, endln:33:36, parent:$display
-          |vpiConstType:6
-          |vpiDecompile:@%0dns %s ERROR : %s
-          |vpiSize:20
-          |STRING:@%0dns %s ERROR : %s
+        \_constant: , line:33:14, endln:33:36
         |vpiArgument:
         \_sys_func_call: ($time), line:33:37, endln:33:42, parent:$display
           |vpiName:$time
@@ -2869,9 +2847,7 @@ design: (work@simple_package)
       |vpiName:msg
       |vpiDirection:1
       |vpiTypedef:
-      \_string_typespec: , line:40:19, endln:40:25, parent:msg
-        |vpiInstance:
-        \_package: msgPkg (msgPkg::) msgPkg.pkg:4: , endln:57:10, parent:work@simple_package
+      \_string_typespec: , line:40:19, endln:40:25
     |vpiStmt:
     \_begin: (work@simple_package.msg_fatal), parent:msgPkg::msg_fatal
       |vpiFullName:work@simple_package.msg_fatal
@@ -2879,11 +2855,7 @@ design: (work@simple_package)
       \_sys_func_call: ($display), line:41:4, endln:41:56, parent:work@simple_package.msg_fatal
         |vpiName:$display
         |vpiArgument:
-        \_constant: , line:41:14, endln:41:36, parent:$display
-          |vpiConstType:6
-          |vpiDecompile:@%0dns %s FATAL : %s
-          |vpiSize:20
-          |STRING:@%0dns %s FATAL : %s
+        \_constant: , line:41:14, endln:41:36
         |vpiArgument:
         \_sys_func_call: ($time), line:41:37, endln:41:42, parent:$display
           |vpiName:$time

--- a/tests/UnitPartSelect/UnitPartSelect.log
+++ b/tests/UnitPartSelect/UnitPartSelect.log
@@ -625,9 +625,9 @@ design: (work@toto)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -844,9 +844,9 @@ design: (work@toto)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -862,9 +862,9 @@ design: (work@toto)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -880,9 +880,9 @@ design: (work@toto)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -900,9 +900,9 @@ design: (work@toto)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/UnitThisNew/UnitThisNew.log
+++ b/tests/UnitThisNew/UnitThisNew.log
@@ -628,9 +628,9 @@ design: (unnamed)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -847,9 +847,9 @@ design: (unnamed)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -865,9 +865,9 @@ design: (unnamed)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -883,9 +883,9 @@ design: (unnamed)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -903,9 +903,9 @@ design: (unnamed)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/UnpackPort/UnpackPort.log
+++ b/tests/UnpackPort/UnpackPort.log
@@ -211,9 +211,9 @@ design: (work@dut)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -430,9 +430,9 @@ design: (work@dut)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -448,9 +448,9 @@ design: (work@dut)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -466,9 +466,9 @@ design: (work@dut)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -486,9 +486,9 @@ design: (work@dut)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -590,27 +590,6 @@ design: (work@dut)
             |UINT:127
           |vpiTypespec:
           \_struct_typespec: (struct2), line:2:10, endln:2:16
-            |vpiPacked:1
-            |vpiName:struct2
-            |vpiTypespecMember:
-            \_typespec_member: (third), line:3:18, endln:3:23, parent:struct2
-              |vpiName:third
-              |vpiTypespec:
-              \_logic_typespec: , line:3:6, endln:3:11, parent:third
-                |vpiRange:
-                \_range: , line:3:13, endln:3:16
-                  |vpiLeftRange:
-                  \_constant: , line:3:13, endln:3:14
-                    |vpiConstType:9
-                    |vpiDecompile:5
-                    |vpiSize:64
-                    |UINT:5
-                  |vpiRightRange:
-                  \_constant: , line:3:15, endln:3:16
-                    |vpiConstType:9
-                    |vpiDecompile:0
-                    |vpiSize:64
-                    |UINT:0
         |vpiLhs:
         \_bit_select: (work@dut.g_fill[0].var3), line:9:13, endln:9:17
           |vpiName:var3
@@ -644,27 +623,6 @@ design: (work@dut)
             |UINT:127
           |vpiTypespec:
           \_struct_typespec: (struct2), line:2:10, endln:2:16
-            |vpiPacked:1
-            |vpiName:struct2
-            |vpiTypespecMember:
-            \_typespec_member: (third), line:3:18, endln:3:23, parent:struct2
-              |vpiName:third
-              |vpiTypespec:
-              \_logic_typespec: , line:3:6, endln:3:11, parent:third
-                |vpiRange:
-                \_range: , line:3:13, endln:3:16
-                  |vpiLeftRange:
-                  \_constant: , line:3:13, endln:3:14
-                    |vpiConstType:9
-                    |vpiDecompile:5
-                    |vpiSize:64
-                    |UINT:5
-                  |vpiRightRange:
-                  \_constant: , line:3:15, endln:3:16
-                    |vpiConstType:9
-                    |vpiDecompile:0
-                    |vpiSize:64
-                    |UINT:0
         |vpiLhs:
         \_bit_select: (work@dut.g_fill[1].var3), line:9:13, endln:9:17
           |vpiName:var3
@@ -698,27 +656,6 @@ design: (work@dut)
             |UINT:127
           |vpiTypespec:
           \_struct_typespec: (struct2), line:2:10, endln:2:16
-            |vpiPacked:1
-            |vpiName:struct2
-            |vpiTypespecMember:
-            \_typespec_member: (third), line:3:18, endln:3:23, parent:struct2
-              |vpiName:third
-              |vpiTypespec:
-              \_logic_typespec: , line:3:6, endln:3:11, parent:third
-                |vpiRange:
-                \_range: , line:3:13, endln:3:16
-                  |vpiLeftRange:
-                  \_constant: , line:3:13, endln:3:14
-                    |vpiConstType:9
-                    |vpiDecompile:5
-                    |vpiSize:64
-                    |UINT:5
-                  |vpiRightRange:
-                  \_constant: , line:3:15, endln:3:16
-                    |vpiConstType:9
-                    |vpiDecompile:0
-                    |vpiSize:64
-                    |UINT:0
         |vpiLhs:
         \_bit_select: (work@dut.g_fill[2].var3), line:9:13, endln:9:17
           |vpiName:var3
@@ -752,27 +689,6 @@ design: (work@dut)
             |UINT:127
           |vpiTypespec:
           \_struct_typespec: (struct2), line:2:10, endln:2:16
-            |vpiPacked:1
-            |vpiName:struct2
-            |vpiTypespecMember:
-            \_typespec_member: (third), line:3:18, endln:3:23, parent:struct2
-              |vpiName:third
-              |vpiTypespec:
-              \_logic_typespec: , line:3:6, endln:3:11, parent:third
-                |vpiRange:
-                \_range: , line:3:13, endln:3:16
-                  |vpiLeftRange:
-                  \_constant: , line:3:13, endln:3:14
-                    |vpiConstType:9
-                    |vpiDecompile:5
-                    |vpiSize:64
-                    |UINT:5
-                  |vpiRightRange:
-                  \_constant: , line:3:15, endln:3:16
-                    |vpiConstType:9
-                    |vpiDecompile:0
-                    |vpiSize:64
-                    |UINT:0
         |vpiLhs:
         \_bit_select: (work@dut.g_fill[3].var3), line:9:13, endln:9:17
           |vpiName:var3
@@ -806,27 +722,6 @@ design: (work@dut)
             |UINT:127
           |vpiTypespec:
           \_struct_typespec: (struct2), line:2:10, endln:2:16
-            |vpiPacked:1
-            |vpiName:struct2
-            |vpiTypespecMember:
-            \_typespec_member: (third), line:3:18, endln:3:23, parent:struct2
-              |vpiName:third
-              |vpiTypespec:
-              \_logic_typespec: , line:3:6, endln:3:11, parent:third
-                |vpiRange:
-                \_range: , line:3:13, endln:3:16
-                  |vpiLeftRange:
-                  \_constant: , line:3:13, endln:3:14
-                    |vpiConstType:9
-                    |vpiDecompile:5
-                    |vpiSize:64
-                    |UINT:5
-                  |vpiRightRange:
-                  \_constant: , line:3:15, endln:3:16
-                    |vpiConstType:9
-                    |vpiDecompile:0
-                    |vpiSize:64
-                    |UINT:0
         |vpiLhs:
         \_bit_select: (work@dut.g_fill[4].var3), line:9:13, endln:9:17
           |vpiName:var3
@@ -860,27 +755,6 @@ design: (work@dut)
             |UINT:127
           |vpiTypespec:
           \_struct_typespec: (struct2), line:2:10, endln:2:16
-            |vpiPacked:1
-            |vpiName:struct2
-            |vpiTypespecMember:
-            \_typespec_member: (third), line:3:18, endln:3:23, parent:struct2
-              |vpiName:third
-              |vpiTypespec:
-              \_logic_typespec: , line:3:6, endln:3:11, parent:third
-                |vpiRange:
-                \_range: , line:3:13, endln:3:16
-                  |vpiLeftRange:
-                  \_constant: , line:3:13, endln:3:14
-                    |vpiConstType:9
-                    |vpiDecompile:5
-                    |vpiSize:64
-                    |UINT:5
-                  |vpiRightRange:
-                  \_constant: , line:3:15, endln:3:16
-                    |vpiConstType:9
-                    |vpiDecompile:0
-                    |vpiSize:64
-                    |UINT:0
         |vpiLhs:
         \_bit_select: (work@dut.g_fill[5].var3), line:9:13, endln:9:17
           |vpiName:var3
@@ -914,27 +788,6 @@ design: (work@dut)
             |UINT:127
           |vpiTypespec:
           \_struct_typespec: (struct2), line:2:10, endln:2:16
-            |vpiPacked:1
-            |vpiName:struct2
-            |vpiTypespecMember:
-            \_typespec_member: (third), line:3:18, endln:3:23, parent:struct2
-              |vpiName:third
-              |vpiTypespec:
-              \_logic_typespec: , line:3:6, endln:3:11, parent:third
-                |vpiRange:
-                \_range: , line:3:13, endln:3:16
-                  |vpiLeftRange:
-                  \_constant: , line:3:13, endln:3:14
-                    |vpiConstType:9
-                    |vpiDecompile:5
-                    |vpiSize:64
-                    |UINT:5
-                  |vpiRightRange:
-                  \_constant: , line:3:15, endln:3:16
-                    |vpiConstType:9
-                    |vpiDecompile:0
-                    |vpiSize:64
-                    |UINT:0
         |vpiLhs:
         \_bit_select: (work@dut.g_fill[6].var3), line:9:13, endln:9:17
           |vpiName:var3

--- a/tests/Values/Values.log
+++ b/tests/Values/Values.log
@@ -227,9 +227,9 @@ design: (work@top)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -446,9 +446,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -464,9 +464,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -482,9 +482,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -502,9 +502,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/VarInFunc/VarInFunc.log
+++ b/tests/VarInFunc/VarInFunc.log
@@ -198,9 +198,9 @@ design: (work@top)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -417,9 +417,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -435,9 +435,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -453,9 +453,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -473,9 +473,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -750,10 +750,6 @@ design: (work@top)
       \_assign_stmt: , line:4:4, endln:4:35, parent:work@top.compute_next_state
         |vpiRhs:
         \_constant: , line:4:31, endln:4:35
-          |vpiConstType:3
-          |vpiDecompile:3'b1
-          |vpiSize:3
-          |BIN:1
         |vpiLhs:
         \_ref_obj: (work@top.compute_next_state.function_variable), line:4:11, endln:4:28
           |vpiName:function_variable
@@ -766,16 +762,8 @@ design: (work@top)
             \_range: , line:3:11, endln:3:14, parent:work@top.compute_next_state.function_variable
               |vpiLeftRange:
               \_constant: , line:3:11, endln:3:12
-                |vpiConstType:9
-                |vpiDecompile:2
-                |vpiSize:64
-                |UINT:2
               |vpiRightRange:
               \_constant: , line:3:13, endln:3:14
-                |vpiConstType:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
       |vpiStmt:
       \_return_stmt: , line:5:4, endln:5:10, parent:work@top.compute_next_state
         |vpiCondition:

--- a/tests/VarSelect/VarSelect.log
+++ b/tests/VarSelect/VarSelect.log
@@ -245,9 +245,9 @@ design: (work@top)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -464,9 +464,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -482,9 +482,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -500,9 +500,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -520,9 +520,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/tests/WildConn/WildConn.log
+++ b/tests/WildConn/WildConn.log
@@ -137,9 +137,9 @@ design: (work@top)
       |vpiName:bound
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:6:16, endln:6:19, parent:bound
+      \_int_typespec: , line:6:16, endln:6:19
       |vpiExpr:
-      \_constant: , line:6:28, endln:6:29, parent:bound
+      \_constant: , line:6:28, endln:6:29
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -356,9 +356,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:60:15, endln:60:18, parent:keyCount
+      \_int_typespec: , line:60:15, endln:60:18
       |vpiExpr:
-      \_constant: , line:60:30, endln:60:31, parent:keyCount
+      \_constant: , line:60:30, endln:60:31
         |vpiConstType:9
         |vpiDecompile:0
         |vpiSize:64
@@ -374,9 +374,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:63:11, endln:63:14, parent:keyCount
+      \_int_typespec: , line:63:11, endln:63:14
       |vpiExpr:
-      \_constant: , line:63:26, endln:63:27, parent:keyCount
+      \_constant: , line:63:26, endln:63:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -392,9 +392,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:66:11, endln:66:14, parent:keyCount
+      \_int_typespec: , line:66:11, endln:66:14
       |vpiExpr:
-      \_constant: , line:66:26, endln:66:27, parent:keyCount
+      \_constant: , line:66:26, endln:66:27
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64
@@ -412,9 +412,9 @@ design: (work@top)
       |vpiName:keyCount
       |vpiDirection:1
       |vpiTypedef:
-      \_int_typespec: , line:69:23, endln:69:26, parent:keyCount
+      \_int_typespec: , line:69:23, endln:69:26
       |vpiExpr:
-      \_constant: , line:69:38, endln:69:39, parent:keyCount
+      \_constant: , line:69:38, endln:69:39
         |vpiConstType:9
         |vpiDecompile:1
         |vpiSize:64

--- a/third_party/tests/black-parrot/bp_top/syn/runsurelog.sh
+++ b/third_party/tests/black-parrot/bp_top/syn/runsurelog.sh
@@ -3,7 +3,7 @@
    rm -rf results/ simsc/slpp_all
    make build_cov.sc sim.sc SUITE=riscv_tests PROG=rsort
    rm -rf results/ simsc/slpp_all
-   make build_cov.sc sim.sc SUITE=riscv_tests PROG=rsort VERILATOR="$1 -sverilog -parse -nopython -verbose -timescale=1ps/1ps -elabuhdm -d coveruhdm -verbose"  && echo "OK"
+   make build_cov.sc sim.sc SUITE=riscv_tests PROG=rsort VERILATOR="$1 -sverilog -parse -nopython -verbose -timescale=1ps/1ps -elabuhdm -d coveruhdm -d uhdmstats -verbose -mp 1"  && echo "OK"
     #save your output
 
 } || { # catch


### PR DESCRIPTION
Leaf objects loose their parent relation since they are now shared. 
The memory savings is in the order of several Gb on large testcases post UHDM elaboration.