### PR TITLE
API directory: first pass IWYU and include sequence cleanup.

### DIFF
--- a/src/API/SLAPI.cpp
+++ b/src/API/SLAPI.cpp
@@ -20,49 +20,37 @@
  *
  * Created on May 13, 2017, 4:42 PM
  */
-#include "API/PythonAPI.h"
-#include <string>
-#include <vector>
-#include <string.h>
-#include "antlr4-runtime.h"
-using namespace antlr4;
-
-#include "ErrorReporting/Waiver.h"
-#include "ErrorReporting/ErrorDefinition.h"
-#include "SourceCompile/SymbolTable.h"
-#include "ErrorReporting/ErrorContainer.h"
-#include "Utils/StringUtils.h"
-
-#include "CommandLine/CommandLineParser.h"
-#include "SourceCompile/CompilationUnit.h"
-#include "SourceCompile/PreprocessFile.h"
-#include "SourceCompile/CompileSourceFile.h"
-#include "SourceCompile/Compiler.h"
-#include "SourceCompile/ParseFile.h"
-#include "SourceCompile/PythonListen.h"
-#include "Design/FileContent.h"
-#include "Testbench/ClassDefinition.h"
-#include <cstdlib>
-#include <iostream>
-#include "antlr4-runtime.h"
-using namespace std;
-using namespace antlr4;
-using namespace SURELOG;
-
-#include "ParserRuleContext.h"
-
-#include "parser/SV3_1aLexer.h"
-#include "parser/SV3_1aParser.h"
-#include "parser/SV3_1aParserBaseListener.h"
-#include "API/SV3_1aPythonListener.h"
-#include "Utils/ParseUtils.h"
-#include "Utils/FileUtils.h"
-#include "API/PythonAPI.h"
-
 #include "API/SLAPI.h"
 
-void SURELOG::SLsetWaiver(const char* messageId, const char* fileName,
-                          unsigned int line, const char* objectName) {
+#include <string.h>
+
+#include <cstdlib>
+#include <iostream>
+
+#include "API/PythonAPI.h"
+#include "API/SV3_1aPythonListener.h"
+
+#include "CommandLine/CommandLineParser.h"
+#include "Design/FileContent.h"
+#include "ErrorReporting/ErrorContainer.h"
+#include "ErrorReporting/ErrorDefinition.h"
+#include "ErrorReporting/Waiver.h"
+#include "SourceCompile/CompilationUnit.h"
+#include "SourceCompile/Compiler.h"
+#include "SourceCompile/PreprocessFile.h"
+#include "SourceCompile/SymbolTable.h"
+#include "Testbench/ClassDefinition.h"
+#include "Utils/FileUtils.h"
+#include "Utils/ParseUtils.h"
+#include "Utils/StringUtils.h"
+
+#include "antlr4-runtime.h"
+#include "parser/SV3_1aLexer.h"
+#include "parser/SV3_1aParser.h"
+
+namespace SURELOG {
+void SLsetWaiver(const char* messageId, const char* fileName,
+                 unsigned int line, const char* objectName) {
   if (fileName == 0 && line == 0 && objectName == 0) {
     Waiver::setWaiver(messageId, "", 0, "");
   } else if (line == 0 && objectName == 0) {
@@ -74,28 +62,28 @@ void SURELOG::SLsetWaiver(const char* messageId, const char* fileName,
   }
 }
 
-void SURELOG::SLregisterNewErrorType(const char* messageId, const char* text,
-                                     const char* secondLine) {
+void SLregisterNewErrorType(const char* messageId, const char* text,
+                            const char* secondLine) {
   //[WARNI:PP0103]
   std::string errorId = messageId;
   errorId = StringUtils::rtrim(errorId, ']');
   errorId = StringUtils::ltrim(errorId, '[');
   ErrorDefinition::ErrorType type = ErrorDefinition::getErrorType(messageId);
   ErrorDefinition::ErrorSeverity severity =
-      ErrorDefinition::getErrorSeverity(errorId.substr(0, 5));
+    ErrorDefinition::getErrorSeverity(errorId.substr(0, 5));
   ErrorDefinition::ErrorCategory category =
-      ErrorDefinition::getCategory(errorId.substr(6, 2));
+    ErrorDefinition::getCategory(errorId.substr(6, 2));
   ErrorDefinition::rec(type, severity, category, text, secondLine);
 }
 
-void SURELOG::SLoverrideSeverity(const char* messageId, const char* severity) {
+void SLoverrideSeverity(const char* messageId, const char* severity) {
   ErrorDefinition::setSeverity(ErrorDefinition::getErrorType(messageId),
                                ErrorDefinition::getErrorSeverity(severity));
 }
 
-void SURELOG::SLaddError(ErrorContainer* errors, const char* messageId,
-                         const char* fileName, unsigned int line,
-                         unsigned int col, const char* objectName) {
+void SLaddError(ErrorContainer* errors, const char* messageId,
+                const char* fileName, unsigned int line,
+                unsigned int col, const char* objectName) {
   if (errors == NULL) return;
   SymbolTable* symbolTable = errors->getSymbolTable();
   SymbolId fileId = 0;
@@ -111,11 +99,11 @@ void SURELOG::SLaddError(ErrorContainer* errors, const char* messageId,
   errors->addError(err, false, false);
 }
 
-void SURELOG::SLaddMLError(ErrorContainer* errors, const char* messageId,
-                           const char* fileName1, unsigned int line1,
-                           unsigned int col1, const char* objectName1,
-                           const char* fileName2, unsigned int line2,
-                           unsigned int col2, const char* objectName2) {
+void SLaddMLError(ErrorContainer* errors, const char* messageId,
+                  const char* fileName1, unsigned int line1,
+                  unsigned int col1, const char* objectName1,
+                  const char* fileName2, unsigned int line2,
+                  unsigned int col2, const char* objectName2) {
   if (errors == NULL) return;
   SymbolTable* symbolTable = errors->getSymbolTable();
   SymbolId fileId1 = 0;
@@ -139,97 +127,97 @@ void SURELOG::SLaddMLError(ErrorContainer* errors, const char* messageId,
   errors->addError(err, false, false);
 }
 
-void SURELOG::SLaddErrorContext(SV3_1aPythonListener* prog,
-                                antlr4::ParserRuleContext* context,
-                                const char* messageId, const char* objectName,
-                                bool printColumn) {
+void SLaddErrorContext(SV3_1aPythonListener* prog,
+                       antlr4::ParserRuleContext* context,
+                       const char* messageId, const char* objectName,
+                       bool printColumn) {
   SV3_1aPythonListener* listener = (SV3_1aPythonListener*)prog;
   antlr4::ParserRuleContext* ctx = (antlr4::ParserRuleContext*)context;
   ErrorContainer* errors =
-      listener->getPythonListen()->getCompileSourceFile()->getErrorContainer();
+    listener->getPythonListen()->getCompileSourceFile()->getErrorContainer();
   std::pair<int, int> lineCol =
-      ParseUtils::getLineColumn(listener->getTokenStream(), ctx);
+    ParseUtils::getLineColumn(listener->getTokenStream(), ctx);
   ErrorDefinition::ErrorType type = ErrorDefinition::getErrorType(messageId);
 
   Location loc(
-      listener->getPythonListen()->getParseFile()->getFileId(lineCol.first),
-      listener->getPythonListen()->getParseFile()->getLineNb(lineCol.first),
-      printColumn ? lineCol.second : 0,
-      listener->getPythonListen()
-          ->getCompileSourceFile()
-          ->getSymbolTable()
-          ->registerSymbol(objectName));
+    listener->getPythonListen()->getParseFile()->getFileId(lineCol.first),
+    listener->getPythonListen()->getParseFile()->getLineNb(lineCol.first),
+    printColumn ? lineCol.second : 0,
+    listener->getPythonListen()
+    ->getCompileSourceFile()
+    ->getSymbolTable()
+    ->registerSymbol(objectName));
   Error err(type, loc);
   errors->addError(err, false, false);
 }
 
-void SURELOG::SLaddMLErrorContext(SV3_1aPythonListener* prog,
-                                  antlr4::ParserRuleContext* context1,
-                                  antlr4::ParserRuleContext* context2,
-                                  const char* messageId,
-                                  const char* objectName1,
-                                  const char* objectName2, bool printColumn) {
+void SLaddMLErrorContext(SV3_1aPythonListener* prog,
+                         antlr4::ParserRuleContext* context1,
+                         antlr4::ParserRuleContext* context2,
+                         const char* messageId,
+                         const char* objectName1,
+                         const char* objectName2, bool printColumn) {
   SV3_1aPythonListener* listener = (SV3_1aPythonListener*)prog;
   antlr4::ParserRuleContext* ctx1 = (antlr4::ParserRuleContext*)context1;
   antlr4::ParserRuleContext* ctx2 = (antlr4::ParserRuleContext*)context2;
   ErrorContainer* errors =
-      listener->getPythonListen()->getCompileSourceFile()->getErrorContainer();
+    listener->getPythonListen()->getCompileSourceFile()->getErrorContainer();
   std::pair<int, int> lineCol1 =
-      ParseUtils::getLineColumn(listener->getTokenStream(), ctx1);
+    ParseUtils::getLineColumn(listener->getTokenStream(), ctx1);
   std::pair<int, int> lineCol2 =
-      ParseUtils::getLineColumn(listener->getTokenStream(), ctx2);
+    ParseUtils::getLineColumn(listener->getTokenStream(), ctx2);
   ErrorDefinition::ErrorType type = ErrorDefinition::getErrorType(messageId);
 
   Location loc1(
-      listener->getPythonListen()->getParseFile()->getFileId(lineCol1.first),
-      listener->getPythonListen()->getParseFile()->getLineNb(lineCol1.first),
-      printColumn ? lineCol1.second : 0,
-      listener->getPythonListen()
-          ->getCompileSourceFile()
-          ->getSymbolTable()
-          ->registerSymbol(objectName1));
+    listener->getPythonListen()->getParseFile()->getFileId(lineCol1.first),
+    listener->getPythonListen()->getParseFile()->getLineNb(lineCol1.first),
+    printColumn ? lineCol1.second : 0,
+    listener->getPythonListen()
+    ->getCompileSourceFile()
+    ->getSymbolTable()
+    ->registerSymbol(objectName1));
 
   Location loc2(
-      listener->getPythonListen()->getParseFile()->getFileId(lineCol2.first),
-      listener->getPythonListen()->getParseFile()->getLineNb(lineCol2.first),
-      printColumn ? lineCol2.second : 0,
-      listener->getPythonListen()
-          ->getCompileSourceFile()
-          ->getSymbolTable()
-          ->registerSymbol(objectName2));
+    listener->getPythonListen()->getParseFile()->getFileId(lineCol2.first),
+    listener->getPythonListen()->getParseFile()->getLineNb(lineCol2.first),
+    printColumn ? lineCol2.second : 0,
+    listener->getPythonListen()
+    ->getCompileSourceFile()
+    ->getSymbolTable()
+    ->registerSymbol(objectName2));
   Error err(type, loc1, loc2);
   errors->addError(err, false, false);
 }
 
-std::string SURELOG::SLgetFile(SV3_1aPythonListener* prog,
-                               antlr4::ParserRuleContext* context) {
+std::string SLgetFile(SV3_1aPythonListener* prog,
+                      antlr4::ParserRuleContext* context) {
   SV3_1aPythonListener* listener = (SV3_1aPythonListener*)prog;
   std::string file =
-      listener->getPythonListen()->getParseFile()->getFileName(0);
+    listener->getPythonListen()->getParseFile()->getFileName(0);
   return file;
 }
 
-int SURELOG::SLgetLine(SV3_1aPythonListener* prog, antlr4::ParserRuleContext* context) {
+int SLgetLine(SV3_1aPythonListener* prog, antlr4::ParserRuleContext* context) {
   SV3_1aPythonListener* listener = (SV3_1aPythonListener*)prog;
   antlr4::ParserRuleContext* ctx = (antlr4::ParserRuleContext*)context;
   std::pair<int, int> lineCol =
-      ParseUtils::getLineColumn(listener->getTokenStream(), ctx);
+    ParseUtils::getLineColumn(listener->getTokenStream(), ctx);
   return lineCol.first;
 }
 
-int SURELOG::SLgetColumn(SV3_1aPythonListener* prog,
-                         antlr4::ParserRuleContext* context) {
+int SLgetColumn(SV3_1aPythonListener* prog,
+                antlr4::ParserRuleContext* context) {
   SV3_1aPythonListener* listener = (SV3_1aPythonListener*)prog;
   antlr4::ParserRuleContext* ctx = (antlr4::ParserRuleContext*)context;
   std::pair<int, int> lineCol =
-      ParseUtils::getLineColumn(listener->getTokenStream(), ctx);
+    ParseUtils::getLineColumn(listener->getTokenStream(), ctx);
   return lineCol.second;
 }
 
-std::string SURELOG::SLgetText(SV3_1aPythonListener* /*prog*/,
-                               antlr4::ParserRuleContext* context) {
+std::string SLgetText(SV3_1aPythonListener* /*prog*/,
+                      antlr4::ParserRuleContext* context) {
   antlr4::ParserRuleContext* ctx = (antlr4::ParserRuleContext*)context;
-  std::vector<Token*> tokens = ParseUtils::getFlatTokenList(ctx);
+  std::vector<antlr4::Token*> tokens = ParseUtils::getFlatTokenList(ctx);
   std::string text;
   for (auto token : tokens) {
     text += token->getText() + " ";
@@ -237,10 +225,10 @@ std::string SURELOG::SLgetText(SV3_1aPythonListener* /*prog*/,
   return text;
 }
 
-std::vector<std::string> SURELOG::SLgetTokens(SV3_1aPythonListener* prog,
-                                              antlr4::ParserRuleContext* context) {
+std::vector<std::string> SLgetTokens(SV3_1aPythonListener* prog,
+                                     antlr4::ParserRuleContext* context) {
   antlr4::ParserRuleContext* ctx = (antlr4::ParserRuleContext*)context;
-  std::vector<Token*> tokens = ParseUtils::getFlatTokenList(ctx);
+  std::vector<antlr4::Token*> tokens = ParseUtils::getFlatTokenList(ctx);
   std::vector<std::string> body_tokens;
   for (auto token : tokens) {
     body_tokens.push_back(token->getText());
@@ -248,21 +236,21 @@ std::vector<std::string> SURELOG::SLgetTokens(SV3_1aPythonListener* prog,
   return body_tokens;
 }
 
-antlr4::ParserRuleContext* SURELOG::SLgetParentContext(SV3_1aPythonListener* prog,
-                                               antlr4::ParserRuleContext* context) {
+antlr4::ParserRuleContext* SLgetParentContext(SV3_1aPythonListener* prog,
+                                              antlr4::ParserRuleContext* context) {
   antlr4::ParserRuleContext* ctx = (antlr4::ParserRuleContext*)context;
   return (antlr4::ParserRuleContext*)ctx->parent;
 }
 
-std::vector<antlr4::ParserRuleContext*> SURELOG::SLgetChildrenContext(
-    SV3_1aPythonListener* prog, antlr4::ParserRuleContext* context) {
+std::vector<antlr4::ParserRuleContext*> SLgetChildrenContext(
+  SV3_1aPythonListener* prog, antlr4::ParserRuleContext* context) {
   antlr4::ParserRuleContext* ctx = (antlr4::ParserRuleContext*)context;
   std::vector<antlr4::ParserRuleContext*> children;
 
   for (unsigned int i = 0; i < ctx->children.size(); i++) {
     // Get the i-th child node of `parent`.
-    tree::ParseTree* child = ctx->children[i];
-    tree::TerminalNode* node = dynamic_cast<tree::TerminalNode*>(child);
+    antlr4::tree::ParseTree* child = ctx->children[i];
+    antlr4::tree::TerminalNode* node = dynamic_cast<antlr4::tree::TerminalNode*>(child);
     if (node) {
       // Terminal node
     } else {
@@ -273,95 +261,95 @@ std::vector<antlr4::ParserRuleContext*> SURELOG::SLgetChildrenContext(
   return children;
 }
 
-NodeId SURELOG::SLgetRootNode(FileContent* fC) {
+NodeId SLgetRootNode(FileContent* fC) {
   if (!fC) return 0;
   return fC->getRootNode();
 }
 
-std::string SURELOG::SLgetFile(FileContent* fC, NodeId id) {
+std::string SLgetFile(FileContent* fC, NodeId id) {
   if (!fC) return "";
   return fC->getSymbolTable()->getSymbol(fC->getFileId(id));
 }
 
-unsigned int SURELOG::SLgetType(FileContent* fC, NodeId id) {
+unsigned int SLgetType(FileContent* fC, NodeId id) {
   if (!fC) return 0;
   return fC->Type(id);
 }
 
-NodeId SURELOG::SLgetChild(FileContent* fC, NodeId index) {
+NodeId SLgetChild(FileContent* fC, NodeId index) {
   if (!fC) return 0;
   return fC->Child(index);
 }
 
-NodeId SURELOG::SLgetSibling(FileContent* fC, NodeId index) {
+NodeId SLgetSibling(FileContent* fC, NodeId index) {
   if (!fC) return 0;
   return fC->Sibling(index);
 }
 
-NodeId SURELOG::SLgetParent(FileContent* fC, NodeId index) {
+NodeId SLgetParent(FileContent* fC, NodeId index) {
   if (!fC) return 0;
   return fC->Parent(index);
 }
 
-unsigned int SURELOG::SLgetLine(FileContent* fC, NodeId index) {
+unsigned int SLgetLine(FileContent* fC, NodeId index) {
   if (!fC) return 0;
   return fC->Line(index);
 }
 
-std::string SURELOG::SLgetName(FileContent* fC, NodeId index) {
+std::string SLgetName(FileContent* fC, NodeId index) {
   if (!fC) return "";
   return fC->SymName(index);
 }
 
-NodeId SURELOG::SLgetChild(FileContent* fC, NodeId parent, unsigned int type) {
+NodeId SLgetChild(FileContent* fC, NodeId parent, unsigned int type) {
   if (!fC) return 0;
   return fC->sl_get(parent, (VObjectType)type);
 }
 
-NodeId SURELOG::SLgetParent(FileContent* fC, NodeId parent, unsigned int type) {
+NodeId SLgetParent(FileContent* fC, NodeId parent, unsigned int type) {
   if (!fC) return 0;
   return fC->sl_parent(parent, (VObjectType)type);
 }
 
-std::vector<unsigned int> SURELOG::SLgetAll(FileContent* fC, NodeId parent,
-                                            unsigned int type) {
+std::vector<unsigned int> SLgetAll(FileContent* fC, NodeId parent,
+                                   unsigned int type) {
   if (!fC) return {};
   return fC->sl_get_all(parent, (VObjectType)type);
 }
 
-std::vector<unsigned int> SURELOG::SLgetAll(FileContent* fC, NodeId parent,
-                                            std::vector<unsigned int> types) {
+std::vector<unsigned int> SLgetAll(FileContent* fC, NodeId parent,
+                                   std::vector<unsigned int> types) {
   if (!fC) return {};
   std::vector<VObjectType> vtypes;
   for (auto type : types) vtypes.push_back((VObjectType)type);
   return fC->sl_get_all(parent, vtypes);
 }
 
-NodeId SURELOG::SLcollect(FileContent* fC, NodeId parent, unsigned int type) {
+NodeId SLcollect(FileContent* fC, NodeId parent, unsigned int type) {
   if (!fC) return {};
   return fC->sl_collect(parent, (VObjectType)type);
 }
 
-std::vector<unsigned int> SURELOG::SLcollectAll(FileContent* fC, NodeId parent,
-                                                unsigned int type, bool first) {
+std::vector<unsigned int> SLcollectAll(FileContent* fC, NodeId parent,
+                                       unsigned int type, bool first) {
   if (fC)
     return fC->sl_collect_all(parent, (VObjectType)type, first);
   else
     return {};
 }
 
-std::vector<unsigned int> SURELOG::SLcollectAll(FileContent* fC, NodeId parent,
-                                                std::vector<unsigned int> types,
-                                                bool first) {
+std::vector<unsigned int> SLcollectAll(FileContent* fC, NodeId parent,
+                                       std::vector<unsigned int> types,
+                                       bool first) {
   if (!fC) return {};
   std::vector<VObjectType> vtypes;
   for (auto type : types) vtypes.push_back((VObjectType)type);
   return fC->sl_collect_all(parent, vtypes, first);
 }
 
-std::vector<unsigned int> SURELOG::SLcollectAll(
-    FileContent* fC, NodeId parent, std::vector<unsigned int> types,
-    std::vector<unsigned int> stopPoints, bool first) {
+std::vector<unsigned int> SLcollectAll(
+  FileContent* fC, NodeId parent, std::vector<unsigned int> types,
+  std::vector<unsigned int> stopPoints, bool first) {
   if (!fC) return {};
   std::vector<VObjectType> vtypes;
   for (auto type : types) vtypes.push_back((VObjectType)type);
@@ -370,77 +358,77 @@ std::vector<unsigned int> SURELOG::SLcollectAll(
   return fC->sl_collect_all(parent, vtypes, vstops, first);
 }
 
-unsigned int SURELOG::SLgetnModuleDefinition(Design* design) {
+unsigned int SLgetnModuleDefinition(Design* design) {
   if (!design) return 0;
   return design->getModuleDefinitions().size();
 }
 
-unsigned int SURELOG::SLgetnProgramDefinition(Design* design) {
+unsigned int SLgetnProgramDefinition(Design* design) {
   if (!design) return 0;
   return design->getProgramDefinitions().size();
 }
 
-unsigned int SURELOG::SLgetnPackageDefinition(Design* design) {
+unsigned int SLgetnPackageDefinition(Design* design) {
   if (!design) return 0;
   return design->getPackageDefinitions().size();
 }
 
-unsigned int SURELOG::SLgetnClassDefinition(Design* design) {
+unsigned int SLgetnClassDefinition(Design* design) {
   if (!design) return 0;
   return design->getUniqueClassDefinitions().size();
 }
 
-unsigned int SURELOG::SLgetnTopModuleInstance(Design* design) {
+unsigned int SLgetnTopModuleInstance(Design* design) {
   if (!design) return 0;
   return design->getTopLevelModuleInstances().size();
 }
 
-ModuleDefinition* SURELOG::SLgetModuleDefinition(Design* design,
-                                                 unsigned int index) {
+ModuleDefinition* SLgetModuleDefinition(Design* design,
+                                        unsigned int index) {
   if (!design) return 0;
   ModuleNameModuleDefinitionMap::iterator itr =
-      design->getModuleDefinitions().begin();
+    design->getModuleDefinitions().begin();
   for (unsigned int i = 0; i < index; i++) itr++;
   return (*itr).second;
 }
 
-Program* SURELOG::SLgetProgramDefinition(Design* design, unsigned int index) {
+Program* SLgetProgramDefinition(Design* design, unsigned int index) {
   if (!design) return 0;
   ProgramNameProgramDefinitionMap::iterator itr =
-      design->getProgramDefinitions().begin();
+    design->getProgramDefinitions().begin();
   for (unsigned int i = 0; i < index; i++) itr++;
   return (*itr).second;
 }
 
-Package* SURELOG::SLgetPackageDefinition(Design* design, unsigned int index) {
+Package* SLgetPackageDefinition(Design* design, unsigned int index) {
   if (!design) return 0;
   PackageNamePackageDefinitionMultiMap::iterator itr =
-      design->getPackageDefinitions().begin();
+    design->getPackageDefinitions().begin();
   for (unsigned int i = 0; i < index; i++) itr++;
   return (*itr).second;
 }
 
-ClassDefinition* SURELOG::SLgetClassDefinition(Design* design,
-                                               unsigned int index) {
+ClassDefinition* SLgetClassDefinition(Design* design,
+                                      unsigned int index) {
   if (!design) return 0;
   ClassNameClassDefinitionMap::iterator itr =
-      design->getUniqueClassDefinitions().begin();
+    design->getUniqueClassDefinitions().begin();
   for (unsigned int i = 0; i < index; i++) itr++;
   return (*itr).second;
 }
 
-ModuleInstance* SURELOG::SLgetTopModuleInstance(Design* design,
-                                                unsigned int index) {
+ModuleInstance* SLgetTopModuleInstance(Design* design,
+                                       unsigned int index) {
   if (!design) return 0;
   return design->getTopLevelModuleInstances()[index];
 }
 
-std::string SURELOG::SLgetModuleName(ModuleDefinition* module) {
+std::string SLgetModuleName(ModuleDefinition* module) {
   if (!module) return "";
   return module->getName();
 }
 
-std::string SURELOG::SLgetModuleFile(ModuleDefinition* module) {
+std::string SLgetModuleFile(ModuleDefinition* module) {
   if (!module) return "";
   if (module->getFileContents().size())
     return module->getFileContents()[0]->getFileName(module->getNodeIds()[0]);
@@ -448,7 +436,7 @@ std::string SURELOG::SLgetModuleFile(ModuleDefinition* module) {
     return "";
 }
 
-unsigned int SURELOG::SLgetModuleLine(ModuleDefinition* module) {
+unsigned int SLgetModuleLine(ModuleDefinition* module) {
   if (!module) return 0;
   if (module->getFileContents().size())
     return module->getFileContents()[0]->Line(module->getNodeIds()[0]);
@@ -456,12 +444,12 @@ unsigned int SURELOG::SLgetModuleLine(ModuleDefinition* module) {
     return 0;
 }
 
-VObjectType SURELOG::SLgetModuleType(ModuleDefinition* module) {
+VObjectType SLgetModuleType(ModuleDefinition* module) {
   if (!module) return VObjectType::slNoType;
   return module->getType();
 }
 
-FileContent* SURELOG::SLgetModuleFileContent(ModuleDefinition* module) {
+FileContent* SLgetModuleFileContent(ModuleDefinition* module) {
   if (!module) return NULL;
   if (module->getFileContents().size())
     // TODO(alain): fix const cast.
@@ -470,7 +458,7 @@ FileContent* SURELOG::SLgetModuleFileContent(ModuleDefinition* module) {
     return NULL;
 }
 
-NodeId SURELOG::SLgetModuleRootNode(ModuleDefinition* module) {
+NodeId SLgetModuleRootNode(ModuleDefinition* module) {
   if (!module) return 0;
   if (module->getFileContents().size())
     return module->getNodeIds()[0];
@@ -478,12 +466,12 @@ NodeId SURELOG::SLgetModuleRootNode(ModuleDefinition* module) {
     return 0;
 }
 
-std::string SURELOG::SLgetClassName(ClassDefinition* module) {
+std::string SLgetClassName(ClassDefinition* module) {
   if (!module) return "";
   return module->getName();
 }
 
-std::string SURELOG::SLgetClassFile(ClassDefinition* module) {
+std::string SLgetClassFile(ClassDefinition* module) {
   if (!module) return "";
   if (module->getFileContents().size() && module->getFileContents()[0])
     return module->getFileContents()[0]->getFileName(module->getNodeIds()[0]);
@@ -491,7 +479,7 @@ std::string SURELOG::SLgetClassFile(ClassDefinition* module) {
     return "";
 }
 
-unsigned int SURELOG::SLgetClassLine(ClassDefinition* module) {
+unsigned int SLgetClassLine(ClassDefinition* module) {
   if (!module) return 0;
   if (module->getFileContents().size() && module->getFileContents()[0])
     return module->getFileContents()[0]->Line(module->getNodeIds()[0]);
@@ -499,12 +487,12 @@ unsigned int SURELOG::SLgetClassLine(ClassDefinition* module) {
     return 0;
 }
 
-VObjectType SURELOG::SLgetClassType(ClassDefinition* module) {
+VObjectType SLgetClassType(ClassDefinition* module) {
   if (!module) return VObjectType::slNoType;
   return module->getType();
 }
 
-FileContent* SURELOG::SLgetClassFileContent(ClassDefinition* module) {
+FileContent* SLgetClassFileContent(ClassDefinition* module) {
   if (!module) return 0;
   if (module->getFileContents().size() && module->getFileContents()[0])
     // TODO(Alain): Fix api.
@@ -513,7 +501,7 @@ FileContent* SURELOG::SLgetClassFileContent(ClassDefinition* module) {
     return NULL;
 }
 
-NodeId SURELOG::SLgetClassRootNode(ClassDefinition* module) {
+NodeId SLgetClassRootNode(ClassDefinition* module) {
   if (!module) return 0;
   if (module->getFileContents().size() && module->getFileContents()[0])
     return module->getNodeIds()[0];
@@ -521,12 +509,12 @@ NodeId SURELOG::SLgetClassRootNode(ClassDefinition* module) {
     return 0;
 }
 
-std::string SURELOG::SLgetPackageName(Package* module) {
+std::string SLgetPackageName(Package* module) {
   if (!module) return "";
   return module->getName();
 }
 
-std::string SURELOG::SLgetPackageFile(Package* module) {
+std::string SLgetPackageFile(Package* module) {
   if (!module) return "";
   if (module->getFileContents().size())
     return module->getFileContents()[0]->getFileName(module->getNodeIds()[0]);
@@ -534,7 +522,7 @@ std::string SURELOG::SLgetPackageFile(Package* module) {
     return "";
 }
 
-unsigned int SURELOG::SLgetPackageLine(Package* module) {
+unsigned int SLgetPackageLine(Package* module) {
   if (!module) return 0;
   if (module->getFileContents().size())
     return module->getFileContents()[0]->Line(module->getNodeIds()[0]);
@@ -542,12 +530,12 @@ unsigned int SURELOG::SLgetPackageLine(Package* module) {
     return 0;
 }
 
-VObjectType SURELOG::SLgetPackageType(Package* module) {
+VObjectType SLgetPackageType(Package* module) {
   if (!module) return VObjectType::slNoType;
   return module->getType();
 }
 
-FileContent* SURELOG::SLgetPackageFileContent(Package* module) {
+FileContent* SLgetPackageFileContent(Package* module) {
   if (!module) return 0;
   if (module->getFileContents().size())
     return const_cast<FileContent*>(module->getFileContents()[0]);
@@ -555,7 +543,7 @@ FileContent* SURELOG::SLgetPackageFileContent(Package* module) {
     return NULL;
 }
 
-NodeId SURELOG::SLgetPackageRootNode(Package* module) {
+NodeId SLgetPackageRootNode(Package* module) {
   if (!module) return 0;
   if (module->getFileContents().size())
     return module->getNodeIds()[0];
@@ -563,12 +551,12 @@ NodeId SURELOG::SLgetPackageRootNode(Package* module) {
     return 0;
 }
 
-std::string SURELOG::SLgetProgramName(Program* module) {
+std::string SLgetProgramName(Program* module) {
   if (!module) return "";
   return module->getName();
 }
 
-std::string SURELOG::SLgetProgramFile(Program* module) {
+std::string SLgetProgramFile(Program* module) {
   if (!module) return "";
   if (module->getFileContents().size())
     return module->getFileContents()[0]->getFileName(module->getNodeIds()[0]);
@@ -576,7 +564,7 @@ std::string SURELOG::SLgetProgramFile(Program* module) {
     return "";
 }
 
-unsigned int SURELOG::SLgetProgramLine(Program* module) {
+unsigned int SLgetProgramLine(Program* module) {
   if (!module) return 0;
   if (module->getFileContents().size())
     return module->getFileContents()[0]->Line(module->getNodeIds()[0]);
@@ -584,12 +572,12 @@ unsigned int SURELOG::SLgetProgramLine(Program* module) {
     return 0;
 }
 
-VObjectType SURELOG::SLgetProgramType(Program* module) {
+VObjectType SLgetProgramType(Program* module) {
   if (!module) return VObjectType::slNoType;
   return module->getType();
 }
 
-FileContent* SURELOG::SLgetProgramFileContent(Program* module) {
+FileContent* SLgetProgramFileContent(Program* module) {
   if (!module) return 0;
   if (module->getFileContents().size())
     return const_cast<FileContent*>(module->getFileContents()[0]);
@@ -597,7 +585,7 @@ FileContent* SURELOG::SLgetProgramFileContent(Program* module) {
     return NULL;
 }
 
-NodeId SURELOG::SLgetProgramRootNode(Program* module) {
+NodeId SLgetProgramRootNode(Program* module) {
   if (!module) return 0;
   if (module->getFileContents().size())
     return module->getNodeIds()[0];
@@ -605,69 +593,70 @@ NodeId SURELOG::SLgetProgramRootNode(Program* module) {
     return 0;
 }
 
-VObjectType SURELOG::SLgetInstanceType(ModuleInstance* instance) {
+VObjectType SLgetInstanceType(ModuleInstance* instance) {
   if (!instance) return VObjectType::slNoType;
   return instance->getType();
 }
 
-VObjectType SURELOG::SLgetInstanceModuleType(ModuleInstance* instance) {
+VObjectType SLgetInstanceModuleType(ModuleInstance* instance) {
   if (!instance) return VObjectType::slNoType;
   return instance->getModuleType();
 }
 
-std::string SURELOG::SLgetInstanceName(ModuleInstance* instance) {
+std::string SLgetInstanceName(ModuleInstance* instance) {
   if (!instance) return "";
   return instance->getInstanceName();
 }
 
-std::string SURELOG::SLgetInstanceFullPathName(ModuleInstance* instance) {
+std::string SLgetInstanceFullPathName(ModuleInstance* instance) {
   if (!instance) return "";
   return instance->getFullPathName();
 }
 
-std::string SURELOG::SLgetInstanceModuleName(ModuleInstance* instance) {
+std::string SLgetInstanceModuleName(ModuleInstance* instance) {
   if (!instance) return "";
   return instance->getModuleName();
 }
 
-DesignComponent* SURELOG::SLgetInstanceDefinition(ModuleInstance* instance) {
+DesignComponent* SLgetInstanceDefinition(ModuleInstance* instance) {
   if (!instance) return NULL;
   return instance->getDefinition();
 }
 
-std::string SURELOG::SLgetInstanceFileName(ModuleInstance* instance) {
+std::string SLgetInstanceFileName(ModuleInstance* instance) {
   if (!instance) return "";
   return instance->getFileContent()->getFileName(instance->getNodeId());
 }
 
-FileContent* SURELOG::SLgetInstanceFileContent(ModuleInstance* instance) {
+FileContent* SLgetInstanceFileContent(ModuleInstance* instance) {
   if (!instance) return NULL;
   // TODO(Alain): fix to return const
   return const_cast<FileContent*>(instance->getFileContent());
 }
 
-NodeId SURELOG::SLgetInstanceNodeId(ModuleInstance* instance) {
+NodeId SLgetInstanceNodeId(ModuleInstance* instance) {
   if (!instance) return 0;
   return instance->getNodeId();
 }
 
-unsigned int SURELOG::SLgetInstanceLine(ModuleInstance* instance) {
+unsigned int SLgetInstanceLine(ModuleInstance* instance) {
   if (!instance) return 0;
   return instance->getLineNb();
 }
 
-unsigned int SURELOG::SLgetnInstanceChildren(ModuleInstance* instance) {
+unsigned int SLgetnInstanceChildren(ModuleInstance* instance) {
   if (!instance) return 0;
   return instance->getNbChildren();
 }
 
-ModuleInstance* SURELOG::SLgetInstanceChildren(ModuleInstance* instance,
-                                               unsigned int i) {
+ModuleInstance* SLgetInstanceChildren(ModuleInstance* instance,
+                                      unsigned int i) {
   if (!instance) return NULL;
   return instance->getChildren(i);
 }
 
-ModuleInstance* SURELOG::SLgetInstanceParent(ModuleInstance* instance) {
+ModuleInstance* SLgetInstanceParent(ModuleInstance* instance) {
   if (!instance) return NULL;
   return instance->getParent();
 }
+}  // namespace SURELOG

--- a/src/API/SLAPI.h
+++ b/src/API/SLAPI.h
@@ -24,6 +24,12 @@
 #ifndef SLAPI_H
 #define SLAPI_H
 
+#include <string>
+#include <vector>
+
+#include "ParserRuleContext.h"  // Antlr runtime
+#include "SourceCompile/VObjectTypes.h"
+
 typedef unsigned int NodeId;
 namespace SURELOG {
 

--- a/src/API/SV3_1aPythonListener.cpp
+++ b/src/API/SV3_1aPythonListener.cpp
@@ -20,31 +20,30 @@
  *
  * Created on April 16, 2017, 8:28 PM
  */
-#include "SourceCompile/SymbolTable.h"
+#include "API/SV3_1aPythonListener.h"
+
+#include <cstdlib>
+#include <iostream>
+
+#include "API/PythonAPI.h"
 #include "CommandLine/CommandLineParser.h"
 #include "ErrorReporting/ErrorContainer.h"
 #include "SourceCompile/CompilationUnit.h"
-#include "SourceCompile/PreprocessFile.h"
 #include "SourceCompile/CompileSourceFile.h"
 #include "SourceCompile/Compiler.h"
 #include "SourceCompile/ParseFile.h"
+#include "SourceCompile/PreprocessFile.h"
 #include "SourceCompile/PythonListen.h"
-#include <cstdlib>
-#include <iostream>
-#include "antlr4-runtime.h"
-using namespace std;
-using namespace antlr4;
-using namespace SURELOG;
+#include "SourceCompile/SymbolTable.h"
+#include "Utils/FileUtils.h"
+#include "Utils/ParseUtils.h"
 
+#include "antlr4-runtime.h"
 #include "parser/SV3_1aLexer.h"
 #include "parser/SV3_1aParser.h"
 #include "parser/SV3_1aParserBaseListener.h"
-#include "API/SV3_1aPythonListener.h"
-using namespace antlr4;
-#include "Utils/ParseUtils.h"
-#include "Utils/FileUtils.h"
-#include "API/PythonAPI.h"
 
+namespace SURELOG {
 SV3_1aPythonListener::SV3_1aPythonListener (PythonListen* pl, PyThreadState* interpState, antlr4::CommonTokenStream* tokens, unsigned int lineOffset) :
 m_pl(pl), m_interpState(interpState), m_tokens(tokens), m_lineOffset(lineOffset) { }
 
@@ -57,7 +56,9 @@ SV3_1aPythonListener::logError (ErrorDefinition::ErrorType error, antlr4::Parser
 {
   std::pair<int, int> lineCol = ParseUtils::getLineColumn (getTokenStream (), ctx);
 
-  Location loc (m_pl->getParseFile()->getFileId (lineCol.first + m_lineOffset), m_pl->getParseFile()->getLineNb (lineCol.first + m_lineOffset), printColumn ? lineCol.second : 0,
+  Location loc (m_pl->getParseFile()->getFileId (lineCol.first + m_lineOffset),
+                m_pl->getParseFile()->getLineNb (lineCol.first + m_lineOffset),
+                printColumn ? lineCol.second : 0,
                 m_pl->getCompileSourceFile()->getSymbolTable ()->registerSymbol(object));
   Error err (error, loc);
   m_pl->addError (err);
@@ -79,3 +80,4 @@ SV3_1aPythonListener::logError (ErrorDefinition::ErrorType error, Location& loc,
   Error err (error, loc, &extras);
   m_pl->getCompileSourceFile ()->getErrorContainer ()->addError (err, showDuplicates);
 }
+}  // namespace SURELOG

--- a/src/API/SV3_1aPythonListener.h
+++ b/src/API/SV3_1aPythonListener.h
@@ -13,9 +13,14 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  */
-#include "PythonAPI.h"
 #ifndef SV3_1APYTHONLISTENER_H
 #define SV3_1APYTHONLISTENER_H
+
+#include "PythonAPI.h"
+#include "SourceCompile/CompileSourceFile.h"
+#include "SourceCompile/ParseFile.h"
+#include "SourceCompile/PythonListen.h"
+#include "parser/SV3_1aParserBaseListener.h"
 
 namespace SURELOG {
 

--- a/src/API/Surelog.cpp
+++ b/src/API/Surelog.cpp
@@ -14,7 +14,8 @@
  limitations under the License.
  */
 
-#include "CommandLine/CommandLineParser.h"
+#include "API/Surelog.h"
+
 #include "SourceCompile/SymbolTable.h"
 #include "SourceCompile/CompilationUnit.h"
 #include "SourceCompile/PreprocessFile.h"
@@ -23,8 +24,6 @@
 #include "ErrorReporting/ErrorContainer.h"
 #include "ErrorReporting/Report.h"
 #include "ErrorReporting/Waiver.h"
-#include "Surelog.h"
-
 
 SURELOG::scompiler* SURELOG::start_compiler (SURELOG::CommandLineParser* clp) {
   Compiler* the_compiler = new SURELOG::Compiler(clp, clp->getErrorContainer(),

--- a/src/API/Surelog.h
+++ b/src/API/Surelog.h
@@ -20,15 +20,17 @@
  *
  * Created on November 21, 2019, 10:09 PM
  */
-
 #ifndef SURELOG_H
 #define SURELOG_H
+
 #include "sv_vpi_user.h"
+#include "CommandLine/CommandLineParser.h"
+#include "Design/Design.h"
 
 namespace SURELOG {
   struct scompiler;
   // Create a compiler session based on the command line options
-  SURELOG::scompiler* start_compiler (SURELOG::CommandLineParser* clp); 
+  SURELOG::scompiler* start_compiler (SURELOG::CommandLineParser* clp);
 
   // Surelog internal design representation and AST access
   SURELOG::Design*    get_design(SURELOG::scompiler* compiler);
@@ -39,9 +41,9 @@ namespace SURELOG {
   //      third_party/UHDM/headers/
   vpiHandle get_uhdm_design(SURELOG::scompiler* compiler);
 
-  // Terminate the compiler session, cleanup internal datastructures, 
-  // the design persists post this operation 
+  // Terminate the compiler session, cleanup internal datastructures,
+  // the design persists post this operation
   void       shutdown_compiler(SURELOG::scompiler* compiler);
-}  
+}
 
 #endif

--- a/src/API/generate_python_listener_api.tcl
+++ b/src/API/generate_python_listener_api.tcl
@@ -41,17 +41,21 @@ puts $oid " WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or impl
 puts $oid " See the License for the specific language governing permissions and"
 puts $oid " limitations under the License."
 puts $oid " */"
-
-puts $oid "#include \"PythonAPI.h\""
 puts $oid "#ifndef SV3_1APYTHONLISTENER_H"
 puts $oid "#define SV3_1APYTHONLISTENER_H"
+puts $oid ""
+puts $oid "#include \"PythonAPI.h\""
+puts $oid "#include \"SourceCompile/CompileSourceFile.h\""
+puts $oid "#include \"SourceCompile/ParseFile.h\""
+puts $oid "#include \"SourceCompile/PythonListen.h\""
+puts $oid "#include \"parser/SV3_1aParserBaseListener.h\""
 puts $oid ""
 puts $oid "namespace SURELOG {"
 puts $oid ""
 puts $oid ""
 puts $oid "class SV3_1aPythonListener : public SV3_1aParserBaseListener {"
 puts $oid "private:"
-puts $oid "    PythonListen* m_pl;"      
+puts $oid "    PythonListen* m_pl;"
 puts $oid "    PyThreadState* m_interpState;"
 puts $oid "    antlr4::CommonTokenStream* m_tokens;"
 puts $oid "    unsigned int               m_lineOffset;"
@@ -65,8 +69,8 @@ puts $oid "    ~SV3_1aPythonListener();"
 puts $oid ""
 puts $oid " void logError(ErrorDefinition::ErrorType error, antlr4::ParserRuleContext* ctx, std::string object, bool printColumn = false);"
 puts $oid " void logError(ErrorDefinition::ErrorType, Location& loc, bool showDuplicates = false);"
-puts $oid " void logError(ErrorDefinition::ErrorType, Location& loc, Location& extraLoc, bool showDuplicates = false);"      
-    
+puts $oid " void logError(ErrorDefinition::ErrorType, Location& loc, Location& extraLoc, bool showDuplicates = false);"
+
 
 puts $pid "# This is a SURELOG Python API Listener"
 puts $pid ""
@@ -96,10 +100,10 @@ foreach line $lines {
 	if [regexp {enter} $ruleName] {
 	    if ![regexp {enterEveryRule} $ruleName] {
 		puts $pid "\tif trace:"
-		puts $pid "\t\tprint(\"$ruleName\")" 
+		puts $pid "\t\tprint(\"$ruleName\")"
 		puts $pid "\t\tprint(\"  File:\",SLgetFile(prog, ctx),\",\",SLgetLine(prog, ctx))"
 		puts $pid "\t\ttext = SLgetText(prog, ctx)"
-		puts $pid "\t\tprint(\"  Text:\",text\[:20\],\"...\")" 
+		puts $pid "\t\tprint(\"  Text:\",text\[:20\],\"...\")"
 	    }
 	}
 	puts $pid "\tpass"
@@ -123,6 +127,3 @@ flush $pid
 close $pid
 
 flush stdout
-
-
-


### PR DESCRIPTION
Move the header for a particular compilation unit always at
the top for that compilation unit (e.g. foo.cpp includes foo.h first).

That way, we can easily see if there are some hidden dependencies that
only worked 'by accident' by virtue of sequence they have been included.
If every compilation unit does that, we guarantee that each header
is self-contained.

Start with the src/API/ directory for this.

The remaining header have been grouped by c++ and
project headers, and then sorted alphabetically.

Using namespace declarations have been removed where not needed.

Signed-off-by: Henner Zeller <h.zeller@acm.org>