### PR TITLE
Include compilation unit header first and fix dependencies.

### DIFF
--- a/src/SourceCompile/SV3_1aPpTreeListenerHelper.cpp
+++ b/src/SourceCompile/SV3_1aPpTreeListenerHelper.cpp
@@ -20,33 +20,30 @@
  *
  * Created on December 4, 2019, 8:17 PM
  */
-
-#include "SourceCompile/SymbolTable.h"
-#include "CommandLine/CommandLineParser.h"
-#include "ErrorReporting/ErrorContainer.h"
-#include "SourceCompile/SymbolTable.h"
-#include "SourceCompile/CompilationUnit.h"
-#include "SourceCompile/PreprocessFile.h"
-#include "SourceCompile/CompileSourceFile.h"
-#include "SourceCompile/Compiler.h"
-#include "SourceCompile/PreprocessFile.h"
-#include "Utils/StringUtils.h"
+#include "SourceCompile/SV3_1aPpTreeListenerHelper.h"
 
 #include <cstdlib>
 #include <iostream>
 #include <regex>
 
-using namespace std;
-using namespace SURELOG;
+#include "CommandLine/CommandLineParser.h"
+#include "ErrorReporting/ErrorContainer.h"
+#include "SourceCompile/CompilationUnit.h"
+#include "SourceCompile/CompileSourceFile.h"
+#include "SourceCompile/Compiler.h"
+#include "SourceCompile/PreprocessFile.h"
+#include "SourceCompile/PreprocessFile.h"
+#include "SourceCompile/SymbolTable.h"
+#include "SourceCompile/SymbolTable.h"
+#include "Utils/FileUtils.h"
+#include "Utils/ParseUtils.h"
+#include "Utils/StringUtils.h"
 
 #include "parser/SV3_1aPpLexer.h"
 #include "parser/SV3_1aPpParser.h"
 #include "parser/SV3_1aPpParserBaseListener.h"
-using namespace antlr4;
-#include "Utils/ParseUtils.h"
-#include "Utils/FileUtils.h"
 
-#include "SV3_1aPpTreeListenerHelper.h"
+using namespace SURELOG;
 
 SV3_1aPpTreeListenerHelper::~SV3_1aPpTreeListenerHelper()
 {
@@ -56,8 +53,8 @@ SymbolId SV3_1aPpTreeListenerHelper::registerSymbol(const std::string &symbol) {
   return m_pp->getCompileSourceFile()->getSymbolTable()->registerSymbol(symbol);
 }
 
-std::tuple<unsigned int, unsigned short, unsigned int, unsigned short> SV3_1aPpTreeListenerHelper::getFileLine(ParserRuleContext* ctx,
-                                                SymbolId& fileId) {                                                
+std::tuple<unsigned int, unsigned short, unsigned int, unsigned short> SV3_1aPpTreeListenerHelper::getFileLine(antlr4::ParserRuleContext* ctx,
+                                                SymbolId& fileId) {
   std::pair<int, int> lineCol = ParseUtils::getLineColumn(m_tokens, ctx);
   std::pair<int, int> endLineCol = ParseUtils::getEndLineColumn(m_tokens, ctx);
   unsigned int line = 0;
@@ -127,7 +124,7 @@ void SV3_1aPpTreeListenerHelper::init() {
 
 
 void SV3_1aPpTreeListenerHelper::logError(ErrorDefinition::ErrorType error,
-                                         ParserRuleContext* ctx,
+                                          antlr4::ParserRuleContext* ctx,
                                          std::string object, bool printColumn) {
   if (m_instructions.m_mute) return;
   std::pair<int, int> lineCol =
@@ -169,7 +166,7 @@ void SV3_1aPpTreeListenerHelper::logError(ErrorDefinition::ErrorType error,
 }
 
 
-void SV3_1aPpTreeListenerHelper::forwardToParser(ParserRuleContext* ctx) {
+void SV3_1aPpTreeListenerHelper::forwardToParser(antlr4::ParserRuleContext* ctx) {
   if (m_inActiveBranch && (!m_inMacroDefinitionParsing) &&
       (!m_pp->getCompileSourceFile()
             ->getCommandLineParser()
@@ -182,7 +179,7 @@ void SV3_1aPpTreeListenerHelper::forwardToParser(ParserRuleContext* ctx) {
   }
 }
 
-void SV3_1aPpTreeListenerHelper::addLineFiller(ParserRuleContext* ctx) {
+void SV3_1aPpTreeListenerHelper::addLineFiller(antlr4::ParserRuleContext* ctx) {
   if (m_pp->isMacroBody())
     return;
   const std::string& text = ctx->getText();
@@ -193,7 +190,7 @@ void SV3_1aPpTreeListenerHelper::addLineFiller(ParserRuleContext* ctx) {
 }
 
 void SV3_1aPpTreeListenerHelper::checkMultiplyDefinedMacro(
-    const std::string &macroName, ParserRuleContext* ctx) {
+  const std::string &macroName, antlr4::ParserRuleContext* ctx) {
   std::set<PreprocessFile*> visited;
   MacroInfo* macroInf = m_pp->getMacro(macroName);
   if (macroInf) {

--- a/src/SourceCompile/SV3_1aTreeShapeHelper.cpp
+++ b/src/SourceCompile/SV3_1aTreeShapeHelper.cpp
@@ -20,31 +20,26 @@
  *
  * Created on June 25, 2017, 2:51 PM
  */
-
-#include "SourceCompile/SymbolTable.h"
-#include "CommandLine/CommandLineParser.h"
-#include "ErrorReporting/ErrorContainer.h"
-#include "SourceCompile/CompilationUnit.h"
-#include "SourceCompile/PreprocessFile.h"
-#include "SourceCompile/CompileSourceFile.h"
-#include "SourceCompile/Compiler.h"
-#include "SourceCompile/ParseFile.h"
+#include "SourceCompile/SV3_1aTreeShapeHelper.h"
 
 #include <cstdlib>
 #include <iostream>
-#include "antlr4-runtime.h"
-using namespace std;
-using namespace antlr4;
-using namespace SURELOG;
 
+#include "CommandLine/CommandLineParser.h"
+#include "ErrorReporting/ErrorContainer.h"
+#include "SourceCompile/CompilationUnit.h"
+#include "SourceCompile/CompileSourceFile.h"
+#include "SourceCompile/Compiler.h"
+#include "SourceCompile/ParseFile.h"
+#include "SourceCompile/PreprocessFile.h"
+#include "SourceCompile/SymbolTable.h"
+#include "Utils/ParseUtils.h"
+#include "antlr4-runtime.h"
 #include "parser/SV3_1aLexer.h"
 #include "parser/SV3_1aParser.h"
 #include "parser/SV3_1aParserBaseListener.h"
-#include "SourceCompile/SV3_1aTreeShapeHelper.h"
-using namespace antlr4;
-#include "Utils/ParseUtils.h"
-#include "SourceCompile/SV3_1aTreeShapeHelper.h"
 
+namespace SURELOG {
 SV3_1aTreeShapeHelper::SV3_1aTreeShapeHelper(ParseFile* pf,
                                              antlr4::CommonTokenStream* tokens,
                                              unsigned int lineOffset)
@@ -70,7 +65,7 @@ SV3_1aTreeShapeHelper::SV3_1aTreeShapeHelper(ParseLibraryDef* pf,
 SV3_1aTreeShapeHelper::~SV3_1aTreeShapeHelper() {}
 
 void SV3_1aTreeShapeHelper::logError(ErrorDefinition::ErrorType error,
-                                     ParserRuleContext* ctx, std::string object,
+                                     antlr4::ParserRuleContext* ctx, std::string object,
                                      bool printColumn) {
   std::pair<int, int> lineCol = ParseUtils::getLineColumn(m_tokens, ctx);
 
@@ -113,7 +108,7 @@ SymbolId SV3_1aTreeShapeHelper::registerSymbol(const std::string &symbol) {
 }
 
 void SV3_1aTreeShapeHelper::addNestedDesignElement(
-    ParserRuleContext* ctx, std::string name, DesignElement::ElemType elemtype,
+  antlr4::ParserRuleContext* ctx, std::string name, DesignElement::ElemType elemtype,
     VObjectType objtype) {
   SymbolId fileId;
   auto [line, column, endLine, endColumn] = getFileLine(ctx, fileId);
@@ -132,7 +127,7 @@ void SV3_1aTreeShapeHelper::addNestedDesignElement(
   m_nestedElements.push(m_currentElement);
 }
 
-void SV3_1aTreeShapeHelper::addDesignElement(ParserRuleContext* ctx,
+void SV3_1aTreeShapeHelper::addDesignElement(antlr4::ParserRuleContext* ctx,
                                              std::string name,
                                              DesignElement::ElemType elemtype,
                                              VObjectType objtype) {
@@ -147,7 +142,7 @@ void SV3_1aTreeShapeHelper::addDesignElement(ParserRuleContext* ctx,
   m_currentElement = &m_fileContent->getDesignElements().back();
 }
 
-std::tuple<unsigned int, unsigned short, unsigned int, unsigned short> SV3_1aTreeShapeHelper::getFileLine(ParserRuleContext* ctx,
+std::tuple<unsigned int, unsigned short, unsigned int, unsigned short> SV3_1aTreeShapeHelper::getFileLine(antlr4::ParserRuleContext* ctx,
                                                 SymbolId& fileId) {
   std::pair<int, int> lineCol = ParseUtils::getLineColumn(m_tokens, ctx);
   std::pair<int, int> endLineCol = ParseUtils::getEndLineColumn(m_tokens, ctx);
@@ -183,3 +178,4 @@ std::pair<double, TimeInfo::Unit> SV3_1aTreeShapeHelper::getTimeValue(
 
   return std::make_pair(actual_value, unit);
 }
+}  // namespace SURELOG

--- a/src/SourceCompile/SV3_1aTreeShapeListener.cpp
+++ b/src/SourceCompile/SV3_1aTreeShapeListener.cpp
@@ -20,37 +20,34 @@
  *
  * Created on April 16, 2017, 8:28 PM
  */
-
-#include "SourceCompile/SymbolTable.h"
-#include "CommandLine/CommandLineParser.h"
-#include "ErrorReporting/ErrorContainer.h"
-#include "SourceCompile/CompilationUnit.h"
-#include "SourceCompile/PreprocessFile.h"
-#include "SourceCompile/CompileSourceFile.h"
-#include "SourceCompile/Compiler.h"
-#include "SourceCompile/ParseFile.h"
-#include "Utils/StringUtils.h"
+#include "SourceCompile/SV3_1aTreeShapeListener.h"
 
 #include <cstdlib>
 #include <iostream>
 #include <regex>
+
+#include "CommandLine/CommandLineParser.h"
+#include "ErrorReporting/ErrorContainer.h"
+#include "SourceCompile/CompilationUnit.h"
+#include "SourceCompile/CompileSourceFile.h"
+#include "SourceCompile/Compiler.h"
+#include "SourceCompile/ParseFile.h"
+#include "SourceCompile/PreprocessFile.h"
+#include "SourceCompile/SymbolTable.h"
+#include "Utils/StringUtils.h"
 #include "antlr4-runtime.h"
 
-using namespace std;
-using namespace antlr4;
-using namespace SURELOG;
 
 #include "parser/SV3_1aLexer.h"
 #include "parser/SV3_1aParser.h"
 #include "parser/SV3_1aParserBaseListener.h"
-#include "parser/SV3_1aPpParserBaseListener.h"
 #include "Utils/ParseUtils.h"
 #include "Utils/FileUtils.h"
 #include "SourceCompile/SV3_1aPpTreeShapeListener.h"
-#include "SourceCompile/SV3_1aTreeShapeListener.h"
-#include "SourceCompile/SV3_1aTreeShapeHelper.h"
-using namespace antlr4;
 
+#include "SourceCompile/SV3_1aTreeShapeHelper.h"
+
+namespace SURELOG {
 void SV3_1aTreeShapeListener::enterTop_level_rule(
     SV3_1aParser::Top_level_ruleContext * /*ctx*/) {
   if (m_pf->getFileContent() == NULL) {
@@ -106,56 +103,56 @@ void SV3_1aTreeShapeListener::exitModule_declaration(
 
 void SV3_1aTreeShapeListener::exitClass_constructor_declaration(SV3_1aParser::Class_constructor_declarationContext * ctx) {
   if (ctx->ENDFUNCTION())
-    addVObject((ParserRuleContext*) ctx->ENDFUNCTION(), VObjectType::slEndfunction);
+    addVObject((antlr4::ParserRuleContext*) ctx->ENDFUNCTION(), VObjectType::slEndfunction);
   addVObject (ctx, VObjectType::slClass_constructor_declaration);
 }
 
 void SV3_1aTreeShapeListener::exitFunction_body_declaration(SV3_1aParser::Function_body_declarationContext * ctx) {
   if (ctx->ENDFUNCTION())
-    addVObject((ParserRuleContext*) ctx->ENDFUNCTION(), VObjectType::slEndfunction);
+    addVObject((antlr4::ParserRuleContext*) ctx->ENDFUNCTION(), VObjectType::slEndfunction);
   addVObject (ctx, VObjectType::slFunction_body_declaration);
 }
 
 void SV3_1aTreeShapeListener::exitTask_body_declaration(SV3_1aParser::Task_body_declarationContext * ctx) {
   if (ctx->ENDTASK())
-    addVObject((ParserRuleContext*) ctx->ENDTASK(), VObjectType::slEndtask);
+    addVObject((antlr4::ParserRuleContext*) ctx->ENDTASK(), VObjectType::slEndtask);
   addVObject (ctx, VObjectType::slTask_body_declaration);
 }
 
 void SV3_1aTreeShapeListener::exitJump_statement(SV3_1aParser::Jump_statementContext * ctx) {
   if (ctx->BREAK()) {
-    addVObject((ParserRuleContext*) ctx->BREAK(), VObjectType::slBreakStmt);
+    addVObject((antlr4::ParserRuleContext*) ctx->BREAK(), VObjectType::slBreakStmt);
   } else if (ctx->CONTINUE()) {
-    addVObject((ParserRuleContext*) ctx->CONTINUE(), VObjectType::slContinueStmt);
+    addVObject((antlr4::ParserRuleContext*) ctx->CONTINUE(), VObjectType::slContinueStmt);
   } else if (ctx->RETURN()) {
-    addVObject((ParserRuleContext*) ctx->RETURN(), VObjectType::slReturnStmt);
+    addVObject((antlr4::ParserRuleContext*) ctx->RETURN(), VObjectType::slReturnStmt);
   }
   addVObject (ctx, VObjectType::slJump_statement);
 }
 
 void SV3_1aTreeShapeListener::exitClass_declaration(SV3_1aParser::Class_declarationContext * ctx) {
   if (ctx->VIRTUAL())
-    addVObject ((ParserRuleContext*) ctx->VIRTUAL(), VObjectType::slVirtual);
+    addVObject ((antlr4::ParserRuleContext*) ctx->VIRTUAL(), VObjectType::slVirtual);
   if (ctx->IMPLEMENTS())
-    addVObject ((ParserRuleContext*) ctx->IMPLEMENTS(), VObjectType::slImplements);
+    addVObject ((antlr4::ParserRuleContext*) ctx->IMPLEMENTS(), VObjectType::slImplements);
   if (ctx->EXTENDS())
-    addVObject ((ParserRuleContext*) ctx->EXTENDS(), VObjectType::slExtends);
+    addVObject ((antlr4::ParserRuleContext*) ctx->EXTENDS(), VObjectType::slExtends);
   if (ctx->ENDCLASS())
-    addVObject ((ParserRuleContext*) ctx->ENDCLASS(), VObjectType::slEndclass);
+    addVObject ((antlr4::ParserRuleContext*) ctx->ENDCLASS(), VObjectType::slEndclass);
   addVObject (ctx, VObjectType::slClass_declaration);
 }
 
 void SV3_1aTreeShapeListener::exitInterface_class_declaration(SV3_1aParser::Interface_class_declarationContext * ctx)  {
   if (ctx->EXTENDS())
-    addVObject ((ParserRuleContext*) ctx->EXTENDS(), VObjectType::slExtends);
+    addVObject ((antlr4::ParserRuleContext*) ctx->EXTENDS(), VObjectType::slExtends);
   if (ctx->ENDCLASS())
-    addVObject ((ParserRuleContext*) ctx->ENDCLASS(), VObjectType::slEndclass);
+    addVObject ((antlr4::ParserRuleContext*) ctx->ENDCLASS(), VObjectType::slEndclass);
   addVObject (ctx, VObjectType::slInterface_class_declaration);
 }
 
 void SV3_1aTreeShapeListener::exitChecker_declaration(SV3_1aParser::Checker_declarationContext * ctx) {
   if (ctx->ENDCHECKER())
-    addVObject ((ParserRuleContext*) ctx->ENDCHECKER(), VObjectType::slEndchecker);
+    addVObject ((antlr4::ParserRuleContext*) ctx->ENDCHECKER(), VObjectType::slEndchecker);
   addVObject (ctx, VObjectType::slChecker_declaration);
 }
 
@@ -211,255 +208,255 @@ void SV3_1aTreeShapeListener::exitInterface_declaration(
     SV3_1aParser::Interface_declarationContext *ctx) {
   if (ctx->EXTERN() == NULL)
     if (ctx->ENDINTERFACE())
-      addVObject ((ParserRuleContext*) ctx->ENDINTERFACE(), VObjectType::slEndinterface);
+      addVObject ((antlr4::ParserRuleContext*) ctx->ENDINTERFACE(), VObjectType::slEndinterface);
   addVObject(ctx, VObjectType::slInterface_declaration);
   m_nestedElements.pop();
 }
 
 void SV3_1aTreeShapeListener::exitProperty_expr(SV3_1aParser::Property_exprContext * ctx) {
   if (ctx->CASE()) {
-    addVObject ((ParserRuleContext*) ctx->CASE(), VObjectType::slCase);
+    addVObject ((antlr4::ParserRuleContext*) ctx->CASE(), VObjectType::slCase);
   }
   if (ctx->ENDCASE()) {
-    addVObject ((ParserRuleContext*) ctx->ENDCASE(), VObjectType::slEndcase);
+    addVObject ((antlr4::ParserRuleContext*) ctx->ENDCASE(), VObjectType::slEndcase);
   } else if (ctx->OR()) {
-    addVObject ((ParserRuleContext*) ctx->OR(), VObjectType::slOR);
+    addVObject ((antlr4::ParserRuleContext*) ctx->OR(), VObjectType::slOR);
   } else if (ctx->AND()) {
-    addVObject ((ParserRuleContext*) ctx->AND(), VObjectType::slAND);
+    addVObject ((antlr4::ParserRuleContext*) ctx->AND(), VObjectType::slAND);
   } else if (ctx->IF()) {
-    addVObject ((ParserRuleContext*) ctx->IF(), VObjectType::slIF);
+    addVObject ((antlr4::ParserRuleContext*) ctx->IF(), VObjectType::slIF);
   } else if (ctx->STRONG()) {
-    addVObject ((ParserRuleContext*) ctx->STRONG(), VObjectType::slSTRONG);
+    addVObject ((antlr4::ParserRuleContext*) ctx->STRONG(), VObjectType::slSTRONG);
   } else if (ctx->WEAK()) {
-    addVObject ((ParserRuleContext*) ctx->WEAK(), VObjectType::slWEAK);
+    addVObject ((antlr4::ParserRuleContext*) ctx->WEAK(), VObjectType::slWEAK);
   } else if (ctx->NOT()) {
-    addVObject ((ParserRuleContext*) ctx->NOT(), VObjectType::slNOT);
+    addVObject ((antlr4::ParserRuleContext*) ctx->NOT(), VObjectType::slNOT);
   } else if (ctx->OVERLAP_IMPLY()) {
-    addVObject ((ParserRuleContext*) ctx->OVERLAP_IMPLY(), VObjectType::slOVERLAP_IMPLY);
+    addVObject ((antlr4::ParserRuleContext*) ctx->OVERLAP_IMPLY(), VObjectType::slOVERLAP_IMPLY);
   } else if (ctx->NON_OVERLAP_IMPLY()) {
-    addVObject ((ParserRuleContext*) ctx->NON_OVERLAP_IMPLY(), VObjectType::slNON_OVERLAP_IMPLY);
+    addVObject ((antlr4::ParserRuleContext*) ctx->NON_OVERLAP_IMPLY(), VObjectType::slNON_OVERLAP_IMPLY);
   } else if (ctx->OVERLAPPED()) {
-    addVObject ((ParserRuleContext*) ctx->OVERLAPPED(), VObjectType::slOVERLAPPED);
+    addVObject ((antlr4::ParserRuleContext*) ctx->OVERLAPPED(), VObjectType::slOVERLAPPED);
   } else if (ctx->NONOVERLAPPED()) {
-    addVObject ((ParserRuleContext*) ctx->NONOVERLAPPED(), VObjectType::slNONOVERLAPPED);
+    addVObject ((antlr4::ParserRuleContext*) ctx->NONOVERLAPPED(), VObjectType::slNONOVERLAPPED);
   } else if (ctx->S_NEXTTIME()) {
-    addVObject ((ParserRuleContext*) ctx->S_NEXTTIME(), VObjectType::slS_NEXTTIME);
+    addVObject ((antlr4::ParserRuleContext*) ctx->S_NEXTTIME(), VObjectType::slS_NEXTTIME);
   } else if (ctx->ALWAYS()) {
-    addVObject ((ParserRuleContext*) ctx->ALWAYS(), VObjectType::slALWAYS);
+    addVObject ((antlr4::ParserRuleContext*) ctx->ALWAYS(), VObjectType::slALWAYS);
   } else if (ctx->S_ALWAYS()) {
-    addVObject ((ParserRuleContext*) ctx->S_ALWAYS(), VObjectType::slS_ALWAYS);
+    addVObject ((antlr4::ParserRuleContext*) ctx->S_ALWAYS(), VObjectType::slS_ALWAYS);
   } else if (ctx->S_EVENTUALLY()) {
-    addVObject ((ParserRuleContext*) ctx->S_EVENTUALLY(), VObjectType::slS_EVENTUALLY);
+    addVObject ((antlr4::ParserRuleContext*) ctx->S_EVENTUALLY(), VObjectType::slS_EVENTUALLY);
   } else if (ctx->EVENTUALLY()) {
-    addVObject ((ParserRuleContext*) ctx->EVENTUALLY(), VObjectType::slEVENTUALLY);
+    addVObject ((antlr4::ParserRuleContext*) ctx->EVENTUALLY(), VObjectType::slEVENTUALLY);
   } else if (ctx->UNTIL()) {
-    addVObject ((ParserRuleContext*) ctx->UNTIL(), VObjectType::slUNTIL);
+    addVObject ((antlr4::ParserRuleContext*) ctx->UNTIL(), VObjectType::slUNTIL);
   } else if (ctx->S_UNTIL()) {
-    addVObject ((ParserRuleContext*) ctx->S_UNTIL(), VObjectType::slS_UNTIL);
+    addVObject ((antlr4::ParserRuleContext*) ctx->S_UNTIL(), VObjectType::slS_UNTIL);
   } else if (ctx->IMPLIES()) {
-    addVObject ((ParserRuleContext*) ctx->IMPLIES(), VObjectType::slIMPLIES);
+    addVObject ((antlr4::ParserRuleContext*) ctx->IMPLIES(), VObjectType::slIMPLIES);
   } else if (ctx->IFF()) {
-    addVObject ((ParserRuleContext*) ctx->IFF(), VObjectType::slIFF);
+    addVObject ((antlr4::ParserRuleContext*) ctx->IFF(), VObjectType::slIFF);
   } else if (ctx->ACCEPT_ON()) {
-    addVObject ((ParserRuleContext*) ctx->ACCEPT_ON(), VObjectType::slACCEPT_ON);
+    addVObject ((antlr4::ParserRuleContext*) ctx->ACCEPT_ON(), VObjectType::slACCEPT_ON);
   } else if (ctx->REJECT_ON()) {
-    addVObject ((ParserRuleContext*) ctx->REJECT_ON(), VObjectType::slREJECT_ON);
+    addVObject ((antlr4::ParserRuleContext*) ctx->REJECT_ON(), VObjectType::slREJECT_ON);
   } else if (ctx->SYNC_ACCEPT_ON()) {
-    addVObject ((ParserRuleContext*) ctx->SYNC_ACCEPT_ON(), VObjectType::slSYNC_ACCEPT_ON);
+    addVObject ((antlr4::ParserRuleContext*) ctx->SYNC_ACCEPT_ON(), VObjectType::slSYNC_ACCEPT_ON);
   } else if (ctx->SYNC_REJECT_ON()) {
-    addVObject ((ParserRuleContext*) ctx->SYNC_REJECT_ON(), VObjectType::slSYNC_REJECT_ON);
-  }       
+    addVObject ((antlr4::ParserRuleContext*) ctx->SYNC_REJECT_ON(), VObjectType::slSYNC_REJECT_ON);
+  }
   addVObject (ctx, VObjectType::slProperty_expr);
 }
 
 void SV3_1aTreeShapeListener::exitGenerate_module_case_statement(SV3_1aParser::Generate_module_case_statementContext * ctx) {
   if (ctx->ENDCASE())
-    addVObject ((ParserRuleContext*) ctx->ENDCASE(), VObjectType::slEndcase);
+    addVObject ((antlr4::ParserRuleContext*) ctx->ENDCASE(), VObjectType::slEndcase);
   addVObject (ctx, VObjectType::slGenerate_module_case_statement);
 }
 
 void SV3_1aTreeShapeListener::exitGenerate_interface_case_statement(SV3_1aParser::Generate_interface_case_statementContext * ctx) {
   if (ctx->ENDCASE())
-    addVObject ((ParserRuleContext*) ctx->ENDCASE(), VObjectType::slEndcase);
+    addVObject ((antlr4::ParserRuleContext*) ctx->ENDCASE(), VObjectType::slEndcase);
   addVObject (ctx, VObjectType::slGenerate_interface_case_statement);
 }
 
 void SV3_1aTreeShapeListener::exitCase_generate_construct(SV3_1aParser::Case_generate_constructContext * ctx) {
   if (ctx->ENDCASE())
-    addVObject ((ParserRuleContext*) ctx->ENDCASE(), VObjectType::slEndcase);
+    addVObject ((antlr4::ParserRuleContext*) ctx->ENDCASE(), VObjectType::slEndcase);
   addVObject (ctx, VObjectType::slCase_generate_construct);
 }
 
 void SV3_1aTreeShapeListener::exitCase_statement(SV3_1aParser::Case_statementContext * ctx) {
   if (ctx->ENDCASE())
-    addVObject ((ParserRuleContext*) ctx->ENDCASE(), VObjectType::slEndcase);
+    addVObject ((antlr4::ParserRuleContext*) ctx->ENDCASE(), VObjectType::slEndcase);
   addVObject (ctx, VObjectType::slCase_statement);
 }
 
 void SV3_1aTreeShapeListener::exitRandcase_statement(SV3_1aParser::Randcase_statementContext * ctx) {
   if (ctx->ENDCASE())
-    addVObject ((ParserRuleContext*) ctx->ENDCASE(), VObjectType::slEndcase);
+    addVObject ((antlr4::ParserRuleContext*) ctx->ENDCASE(), VObjectType::slEndcase);
   addVObject (ctx, VObjectType::slRandcase_statement);
 }
 
 void SV3_1aTreeShapeListener::exitRs_case(SV3_1aParser::Rs_caseContext * ctx) {
   if (ctx->ENDCASE())
-    addVObject ((ParserRuleContext*) ctx->ENDCASE(), VObjectType::slEndcase);
+    addVObject ((antlr4::ParserRuleContext*) ctx->ENDCASE(), VObjectType::slEndcase);
   addVObject (ctx, VObjectType::slRs_case);
 }
 
 void SV3_1aTreeShapeListener::exitSequence_declaration(SV3_1aParser::Sequence_declarationContext * ctx) {
   if (ctx->ENDSEQUENCE())
-    addVObject ((ParserRuleContext*) ctx->ENDSEQUENCE(), VObjectType::slEndsequence);
+    addVObject ((antlr4::ParserRuleContext*) ctx->ENDSEQUENCE(), VObjectType::slEndsequence);
   addVObject (ctx, VObjectType::slSequence_declaration);
 }
 
 void SV3_1aTreeShapeListener::exitRandsequence_statement(SV3_1aParser::Randsequence_statementContext * ctx) {
   if (ctx->ENDSEQUENCE())
-    addVObject ((ParserRuleContext*) ctx->ENDSEQUENCE(), VObjectType::slEndsequence);
+    addVObject ((antlr4::ParserRuleContext*) ctx->ENDSEQUENCE(), VObjectType::slEndsequence);
   addVObject (ctx, VObjectType::slRandsequence_statement);
 }
 
 void SV3_1aTreeShapeListener::exitSeq_block(SV3_1aParser::Seq_blockContext * ctx) {
   if (ctx->END())
-    addVObject ((ParserRuleContext*) ctx->END(), VObjectType::slEnd);
+    addVObject ((antlr4::ParserRuleContext*) ctx->END(), VObjectType::slEnd);
   addVObject (ctx, VObjectType::slSeq_block);
 }
 
 
 void SV3_1aTreeShapeListener::exitGenerate_module_named_block(SV3_1aParser::Generate_module_named_blockContext * ctx) {
   if (ctx->END())
-    addVObject ((ParserRuleContext*) ctx->END(), VObjectType::slEnd);
+    addVObject ((antlr4::ParserRuleContext*) ctx->END(), VObjectType::slEnd);
   addVObject (ctx, VObjectType::slGenerate_module_named_block);
 }
 
 void SV3_1aTreeShapeListener::exitGenerate_module_block(SV3_1aParser::Generate_module_blockContext * ctx) {
   if (ctx->END())
-    addVObject ((ParserRuleContext*) ctx->END(), VObjectType::slEnd);
+    addVObject ((antlr4::ParserRuleContext*) ctx->END(), VObjectType::slEnd);
   addVObject (ctx, VObjectType::slGenerate_module_block);
 }
 
 void SV3_1aTreeShapeListener::exitGenerate_interface_named_block(SV3_1aParser::Generate_interface_named_blockContext * ctx)  {
   if (ctx->END())
-    addVObject ((ParserRuleContext*) ctx->END(), VObjectType::slEnd);
+    addVObject ((antlr4::ParserRuleContext*) ctx->END(), VObjectType::slEnd);
   addVObject (ctx, VObjectType::slGenerate_interface_named_block);
 }
 
 void SV3_1aTreeShapeListener::exitGenerate_interface_block(SV3_1aParser::Generate_interface_blockContext * ctx) {
   if (ctx->END())
-    addVObject ((ParserRuleContext*) ctx->END(), VObjectType::slEnd);
+    addVObject ((antlr4::ParserRuleContext*) ctx->END(), VObjectType::slEnd);
   addVObject (ctx, VObjectType::slGenerate_interface_block);
 }
 
 void SV3_1aTreeShapeListener::exitGenerate_block(SV3_1aParser::Generate_blockContext * ctx) {
   if (ctx->END())
-    addVObject ((ParserRuleContext*) ctx->END(), VObjectType::slEnd);
+    addVObject ((antlr4::ParserRuleContext*) ctx->END(), VObjectType::slEnd);
   addVObject (ctx, VObjectType::slGenerate_block);
 }
 
 void SV3_1aTreeShapeListener::exitNamed_port_connection(SV3_1aParser::Named_port_connectionContext * ctx) {
   if (ctx->DOTSTAR())
-    addVObject ((ParserRuleContext*) ctx->DOTSTAR(), VObjectType::slDotStar);
+    addVObject ((antlr4::ParserRuleContext*) ctx->DOTSTAR(), VObjectType::slDotStar);
   if (ctx->OPEN_PARENS())
-    addVObject ((ParserRuleContext*) ctx->OPEN_PARENS(), VObjectType::slOpenParens);
+    addVObject ((antlr4::ParserRuleContext*) ctx->OPEN_PARENS(), VObjectType::slOpenParens);
   if (ctx->CLOSE_PARENS())
-    addVObject ((ParserRuleContext*) ctx->CLOSE_PARENS(), VObjectType::slCloseParens);  
+    addVObject ((antlr4::ParserRuleContext*) ctx->CLOSE_PARENS(), VObjectType::slCloseParens);
   addVObject (ctx, VObjectType::slNamed_port_connection);
 }
 
 void SV3_1aTreeShapeListener::exitPattern(SV3_1aParser::PatternContext * ctx) {
   if (ctx->DOT())
-    addVObject ((ParserRuleContext*) ctx->DOT(), VObjectType::slDot);
+    addVObject ((antlr4::ParserRuleContext*) ctx->DOT(), VObjectType::slDot);
   else if (ctx->DOTSTAR())
-    addVObject ((ParserRuleContext*) ctx->DOTSTAR(), VObjectType::slDotStar);
+    addVObject ((antlr4::ParserRuleContext*) ctx->DOTSTAR(), VObjectType::slDotStar);
   else if (ctx->TAGGED())
-    addVObject ((ParserRuleContext*) ctx->TAGGED(), VObjectType::slTagged);
- 
+    addVObject ((antlr4::ParserRuleContext*) ctx->TAGGED(), VObjectType::slTagged);
+
   addVObject (ctx, VObjectType::slPattern);
 }
 
 void SV3_1aTreeShapeListener::exitSpecify_block(SV3_1aParser::Specify_blockContext * ctx) {
   if (ctx->ENDSPECIFY())
-    addVObject ((ParserRuleContext*) ctx->ENDSPECIFY(), VObjectType::slEndspecify);
+    addVObject ((antlr4::ParserRuleContext*) ctx->ENDSPECIFY(), VObjectType::slEndspecify);
   addVObject (ctx, VObjectType::slSpecify_block);
 }
 
 void SV3_1aTreeShapeListener::exitConfig_declaration(SV3_1aParser::Config_declarationContext * ctx) {
   if (ctx->ENDCONFIG())
-    addVObject ((ParserRuleContext*) ctx->ENDCONFIG(), VObjectType::slEndconfig);
+    addVObject ((antlr4::ParserRuleContext*) ctx->ENDCONFIG(), VObjectType::slEndconfig);
   addVObject (ctx, VObjectType::slConfig_declaration);
 }
 
 
 void SV3_1aTreeShapeListener::exitDpi_import_export(SV3_1aParser::Dpi_import_exportContext * ctx) {
   if (ctx->IMPORT())
-    addVObject ((ParserRuleContext*) ctx->IMPORT(), VObjectType::slImport);
+    addVObject ((antlr4::ParserRuleContext*) ctx->IMPORT(), VObjectType::slImport);
   if (ctx->EXPORT())
-    addVObject ((ParserRuleContext*) ctx->EXPORT(), VObjectType::slExport);
+    addVObject ((antlr4::ParserRuleContext*) ctx->EXPORT(), VObjectType::slExport);
   addVObject (ctx, VObjectType::slDpi_import_export);
 }
 
 void SV3_1aTreeShapeListener::exitProperty_declaration(SV3_1aParser::Property_declarationContext * ctx) {
   if (ctx->ENDPROPERTY())
-    addVObject ((ParserRuleContext*) ctx->ENDPROPERTY(), VObjectType::slEndproperty);
+    addVObject ((antlr4::ParserRuleContext*) ctx->ENDPROPERTY(), VObjectType::slEndproperty);
   addVObject (ctx, VObjectType::slProperty_declaration);
 }
 
 void SV3_1aTreeShapeListener::exitCovergroup_declaration(SV3_1aParser::Covergroup_declarationContext * ctx) {
   if (ctx->ENDGROUP())
-    addVObject ((ParserRuleContext*) ctx->ENDGROUP(), VObjectType::slEndgroup);
+    addVObject ((antlr4::ParserRuleContext*) ctx->ENDGROUP(), VObjectType::slEndgroup);
   addVObject (ctx, VObjectType::slCovergroup_declaration);
 }
 
 void SV3_1aTreeShapeListener::exitGenerated_module_instantiation(SV3_1aParser::Generated_module_instantiationContext * ctx) {
  if (ctx->ENDGENERATE())
-    addVObject ((ParserRuleContext*) ctx->ENDGENERATE(), VObjectType::slEndgenerate);
+    addVObject ((antlr4::ParserRuleContext*) ctx->ENDGENERATE(), VObjectType::slEndgenerate);
   addVObject (ctx, VObjectType::slGenerated_module_instantiation);
 }
 
 void SV3_1aTreeShapeListener::exitGenerated_interface_instantiation(SV3_1aParser::Generated_interface_instantiationContext * ctx)  {
   if (ctx->ENDGENERATE())
-    addVObject ((ParserRuleContext*) ctx->ENDGENERATE(), VObjectType::slEndgenerate);
+    addVObject ((antlr4::ParserRuleContext*) ctx->ENDGENERATE(), VObjectType::slEndgenerate);
   addVObject (ctx, VObjectType::slGenerated_interface_instantiation);
 }
 
 void SV3_1aTreeShapeListener::exitGenerate_region(SV3_1aParser::Generate_regionContext * ctx) {
   if (ctx->ENDGENERATE())
-    addVObject ((ParserRuleContext*) ctx->ENDGENERATE(), VObjectType::slEndgenerate);
+    addVObject ((antlr4::ParserRuleContext*) ctx->ENDGENERATE(), VObjectType::slEndgenerate);
   addVObject (ctx, VObjectType::slGenerate_region);
 }
 
 void SV3_1aTreeShapeListener::exitUdp_declaration(SV3_1aParser::Udp_declarationContext * ctx) {
   if (ctx->ENDPRIMITIVE())
-    addVObject ((ParserRuleContext*) ctx->ENDPRIMITIVE(), VObjectType::slEndprimitive);
+    addVObject ((antlr4::ParserRuleContext*) ctx->ENDPRIMITIVE(), VObjectType::slEndprimitive);
   addVObject (ctx, VObjectType::slUdp_declaration);
 }
 
 void SV3_1aTreeShapeListener::exitCombinational_body(SV3_1aParser::Combinational_bodyContext * ctx) {
   if (ctx->ENDTABLE())
-    addVObject ((ParserRuleContext*) ctx->ENDTABLE(), VObjectType::slEndtable);
+    addVObject ((antlr4::ParserRuleContext*) ctx->ENDTABLE(), VObjectType::slEndtable);
   addVObject (ctx, VObjectType::slCombinational_body);
 }
 
 void SV3_1aTreeShapeListener::exitSequential_body(SV3_1aParser::Sequential_bodyContext * ctx) {
   if (ctx->ENDTABLE())
-    addVObject ((ParserRuleContext*) ctx->ENDTABLE(), VObjectType::slEndtable);
+    addVObject ((antlr4::ParserRuleContext*) ctx->ENDTABLE(), VObjectType::slEndtable);
   addVObject (ctx, VObjectType::slSequential_body);
 }
 
 void SV3_1aTreeShapeListener::exitClocking_declaration(SV3_1aParser::Clocking_declarationContext * ctx) {
   if (ctx->DEFAULT())
-    addVObject ((ParserRuleContext*) ctx->DEFAULT(), VObjectType::slDefault);
+    addVObject ((antlr4::ParserRuleContext*) ctx->DEFAULT(), VObjectType::slDefault);
   if (ctx->GLOBAL())
-    addVObject ((ParserRuleContext*) ctx->GLOBAL(), VObjectType::slGlobal);
+    addVObject ((antlr4::ParserRuleContext*) ctx->GLOBAL(), VObjectType::slGlobal);
   if (ctx->ENDCLOCKING())
-    addVObject ((ParserRuleContext*) ctx->ENDCLOCKING(), VObjectType::slEndclocking);
+    addVObject ((antlr4::ParserRuleContext*) ctx->ENDCLOCKING(), VObjectType::slEndclocking);
   addVObject (ctx, VObjectType::slClocking_declaration);
 }
 
 void SV3_1aTreeShapeListener::exitPackage_declaration(SV3_1aParser::Package_declarationContext * ctx)  {
   if (ctx->ENDPACKAGE())
-    addVObject ((ParserRuleContext*) ctx->ENDPACKAGE(), VObjectType::slEndpackage);
+    addVObject ((antlr4::ParserRuleContext*) ctx->ENDPACKAGE(), VObjectType::slEndpackage);
   addVObject (ctx, VObjectType::slPackage_declaration);
 }
 
@@ -726,22 +723,22 @@ void SV3_1aTreeShapeListener::exitIdentifier(
 
 void SV3_1aTreeShapeListener::exitUnique_priority(SV3_1aParser::Unique_priorityContext * ctx) {
   if (ctx->PRIORITY()) {
-    addVObject((ParserRuleContext *)ctx->PRIORITY(), VObjectType::slPriority);
+    addVObject((antlr4::ParserRuleContext *)ctx->PRIORITY(), VObjectType::slPriority);
   } else if (ctx->UNIQUE()) {
-    addVObject((ParserRuleContext *)ctx->UNIQUE(), VObjectType::slUnique);
+    addVObject((antlr4::ParserRuleContext *)ctx->UNIQUE(), VObjectType::slUnique);
   } else if (ctx->UNIQUE0()) {
-    addVObject((ParserRuleContext *)ctx->UNIQUE0(), VObjectType::slUnique0);
+    addVObject((antlr4::ParserRuleContext *)ctx->UNIQUE0(), VObjectType::slUnique0);
   }
   addVObject (ctx, VObjectType::slUnique_priority);
 }
 
 void SV3_1aTreeShapeListener::exitCase_keyword(SV3_1aParser::Case_keywordContext * ctx) {
   if (ctx->CASE()) {
-    addVObject((ParserRuleContext *)ctx->CASE(), VObjectType::slCase);
+    addVObject((antlr4::ParserRuleContext *)ctx->CASE(), VObjectType::slCase);
   } else  if (ctx->CASEX()) {
-    addVObject((ParserRuleContext *)ctx->CASEX(), VObjectType::slCaseX);
+    addVObject((antlr4::ParserRuleContext *)ctx->CASEX(), VObjectType::slCaseX);
   } else  if (ctx->CASEZ()) {
-    addVObject((ParserRuleContext *)ctx->CASEZ(), VObjectType::slCaseZ);
+    addVObject((antlr4::ParserRuleContext *)ctx->CASEZ(), VObjectType::slCaseZ);
   }
   addVObject (ctx, VObjectType::slCase_keyword);
 }
@@ -767,43 +764,43 @@ void SV3_1aTreeShapeListener::exitPart_select_op(SV3_1aParser::Part_select_opCon
 void SV3_1aTreeShapeListener::exitSystem_task_names(SV3_1aParser::System_task_namesContext * ctx) {
   std::string ident = ctx->getText();
   if (ctx->TIME())
-    addVObject((ParserRuleContext *)ctx->TIME(), ident, VObjectType::slStringConst);
+    addVObject((antlr4::ParserRuleContext *)ctx->TIME(), ident, VObjectType::slStringConst);
   else if (ctx->REALTIME())
-    addVObject((ParserRuleContext *)ctx->REALTIME(), ident, VObjectType::slStringConst);
+    addVObject((antlr4::ParserRuleContext *)ctx->REALTIME(), ident, VObjectType::slStringConst);
   else if (ctx->ASSERT())
-    addVObject((ParserRuleContext *)ctx->ASSERT(), ident, VObjectType::slStringConst);
+    addVObject((antlr4::ParserRuleContext *)ctx->ASSERT(), ident, VObjectType::slStringConst);
   else if (ctx->Simple_identifier().size())
-    addVObject((ParserRuleContext *)ctx->Simple_identifier()[0], ident, VObjectType::slStringConst);
+    addVObject((antlr4::ParserRuleContext *)ctx->Simple_identifier()[0], ident, VObjectType::slStringConst);
   else if (ctx->SIGNED())
-    addVObject((ParserRuleContext *)ctx->SIGNED(), ident, VObjectType::slStringConst);
+    addVObject((antlr4::ParserRuleContext *)ctx->SIGNED(), ident, VObjectType::slStringConst);
   else if (ctx->UNSIGNED())
-    addVObject((ParserRuleContext *)ctx->UNSIGNED(), ident, VObjectType::slStringConst);
+    addVObject((antlr4::ParserRuleContext *)ctx->UNSIGNED(), ident, VObjectType::slStringConst);
   addVObject(ctx, VObjectType::slSystem_task_names);
 }
 
 void SV3_1aTreeShapeListener::exitClass_type(
     SV3_1aParser::Class_typeContext *ctx) {
   std::string ident;
-  ParserRuleContext *childCtx = NULL;
+  antlr4::ParserRuleContext *childCtx = NULL;
   if (ctx->Simple_identifier()) {
-    childCtx = (ParserRuleContext *)ctx->Simple_identifier();
+    childCtx = (antlr4::ParserRuleContext *)ctx->Simple_identifier();
     ident = ctx->Simple_identifier()->getText();
   } else if (ctx->Escaped_identifier()) {
-    childCtx = (ParserRuleContext *)ctx->Escaped_identifier();
+    childCtx = (antlr4::ParserRuleContext *)ctx->Escaped_identifier();
     ident = ctx->Escaped_identifier()->getText();
     ident.erase(0, 3);
     ident.erase(ident.size() - 3, 3);
   } else if (ctx->THIS()) {
-    childCtx = (ParserRuleContext *)ctx->THIS();
+    childCtx = (antlr4::ParserRuleContext *)ctx->THIS();
     ident = ctx->THIS()->getText();
   } else if (ctx->RANDOMIZE()) {
-    childCtx = (ParserRuleContext *)ctx->RANDOMIZE();
+    childCtx = (antlr4::ParserRuleContext *)ctx->RANDOMIZE();
     ident = ctx->RANDOMIZE()->getText();
   } else if (ctx->SAMPLE()) {
-    childCtx = (ParserRuleContext *)ctx->SAMPLE();
+    childCtx = (antlr4::ParserRuleContext *)ctx->SAMPLE();
     ident = ctx->SAMPLE()->getText();
   } else if (ctx->DOLLAR_UNIT()) {
-    childCtx = (ParserRuleContext *)ctx->DOLLAR_UNIT();
+    childCtx = (antlr4::ParserRuleContext *)ctx->DOLLAR_UNIT();
     ident = ctx->DOLLAR_UNIT()->getText();
   }
   addVObject(childCtx, ident, VObjectType::slStringConst);
@@ -817,12 +814,12 @@ void SV3_1aTreeShapeListener::exitClass_type(
 void SV3_1aTreeShapeListener::exitHierarchical_identifier(
     SV3_1aParser::Hierarchical_identifierContext *ctx) {
   std::string ident;
-  ParserRuleContext *childCtx = NULL;
+  antlr4::ParserRuleContext *childCtx = NULL;
   if (ctx->dollar_root_keyword()) {
-    childCtx = (ParserRuleContext *)ctx->children[1];
+    childCtx = (antlr4::ParserRuleContext *)ctx->children[1];
     ident = ctx->getText();
   } else {
-    childCtx = (ParserRuleContext *)ctx->children[0];
+    childCtx = (antlr4::ParserRuleContext *)ctx->children[0];
     ident = ctx->getText();
   }
   ident = std::regex_replace(ident, std::regex(EscapeSequence), "");
@@ -848,66 +845,66 @@ void SV3_1aTreeShapeListener::exitFile_path_spec(
 
 void SV3_1aTreeShapeListener::exitAnonymous_program(SV3_1aParser::Anonymous_programContext * ctx)  {
   if (ctx->ENDPROGRAM())
-    addVObject ((ParserRuleContext*)ctx->ENDPROGRAM(), VObjectType::slEndprogram);
+    addVObject ((antlr4::ParserRuleContext*)ctx->ENDPROGRAM(), VObjectType::slEndprogram);
   addVObject (ctx, VObjectType::slAnonymous_program);
 }
 
 void SV3_1aTreeShapeListener::exitProgram_declaration(SV3_1aParser::Program_declarationContext * ctx) {
   if (ctx->ENDPROGRAM())
-    addVObject ((ParserRuleContext*)ctx->ENDPROGRAM(), VObjectType::slEndprogram);
+    addVObject ((antlr4::ParserRuleContext*)ctx->ENDPROGRAM(), VObjectType::slEndprogram);
   addVObject (ctx, VObjectType::slProgram_declaration);
 }
 
 void SV3_1aTreeShapeListener::exitProcedural_continuous_assignment(SV3_1aParser::Procedural_continuous_assignmentContext * ctx) {
   if (ctx->ASSIGN()) {
-    addVObject ((ParserRuleContext*)ctx->ASSIGN(), VObjectType::slAssign);
+    addVObject ((antlr4::ParserRuleContext*)ctx->ASSIGN(), VObjectType::slAssign);
   } else if (ctx->DEASSIGN()) {
-    addVObject ((ParserRuleContext*)ctx->DEASSIGN(), VObjectType::slDeassign);
+    addVObject ((antlr4::ParserRuleContext*)ctx->DEASSIGN(), VObjectType::slDeassign);
   } else if (ctx->FORCE()) {
-    addVObject ((ParserRuleContext*)ctx->FORCE(), VObjectType::slForce);
+    addVObject ((antlr4::ParserRuleContext*)ctx->FORCE(), VObjectType::slForce);
   } else if (ctx->RELEASE()) {
-    addVObject ((ParserRuleContext*)ctx->RELEASE(), VObjectType::slRelease);
+    addVObject ((antlr4::ParserRuleContext*)ctx->RELEASE(), VObjectType::slRelease);
   }
   addVObject (ctx, VObjectType::slProcedural_continuous_assignment);
 }
 
 void SV3_1aTreeShapeListener::exitDrive_strength(SV3_1aParser::Drive_strengthContext * ctx)  {
   if (ctx->SUPPLY0()) {
-    addVObject ((ParserRuleContext*)ctx->SUPPLY0(), VObjectType::slSupply0);
+    addVObject ((antlr4::ParserRuleContext*)ctx->SUPPLY0(), VObjectType::slSupply0);
   } else if (ctx->STRONG0()) {
-    addVObject ((ParserRuleContext*)ctx->STRONG0(), VObjectType::slStrong0);
+    addVObject ((antlr4::ParserRuleContext*)ctx->STRONG0(), VObjectType::slStrong0);
   } else if (ctx->PULL0()) {
-    addVObject ((ParserRuleContext*)ctx->PULL0(), VObjectType::slPull0);
+    addVObject ((antlr4::ParserRuleContext*)ctx->PULL0(), VObjectType::slPull0);
   } else if (ctx->WEAK0()) {
-    addVObject ((ParserRuleContext*)ctx->WEAK0(), VObjectType::slWeak0);
+    addVObject ((antlr4::ParserRuleContext*)ctx->WEAK0(), VObjectType::slWeak0);
   }
   if (ctx->SUPPLY1()) {
-    addVObject ((ParserRuleContext*)ctx->SUPPLY1(), VObjectType::slSupply1);
+    addVObject ((antlr4::ParserRuleContext*)ctx->SUPPLY1(), VObjectType::slSupply1);
   } else if (ctx->STRONG1()) {
-    addVObject ((ParserRuleContext*)ctx->STRONG1(), VObjectType::slStrong1);
+    addVObject ((antlr4::ParserRuleContext*)ctx->STRONG1(), VObjectType::slStrong1);
   } else if (ctx->PULL1()) {
-    addVObject ((ParserRuleContext*)ctx->PULL1(), VObjectType::slPull1);
+    addVObject ((antlr4::ParserRuleContext*)ctx->PULL1(), VObjectType::slPull1);
   } else if (ctx->WEAK1()) {
-    addVObject ((ParserRuleContext*)ctx->WEAK1(), VObjectType::slWeak1);
+    addVObject ((antlr4::ParserRuleContext*)ctx->WEAK1(), VObjectType::slWeak1);
   }
 
   if (ctx->HIGHZ0()) {
-    addVObject ((ParserRuleContext*)ctx->HIGHZ0(), VObjectType::slHighZ0);
+    addVObject ((antlr4::ParserRuleContext*)ctx->HIGHZ0(), VObjectType::slHighZ0);
   } else if (ctx->HIGHZ1()) {
-    addVObject ((ParserRuleContext*)ctx->HIGHZ1(), VObjectType::slHighZ1);
+    addVObject ((antlr4::ParserRuleContext*)ctx->HIGHZ1(), VObjectType::slHighZ1);
   }
   addVObject (ctx, VObjectType::slDrive_strength);
 }
 
 void SV3_1aTreeShapeListener::exitStrength0(SV3_1aParser::Strength0Context * ctx)  {
   if (ctx->SUPPLY0()) {
-    addVObject ((ParserRuleContext*)ctx->SUPPLY0(), VObjectType::slSupply0);
+    addVObject ((antlr4::ParserRuleContext*)ctx->SUPPLY0(), VObjectType::slSupply0);
   } else if (ctx->STRONG0()) {
-    addVObject ((ParserRuleContext*)ctx->STRONG0(), VObjectType::slStrong0);
+    addVObject ((antlr4::ParserRuleContext*)ctx->STRONG0(), VObjectType::slStrong0);
   } else if (ctx->PULL0()) {
-    addVObject ((ParserRuleContext*)ctx->PULL0(), VObjectType::slPull0);
+    addVObject ((antlr4::ParserRuleContext*)ctx->PULL0(), VObjectType::slPull0);
   } else if (ctx->WEAK0()) {
-    addVObject ((ParserRuleContext*)ctx->WEAK0(), VObjectType::slWeak0);
+    addVObject ((antlr4::ParserRuleContext*)ctx->WEAK0(), VObjectType::slWeak0);
   }
   addVObject (ctx, VObjectType::slStrength0);
 }
@@ -915,7 +912,7 @@ void SV3_1aTreeShapeListener::exitStrength0(SV3_1aParser::Strength0Context * ctx
 void SV3_1aTreeShapeListener::exitAction_block(SV3_1aParser::Action_blockContext * ctx)
 {
   if (ctx->ELSE()) {
-    addVObject ((ParserRuleContext*)ctx->ELSE(), VObjectType::slElse);
+    addVObject ((antlr4::ParserRuleContext*)ctx->ELSE(), VObjectType::slElse);
   }
   addVObject (ctx, VObjectType::slAction_block);
 }
@@ -923,59 +920,59 @@ void SV3_1aTreeShapeListener::exitAction_block(SV3_1aParser::Action_blockContext
 void SV3_1aTreeShapeListener::exitEvent_trigger(SV3_1aParser::Event_triggerContext * ctx)
 {
   if (ctx->IMPLY())
-    addVObject ((ParserRuleContext*)ctx->IMPLY(), VObjectType::slBinOp_Imply);
+    addVObject ((antlr4::ParserRuleContext*)ctx->IMPLY(), VObjectType::slBinOp_Imply);
   if (ctx->NON_BLOCKING_TRIGGER_EVENT_OP())
-    addVObject ((ParserRuleContext*)ctx->NON_BLOCKING_TRIGGER_EVENT_OP(), VObjectType::slNonBlockingTriggerEvent);
+    addVObject ((antlr4::ParserRuleContext*)ctx->NON_BLOCKING_TRIGGER_EVENT_OP(), VObjectType::slNonBlockingTriggerEvent);
   addVObject (ctx, VObjectType::slEvent_trigger);
 }
 
 
 void SV3_1aTreeShapeListener::exitStrength1(SV3_1aParser::Strength1Context * ctx)  {
   if (ctx->SUPPLY1()) {
-    addVObject ((ParserRuleContext*)ctx->SUPPLY1(), VObjectType::slSupply1);
+    addVObject ((antlr4::ParserRuleContext*)ctx->SUPPLY1(), VObjectType::slSupply1);
   } else if (ctx->STRONG1()) {
-    addVObject ((ParserRuleContext*)ctx->STRONG1(), VObjectType::slStrong1);
+    addVObject ((antlr4::ParserRuleContext*)ctx->STRONG1(), VObjectType::slStrong1);
   } else if (ctx->PULL1()) {
-    addVObject ((ParserRuleContext*)ctx->PULL1(), VObjectType::slPull1);
+    addVObject ((antlr4::ParserRuleContext*)ctx->PULL1(), VObjectType::slPull1);
   } else if (ctx->WEAK1()) {
-    addVObject ((ParserRuleContext*)ctx->WEAK1(), VObjectType::slWeak1);
+    addVObject ((antlr4::ParserRuleContext*)ctx->WEAK1(), VObjectType::slWeak1);
   }
   addVObject (ctx, VObjectType::slStrength1);
 }
 
 void SV3_1aTreeShapeListener::exitCharge_strength(SV3_1aParser::Charge_strengthContext * ctx) {
   if (ctx->SMALL()) {
-    addVObject ((ParserRuleContext*)ctx->SMALL(), VObjectType::slSmall);
+    addVObject ((antlr4::ParserRuleContext*)ctx->SMALL(), VObjectType::slSmall);
   } else if (ctx->MEDIUM()) {
-    addVObject ((ParserRuleContext*)ctx->MEDIUM(), VObjectType::slMedium);
+    addVObject ((antlr4::ParserRuleContext*)ctx->MEDIUM(), VObjectType::slMedium);
   } else if (ctx->LARGE()) {
-    addVObject ((ParserRuleContext*)ctx->LARGE(), VObjectType::slLarge);
+    addVObject ((antlr4::ParserRuleContext*)ctx->LARGE(), VObjectType::slLarge);
   }
   addVObject (ctx, VObjectType::slCharge_strength);
 }
 
 void SV3_1aTreeShapeListener::exitStream_operator(SV3_1aParser::Stream_operatorContext * ctx) {
   if (ctx->SHIFT_RIGHT()) {
-    addVObject ((ParserRuleContext*)ctx->SHIFT_RIGHT(), VObjectType::slBinOp_ShiftRight);
+    addVObject ((antlr4::ParserRuleContext*)ctx->SHIFT_RIGHT(), VObjectType::slBinOp_ShiftRight);
   } else if (ctx->SHIFT_LEFT()) {
-    addVObject ((ParserRuleContext*)ctx->SHIFT_LEFT(), VObjectType::slBinOp_ShiftLeft);
+    addVObject ((antlr4::ParserRuleContext*)ctx->SHIFT_LEFT(), VObjectType::slBinOp_ShiftLeft);
   }
   addVObject (ctx, VObjectType::slStream_operator);
 }
 
 void SV3_1aTreeShapeListener::exitLoop_statement(SV3_1aParser::Loop_statementContext * ctx) {
   if (ctx->DO()) {
-    addVObject ((ParserRuleContext*)ctx->DO(), VObjectType::slDo);
+    addVObject ((antlr4::ParserRuleContext*)ctx->DO(), VObjectType::slDo);
   } else if (ctx->FOREVER()) {
-    addVObject ((ParserRuleContext*)ctx->FOREVER(), VObjectType::slForever);
+    addVObject ((antlr4::ParserRuleContext*)ctx->FOREVER(), VObjectType::slForever);
   } else if (ctx->REPEAT()) {
-    addVObject ((ParserRuleContext*)ctx->REPEAT(), VObjectType::slRepeat);
+    addVObject ((antlr4::ParserRuleContext*)ctx->REPEAT(), VObjectType::slRepeat);
   } else if (ctx->WHILE()) {
-    addVObject ((ParserRuleContext*)ctx->WHILE(), VObjectType::slWhile);
+    addVObject ((antlr4::ParserRuleContext*)ctx->WHILE(), VObjectType::slWhile);
   } else if (ctx->FOR()) {
-    addVObject ((ParserRuleContext*)ctx->FOR(), VObjectType::slFor);
+    addVObject ((antlr4::ParserRuleContext*)ctx->FOR(), VObjectType::slFor);
   } else if (ctx->FOREACH()) {
-    addVObject ((ParserRuleContext*)ctx->FOREACH(), VObjectType::slForeach);
+    addVObject ((antlr4::ParserRuleContext*)ctx->FOREACH(), VObjectType::slForeach);
   }
   addVObject (ctx, VObjectType::slLoop_statement);
 }
@@ -984,26 +981,26 @@ void SV3_1aTreeShapeListener::exitLoop_statement(SV3_1aParser::Loop_statementCon
 void SV3_1aTreeShapeListener::exitPackage_scope(
     SV3_1aParser::Package_scopeContext *ctx) {
    std::string ident;
-  ParserRuleContext *childCtx = NULL;
+   antlr4::ParserRuleContext *childCtx = NULL;
   if (ctx->Simple_identifier()) {
-    childCtx = (ParserRuleContext *)ctx->Simple_identifier();
+    childCtx = (antlr4::ParserRuleContext *)ctx->Simple_identifier();
     ident = ctx->Simple_identifier()->getText();
   } else if (ctx->Escaped_identifier()) {
-    childCtx = (ParserRuleContext *)ctx->Escaped_identifier();
+    childCtx = (antlr4::ParserRuleContext *)ctx->Escaped_identifier();
     ident = ctx->Escaped_identifier()->getText();
     ident.erase(0, 3);
     ident.erase(ident.size() - 3, 3);
   } else if (ctx->THIS()) {
-    childCtx = (ParserRuleContext *)ctx->THIS();
+    childCtx = (antlr4::ParserRuleContext *)ctx->THIS();
     ident = ctx->THIS()->getText();
   } else if (ctx->RANDOMIZE()) {
-    childCtx = (ParserRuleContext *)ctx->RANDOMIZE();
+    childCtx = (antlr4::ParserRuleContext *)ctx->RANDOMIZE();
     ident = ctx->RANDOMIZE()->getText();
   } else if (ctx->SAMPLE()) {
-    childCtx = (ParserRuleContext *)ctx->SAMPLE();
+    childCtx = (antlr4::ParserRuleContext *)ctx->SAMPLE();
     ident = ctx->SAMPLE()->getText();
   } else if (ctx->DOLLAR_UNIT()) {
-    childCtx = (ParserRuleContext *)ctx->DOLLAR_UNIT();
+    childCtx = (antlr4::ParserRuleContext *)ctx->DOLLAR_UNIT();
     ident = ctx->DOLLAR_UNIT()->getText();
   }
   addVObject(childCtx, ident, VObjectType::slStringConst);
@@ -1016,125 +1013,125 @@ void SV3_1aTreeShapeListener::exitPackage_scope(
 
 void SV3_1aTreeShapeListener::exitExpression(SV3_1aParser::ExpressionContext * ctx) {
   if (ctx->MATCHES()) {
-    addVObject ((ParserRuleContext*)ctx->MATCHES(), VObjectType::slMatches);
-  } 
+    addVObject ((antlr4::ParserRuleContext*)ctx->MATCHES(), VObjectType::slMatches);
+  }
   if (ctx->PLUS()) {
     if (ctx->expression().size() == 1)
-      addVObject ((ParserRuleContext*)ctx->PLUS(), VObjectType::slUnary_Plus);
+      addVObject ((antlr4::ParserRuleContext*)ctx->PLUS(), VObjectType::slUnary_Plus);
     else
-      addVObject ((ParserRuleContext*)ctx->PLUS(), VObjectType::slBinOp_Plus);
+      addVObject ((antlr4::ParserRuleContext*)ctx->PLUS(), VObjectType::slBinOp_Plus);
   } else if (ctx->MINUS()) {
     if (ctx->expression().size() == 1)
-      addVObject ((ParserRuleContext*)ctx->MINUS(), VObjectType::slUnary_Minus);
+      addVObject ((antlr4::ParserRuleContext*)ctx->MINUS(), VObjectType::slUnary_Minus);
     else
-      addVObject ((ParserRuleContext*)ctx->MINUS(), VObjectType::slBinOp_Minus);
+      addVObject ((antlr4::ParserRuleContext*)ctx->MINUS(), VObjectType::slBinOp_Minus);
   } else if (ctx->BANG()) {
-    addVObject ((ParserRuleContext*)ctx->BANG(), VObjectType::slUnary_Not);
+    addVObject ((antlr4::ParserRuleContext*)ctx->BANG(), VObjectType::slUnary_Not);
   } else if (ctx->TILDA()) {
-    addVObject ((ParserRuleContext*)ctx->TILDA(), VObjectType::slUnary_Tilda);
+    addVObject ((antlr4::ParserRuleContext*)ctx->TILDA(), VObjectType::slUnary_Tilda);
   } else if (ctx->BITW_AND()) {
     if (ctx->expression().size() == 1)
-      addVObject ((ParserRuleContext*)ctx->BITW_AND(), VObjectType::slUnary_BitwAnd);
+      addVObject ((antlr4::ParserRuleContext*)ctx->BITW_AND(), VObjectType::slUnary_BitwAnd);
     else
-      addVObject ((ParserRuleContext*)ctx->BITW_AND(), VObjectType::slBinOp_BitwAnd);
+      addVObject ((antlr4::ParserRuleContext*)ctx->BITW_AND(), VObjectType::slBinOp_BitwAnd);
   } else if (ctx->BITW_OR()) {
     if (ctx->expression().size() == 1)
-      addVObject ((ParserRuleContext*)ctx->BITW_OR(), VObjectType::slUnary_BitwOr);
+      addVObject ((antlr4::ParserRuleContext*)ctx->BITW_OR(), VObjectType::slUnary_BitwOr);
     else
-      addVObject ((ParserRuleContext*)ctx->BITW_OR(), VObjectType::slBinOp_BitwOr);
+      addVObject ((antlr4::ParserRuleContext*)ctx->BITW_OR(), VObjectType::slBinOp_BitwOr);
   } else if (ctx->BITW_XOR()) {
     if (ctx->expression().size() == 1)
-      addVObject ((ParserRuleContext*)ctx->BITW_XOR(), VObjectType::slUnary_BitwXor);
+      addVObject ((antlr4::ParserRuleContext*)ctx->BITW_XOR(), VObjectType::slUnary_BitwXor);
     else
-      addVObject ((ParserRuleContext*)ctx->BITW_XOR(), VObjectType::slBinOp_BitwXor); 
+      addVObject ((antlr4::ParserRuleContext*)ctx->BITW_XOR(), VObjectType::slBinOp_BitwXor);
   } else if (ctx->REDUCTION_NAND()) {
     if (ctx->expression().size() == 1)
-      addVObject ((ParserRuleContext*)ctx->REDUCTION_NAND(), VObjectType::slUnary_ReductNand);
+      addVObject ((antlr4::ParserRuleContext*)ctx->REDUCTION_NAND(), VObjectType::slUnary_ReductNand);
     else
-      addVObject ((ParserRuleContext*)ctx->REDUCTION_NAND(), VObjectType::slBinOp_ReductNand);
+      addVObject ((antlr4::ParserRuleContext*)ctx->REDUCTION_NAND(), VObjectType::slBinOp_ReductNand);
   } else if (ctx->REDUCTION_NOR()) {
-    addVObject ((ParserRuleContext*)ctx->REDUCTION_NOR(), VObjectType::slUnary_ReductNor);
+    addVObject ((antlr4::ParserRuleContext*)ctx->REDUCTION_NOR(), VObjectType::slUnary_ReductNor);
   } else if (ctx->REDUCTION_XNOR1()) {
     if (ctx->expression().size() == 1)
-      addVObject ((ParserRuleContext*)ctx->REDUCTION_XNOR1(), VObjectType::slUnary_ReductXnor1);
+      addVObject ((antlr4::ParserRuleContext*)ctx->REDUCTION_XNOR1(), VObjectType::slUnary_ReductXnor1);
     else
-      addVObject ((ParserRuleContext*)ctx->REDUCTION_XNOR1(), VObjectType::slBinOp_ReductXnor1);
+      addVObject ((antlr4::ParserRuleContext*)ctx->REDUCTION_XNOR1(), VObjectType::slBinOp_ReductXnor1);
   } else if (ctx->REDUCTION_XNOR2()) {
     if (ctx->expression().size() == 1)
-      addVObject ((ParserRuleContext*)ctx->REDUCTION_XNOR2(), VObjectType::slUnary_ReductXnor2);
+      addVObject ((antlr4::ParserRuleContext*)ctx->REDUCTION_XNOR2(), VObjectType::slUnary_ReductXnor2);
     else
-      addVObject ((ParserRuleContext*)ctx->REDUCTION_XNOR2(), VObjectType::slBinOp_ReductXnor2);
+      addVObject ((antlr4::ParserRuleContext*)ctx->REDUCTION_XNOR2(), VObjectType::slBinOp_ReductXnor2);
   } else if (ctx->STARSTAR()) {
-    addVObject ((ParserRuleContext*)ctx->STARSTAR(), VObjectType::slBinOp_MultMult);
+    addVObject ((antlr4::ParserRuleContext*)ctx->STARSTAR(), VObjectType::slBinOp_MultMult);
   } else if (ctx->STAR()) {
-    addVObject ((ParserRuleContext*)ctx->STAR(), VObjectType::slBinOp_Mult);
+    addVObject ((antlr4::ParserRuleContext*)ctx->STAR(), VObjectType::slBinOp_Mult);
   } else if (ctx->DIV()) {
-    addVObject ((ParserRuleContext*)ctx->DIV(), VObjectType::slBinOp_Div);
+    addVObject ((antlr4::ParserRuleContext*)ctx->DIV(), VObjectType::slBinOp_Div);
   } else if (ctx->PERCENT()) {
-    addVObject ((ParserRuleContext*)ctx->PERCENT(), VObjectType::slBinOp_Percent);
+    addVObject ((antlr4::ParserRuleContext*)ctx->PERCENT(), VObjectType::slBinOp_Percent);
   } else if (ctx->SHIFT_RIGHT()) {
-    addVObject ((ParserRuleContext*)ctx->SHIFT_RIGHT(), VObjectType::slBinOp_ShiftRight);
+    addVObject ((antlr4::ParserRuleContext*)ctx->SHIFT_RIGHT(), VObjectType::slBinOp_ShiftRight);
   } else if (ctx->SHIFT_LEFT()) {
-    addVObject ((ParserRuleContext*)ctx->SHIFT_LEFT(), VObjectType::slBinOp_ShiftLeft);
+    addVObject ((antlr4::ParserRuleContext*)ctx->SHIFT_LEFT(), VObjectType::slBinOp_ShiftLeft);
   } else if (ctx->ARITH_SHIFT_RIGHT()) {
-    addVObject ((ParserRuleContext*)ctx->ARITH_SHIFT_RIGHT(), VObjectType::slBinOp_ArithShiftRight);
+    addVObject ((antlr4::ParserRuleContext*)ctx->ARITH_SHIFT_RIGHT(), VObjectType::slBinOp_ArithShiftRight);
   } else if (ctx->ARITH_SHIFT_LEFT()) {
-    addVObject ((ParserRuleContext*)ctx->ARITH_SHIFT_LEFT(), VObjectType::slBinOp_ArithShiftLeft);
+    addVObject ((antlr4::ParserRuleContext*)ctx->ARITH_SHIFT_LEFT(), VObjectType::slBinOp_ArithShiftLeft);
   } else if (ctx->LESS()) {
-    addVObject ((ParserRuleContext*)ctx->LESS(), VObjectType::slBinOp_Less);
+    addVObject ((antlr4::ParserRuleContext*)ctx->LESS(), VObjectType::slBinOp_Less);
   } else if (ctx->LESS_EQUAL()) {
-    addVObject ((ParserRuleContext*)ctx->LESS_EQUAL(), VObjectType::slBinOp_LessEqual);
+    addVObject ((antlr4::ParserRuleContext*)ctx->LESS_EQUAL(), VObjectType::slBinOp_LessEqual);
   } else if (ctx->PLUSPLUS()) {
-    addVObject ((ParserRuleContext*)ctx->PLUSPLUS(), VObjectType::slIncDec_PlusPlus);
+    addVObject ((antlr4::ParserRuleContext*)ctx->PLUSPLUS(), VObjectType::slIncDec_PlusPlus);
   }  else if (ctx->MINUSMINUS()) {
-    addVObject ((ParserRuleContext*)ctx->MINUSMINUS(), VObjectType::slIncDec_MinusMinus);
+    addVObject ((antlr4::ParserRuleContext*)ctx->MINUSMINUS(), VObjectType::slIncDec_MinusMinus);
   } else if (ctx->GREATER()) {
-    addVObject ((ParserRuleContext*)ctx->GREATER(), VObjectType::slBinOp_Great);
+    addVObject ((antlr4::ParserRuleContext*)ctx->GREATER(), VObjectType::slBinOp_Great);
   } else if (ctx->GREATER_EQUAL()) {
-    addVObject ((ParserRuleContext*)ctx->GREATER_EQUAL(), VObjectType::slBinOp_GreatEqual);
+    addVObject ((antlr4::ParserRuleContext*)ctx->GREATER_EQUAL(), VObjectType::slBinOp_GreatEqual);
   } else if (ctx->INSIDE()) {
-    addVObject ((ParserRuleContext*)ctx->INSIDE(), VObjectType::slInsideOp);
+    addVObject ((antlr4::ParserRuleContext*)ctx->INSIDE(), VObjectType::slInsideOp);
   } else if (ctx->EQUIV()) {
-    addVObject ((ParserRuleContext*)ctx->EQUIV(), VObjectType::slBinOp_Equiv);
+    addVObject ((antlr4::ParserRuleContext*)ctx->EQUIV(), VObjectType::slBinOp_Equiv);
   } else if (ctx->NOTEQUAL()) {
-    addVObject ((ParserRuleContext*)ctx->NOTEQUAL(), VObjectType::slBinOp_Not);
+    addVObject ((antlr4::ParserRuleContext*)ctx->NOTEQUAL(), VObjectType::slBinOp_Not);
   } else if (ctx->BINARY_WILDCARD_EQUAL()) {
-    addVObject ((ParserRuleContext*)ctx->BINARY_WILDCARD_EQUAL(), VObjectType::slBinOp_WildcardEqual);
+    addVObject ((antlr4::ParserRuleContext*)ctx->BINARY_WILDCARD_EQUAL(), VObjectType::slBinOp_WildcardEqual);
   } else if (ctx->BINARY_WILDCARD_NOTEQUAL()) {
-    addVObject ((ParserRuleContext*)ctx->BINARY_WILDCARD_NOTEQUAL(), VObjectType::slBinOp_WildcardNotEqual);
+    addVObject ((antlr4::ParserRuleContext*)ctx->BINARY_WILDCARD_NOTEQUAL(), VObjectType::slBinOp_WildcardNotEqual);
   } else if (ctx->FOUR_STATE_LOGIC_EQUAL()) {
-    addVObject ((ParserRuleContext*)ctx->FOUR_STATE_LOGIC_EQUAL(), VObjectType::slBinOp_FourStateLogicEqual);
+    addVObject ((antlr4::ParserRuleContext*)ctx->FOUR_STATE_LOGIC_EQUAL(), VObjectType::slBinOp_FourStateLogicEqual);
   } else if (ctx->FOUR_STATE_LOGIC_NOTEQUAL()) {
-    addVObject ((ParserRuleContext*)ctx->FOUR_STATE_LOGIC_NOTEQUAL(), VObjectType::slBinOp_FourStateLogicNotEqual);
+    addVObject ((antlr4::ParserRuleContext*)ctx->FOUR_STATE_LOGIC_NOTEQUAL(), VObjectType::slBinOp_FourStateLogicNotEqual);
   } else if (ctx->WILD_EQUAL_OP()) {
-    addVObject ((ParserRuleContext*)ctx->WILD_EQUAL_OP(), VObjectType::slBinOp_WildEqual);
+    addVObject ((antlr4::ParserRuleContext*)ctx->WILD_EQUAL_OP(), VObjectType::slBinOp_WildEqual);
   } else if (ctx->WILD_NOTEQUAL_OP()) {
-    addVObject ((ParserRuleContext*)ctx->WILD_NOTEQUAL_OP(), VObjectType::slBinOp_WildEqual);
+    addVObject ((antlr4::ParserRuleContext*)ctx->WILD_NOTEQUAL_OP(), VObjectType::slBinOp_WildEqual);
   } else if (ctx->BITW_AND()) {
     if (ctx->expression().size() == 1)
-      addVObject ((ParserRuleContext*)ctx->BITW_AND(), VObjectType::slUnary_BitwAnd);
+      addVObject ((antlr4::ParserRuleContext*)ctx->BITW_AND(), VObjectType::slUnary_BitwAnd);
     else
-      addVObject ((ParserRuleContext*)ctx->BITW_AND(), VObjectType::slBinOp_BitwAnd);
+      addVObject ((antlr4::ParserRuleContext*)ctx->BITW_AND(), VObjectType::slBinOp_BitwAnd);
   } else if (ctx->LOGICAL_AND().size()) {
-    addVObject ((ParserRuleContext*)ctx->LOGICAL_AND()[0], VObjectType::slBinOp_LogicAnd);
+    addVObject ((antlr4::ParserRuleContext*)ctx->LOGICAL_AND()[0], VObjectType::slBinOp_LogicAnd);
   } else if (ctx->LOGICAL_OR()) {
-    addVObject ((ParserRuleContext*)ctx->LOGICAL_OR(), VObjectType::slBinOp_LogicOr);
+    addVObject ((antlr4::ParserRuleContext*)ctx->LOGICAL_OR(), VObjectType::slBinOp_LogicOr);
   } else if (ctx->IMPLY()) {
-    addVObject ((ParserRuleContext*)ctx->IMPLY(), VObjectType::slBinOp_Imply);
+    addVObject ((antlr4::ParserRuleContext*)ctx->IMPLY(), VObjectType::slBinOp_Imply);
   } else if (ctx->EQUIVALENCE()) {
-    addVObject ((ParserRuleContext*)ctx->EQUIVALENCE(), VObjectType::slBinOp_Equivalence);
+    addVObject ((antlr4::ParserRuleContext*)ctx->EQUIVALENCE(), VObjectType::slBinOp_Equivalence);
   } else if (ctx->TAGGED()) {
-    addVObject ((ParserRuleContext*)ctx->TAGGED(), VObjectType::slTagged);
-  } 
+    addVObject ((antlr4::ParserRuleContext*)ctx->TAGGED(), VObjectType::slTagged);
+  }
   if (ctx->QMARK()) {
-    addVObject ((ParserRuleContext*)ctx->QMARK(), VObjectType::slQmark);
-  } 
+    addVObject ((antlr4::ParserRuleContext*)ctx->QMARK(), VObjectType::slQmark);
+  }
   addVObject (ctx, VObjectType::slExpression);
 }
 
 void SV3_1aTreeShapeListener::exitEvent_expression(SV3_1aParser::Event_expressionContext * ctx) {
   if (ctx->IFF()) {
-      addVObject ((ParserRuleContext*)ctx->IFF(), VObjectType::slIff);
+      addVObject ((antlr4::ParserRuleContext*)ctx->IFF(), VObjectType::slIff);
   }
   addVObject (ctx, VObjectType::slEvent_expression);
 }
@@ -1142,106 +1139,106 @@ void SV3_1aTreeShapeListener::exitEvent_expression(SV3_1aParser::Event_expressio
 void SV3_1aTreeShapeListener::exitConstant_expression(SV3_1aParser::Constant_expressionContext * ctx) {
   if (ctx->PLUS()) {
     if (ctx->constant_primary())
-      addVObject ((ParserRuleContext*)ctx->PLUS(), VObjectType::slUnary_Plus);
+      addVObject ((antlr4::ParserRuleContext*)ctx->PLUS(), VObjectType::slUnary_Plus);
     else
-      addVObject ((ParserRuleContext*)ctx->PLUS(), VObjectType::slBinOp_Plus);
+      addVObject ((antlr4::ParserRuleContext*)ctx->PLUS(), VObjectType::slBinOp_Plus);
   } else if (ctx->MINUS()) {
     if (ctx->constant_primary())
-      addVObject ((ParserRuleContext*)ctx->MINUS(), VObjectType::slUnary_Minus);
+      addVObject ((antlr4::ParserRuleContext*)ctx->MINUS(), VObjectType::slUnary_Minus);
     else
-      addVObject ((ParserRuleContext*)ctx->MINUS(), VObjectType::slBinOp_Minus);
+      addVObject ((antlr4::ParserRuleContext*)ctx->MINUS(), VObjectType::slBinOp_Minus);
   } else if (ctx->BANG()) {
-    addVObject ((ParserRuleContext*)ctx->BANG(), VObjectType::slUnary_Not);
+    addVObject ((antlr4::ParserRuleContext*)ctx->BANG(), VObjectType::slUnary_Not);
   } else if (ctx->TILDA()) {
-    addVObject ((ParserRuleContext*)ctx->TILDA(), VObjectType::slUnary_Tilda);
+    addVObject ((antlr4::ParserRuleContext*)ctx->TILDA(), VObjectType::slUnary_Tilda);
   } else if (ctx->BITW_AND()) {
     if (ctx->constant_primary())
-      addVObject ((ParserRuleContext*)ctx->BITW_AND(), VObjectType::slUnary_BitwAnd);
+      addVObject ((antlr4::ParserRuleContext*)ctx->BITW_AND(), VObjectType::slUnary_BitwAnd);
     else
-      addVObject ((ParserRuleContext*)ctx->BITW_AND(), VObjectType::slBinOp_BitwAnd);
+      addVObject ((antlr4::ParserRuleContext*)ctx->BITW_AND(), VObjectType::slBinOp_BitwAnd);
   } else if (ctx->BITW_OR()) {
     if (ctx->constant_primary())
-      addVObject ((ParserRuleContext*)ctx->BITW_OR(), VObjectType::slUnary_BitwOr);
+      addVObject ((antlr4::ParserRuleContext*)ctx->BITW_OR(), VObjectType::slUnary_BitwOr);
     else
-      addVObject ((ParserRuleContext*)ctx->BITW_OR(), VObjectType::slBinOp_BitwOr);
+      addVObject ((antlr4::ParserRuleContext*)ctx->BITW_OR(), VObjectType::slBinOp_BitwOr);
   } else if (ctx->BITW_XOR()) {
     if (ctx->constant_primary())
-      addVObject ((ParserRuleContext*)ctx->BITW_XOR(), VObjectType::slUnary_BitwXor);
+      addVObject ((antlr4::ParserRuleContext*)ctx->BITW_XOR(), VObjectType::slUnary_BitwXor);
     else
-      addVObject ((ParserRuleContext*)ctx->BITW_XOR(), VObjectType::slBinOp_BitwXor); 
+      addVObject ((antlr4::ParserRuleContext*)ctx->BITW_XOR(), VObjectType::slBinOp_BitwXor);
   } else if (ctx->REDUCTION_NAND()) {
     if (ctx->constant_primary())
-      addVObject ((ParserRuleContext*)ctx->REDUCTION_NAND(), VObjectType::slUnary_ReductNand);
+      addVObject ((antlr4::ParserRuleContext*)ctx->REDUCTION_NAND(), VObjectType::slUnary_ReductNand);
     else
-      addVObject ((ParserRuleContext*)ctx->REDUCTION_NAND(), VObjectType::slBinOp_ReductNand);
+      addVObject ((antlr4::ParserRuleContext*)ctx->REDUCTION_NAND(), VObjectType::slBinOp_ReductNand);
   } else if (ctx->REDUCTION_NOR()) {
-    addVObject ((ParserRuleContext*)ctx->REDUCTION_NOR(), VObjectType::slUnary_ReductNor);
+    addVObject ((antlr4::ParserRuleContext*)ctx->REDUCTION_NOR(), VObjectType::slUnary_ReductNor);
   } else if (ctx->REDUCTION_XNOR1()) {
     if (ctx->constant_primary())
-      addVObject ((ParserRuleContext*)ctx->REDUCTION_XNOR1(), VObjectType::slUnary_ReductXnor1);
+      addVObject ((antlr4::ParserRuleContext*)ctx->REDUCTION_XNOR1(), VObjectType::slUnary_ReductXnor1);
     else
-      addVObject ((ParserRuleContext*)ctx->REDUCTION_XNOR1(), VObjectType::slBinOp_ReductXnor1);
+      addVObject ((antlr4::ParserRuleContext*)ctx->REDUCTION_XNOR1(), VObjectType::slBinOp_ReductXnor1);
   } else if (ctx->REDUCTION_XNOR2()) {
     if (ctx->constant_primary())
-      addVObject ((ParserRuleContext*)ctx->REDUCTION_XNOR2(), VObjectType::slUnary_ReductXnor2);
+      addVObject ((antlr4::ParserRuleContext*)ctx->REDUCTION_XNOR2(), VObjectType::slUnary_ReductXnor2);
     else
-      addVObject ((ParserRuleContext*)ctx->REDUCTION_XNOR2(), VObjectType::slBinOp_ReductXnor2);
+      addVObject ((antlr4::ParserRuleContext*)ctx->REDUCTION_XNOR2(), VObjectType::slBinOp_ReductXnor2);
   } else if (ctx->STARSTAR()) {
-    addVObject ((ParserRuleContext*)ctx->STARSTAR(), VObjectType::slBinOp_MultMult);
+    addVObject ((antlr4::ParserRuleContext*)ctx->STARSTAR(), VObjectType::slBinOp_MultMult);
   } else if (ctx->STAR()) {
-    addVObject ((ParserRuleContext*)ctx->STAR(), VObjectType::slBinOp_Mult);
+    addVObject ((antlr4::ParserRuleContext*)ctx->STAR(), VObjectType::slBinOp_Mult);
   } else if (ctx->DIV()) {
-    addVObject ((ParserRuleContext*)ctx->DIV(), VObjectType::slBinOp_Div);
+    addVObject ((antlr4::ParserRuleContext*)ctx->DIV(), VObjectType::slBinOp_Div);
   } else if (ctx->PERCENT()) {
-    addVObject ((ParserRuleContext*)ctx->PERCENT(), VObjectType::slBinOp_Percent);
+    addVObject ((antlr4::ParserRuleContext*)ctx->PERCENT(), VObjectType::slBinOp_Percent);
   } else if (ctx->SHIFT_RIGHT()) {
-    addVObject ((ParserRuleContext*)ctx->SHIFT_RIGHT(), VObjectType::slBinOp_ShiftRight);
+    addVObject ((antlr4::ParserRuleContext*)ctx->SHIFT_RIGHT(), VObjectType::slBinOp_ShiftRight);
   } else if (ctx->SHIFT_LEFT()) {
-    addVObject ((ParserRuleContext*)ctx->SHIFT_LEFT(), VObjectType::slBinOp_ShiftLeft);
+    addVObject ((antlr4::ParserRuleContext*)ctx->SHIFT_LEFT(), VObjectType::slBinOp_ShiftLeft);
   } else if (ctx->ARITH_SHIFT_RIGHT()) {
-    addVObject ((ParserRuleContext*)ctx->ARITH_SHIFT_RIGHT(), VObjectType::slBinOp_ArithShiftRight);
+    addVObject ((antlr4::ParserRuleContext*)ctx->ARITH_SHIFT_RIGHT(), VObjectType::slBinOp_ArithShiftRight);
   } else if (ctx->ARITH_SHIFT_LEFT()) {
-    addVObject ((ParserRuleContext*)ctx->ARITH_SHIFT_LEFT(), VObjectType::slBinOp_ArithShiftLeft);
+    addVObject ((antlr4::ParserRuleContext*)ctx->ARITH_SHIFT_LEFT(), VObjectType::slBinOp_ArithShiftLeft);
   } else if (ctx->LESS()) {
-    addVObject ((ParserRuleContext*)ctx->LESS(), VObjectType::slBinOp_Less);
+    addVObject ((antlr4::ParserRuleContext*)ctx->LESS(), VObjectType::slBinOp_Less);
   } else if (ctx->LESS_EQUAL()) {
-    addVObject ((ParserRuleContext*)ctx->LESS_EQUAL(), VObjectType::slBinOp_LessEqual);
+    addVObject ((antlr4::ParserRuleContext*)ctx->LESS_EQUAL(), VObjectType::slBinOp_LessEqual);
   } else if (ctx->GREATER()) {
-    addVObject ((ParserRuleContext*)ctx->GREATER(), VObjectType::slBinOp_Great);
+    addVObject ((antlr4::ParserRuleContext*)ctx->GREATER(), VObjectType::slBinOp_Great);
   } else if (ctx->GREATER_EQUAL()) {
-    addVObject ((ParserRuleContext*)ctx->GREATER_EQUAL(), VObjectType::slBinOp_GreatEqual);
+    addVObject ((antlr4::ParserRuleContext*)ctx->GREATER_EQUAL(), VObjectType::slBinOp_GreatEqual);
   } else if (ctx->INSIDE()) {
-    addVObject ((ParserRuleContext*)ctx->INSIDE(), VObjectType::slInsideOp);
+    addVObject ((antlr4::ParserRuleContext*)ctx->INSIDE(), VObjectType::slInsideOp);
   } else if (ctx->EQUIV()) {
-    addVObject ((ParserRuleContext*)ctx->EQUIV(), VObjectType::slBinOp_Equiv);
+    addVObject ((antlr4::ParserRuleContext*)ctx->EQUIV(), VObjectType::slBinOp_Equiv);
   } else if (ctx->NOTEQUAL()) {
-    addVObject ((ParserRuleContext*)ctx->NOTEQUAL(), VObjectType::slBinOp_Not);
+    addVObject ((antlr4::ParserRuleContext*)ctx->NOTEQUAL(), VObjectType::slBinOp_Not);
   } else if (ctx->BINARY_WILDCARD_EQUAL()) {
-    addVObject ((ParserRuleContext*)ctx->BINARY_WILDCARD_EQUAL(), VObjectType::slBinOp_WildcardEqual);
+    addVObject ((antlr4::ParserRuleContext*)ctx->BINARY_WILDCARD_EQUAL(), VObjectType::slBinOp_WildcardEqual);
   } else if (ctx->BINARY_WILDCARD_NOTEQUAL()) {
-    addVObject ((ParserRuleContext*)ctx->BINARY_WILDCARD_NOTEQUAL(), VObjectType::slBinOp_WildcardNotEqual);
+    addVObject ((antlr4::ParserRuleContext*)ctx->BINARY_WILDCARD_NOTEQUAL(), VObjectType::slBinOp_WildcardNotEqual);
   } else if (ctx->FOUR_STATE_LOGIC_EQUAL()) {
-    addVObject ((ParserRuleContext*)ctx->FOUR_STATE_LOGIC_EQUAL(), VObjectType::slBinOp_FourStateLogicEqual);
+    addVObject ((antlr4::ParserRuleContext*)ctx->FOUR_STATE_LOGIC_EQUAL(), VObjectType::slBinOp_FourStateLogicEqual);
   } else if (ctx->FOUR_STATE_LOGIC_NOTEQUAL()) {
-    addVObject ((ParserRuleContext*)ctx->FOUR_STATE_LOGIC_NOTEQUAL(), VObjectType::slBinOp_FourStateLogicNotEqual);
+    addVObject ((antlr4::ParserRuleContext*)ctx->FOUR_STATE_LOGIC_NOTEQUAL(), VObjectType::slBinOp_FourStateLogicNotEqual);
   } else if (ctx->WILD_EQUAL_OP()) {
-    addVObject ((ParserRuleContext*)ctx->WILD_EQUAL_OP(), VObjectType::slBinOp_WildEqual);
+    addVObject ((antlr4::ParserRuleContext*)ctx->WILD_EQUAL_OP(), VObjectType::slBinOp_WildEqual);
   } else if (ctx->WILD_NOTEQUAL_OP()) {
-    addVObject ((ParserRuleContext*)ctx->WILD_NOTEQUAL_OP(), VObjectType::slBinOp_WildEqual);
+    addVObject ((antlr4::ParserRuleContext*)ctx->WILD_NOTEQUAL_OP(), VObjectType::slBinOp_WildEqual);
   } else if (ctx->BITW_AND()) {
     if (ctx->constant_primary())
-      addVObject ((ParserRuleContext*)ctx->BITW_AND(), VObjectType::slUnary_BitwAnd);
+      addVObject ((antlr4::ParserRuleContext*)ctx->BITW_AND(), VObjectType::slUnary_BitwAnd);
     else
-      addVObject ((ParserRuleContext*)ctx->BITW_AND(), VObjectType::slBinOp_BitwAnd);
+      addVObject ((antlr4::ParserRuleContext*)ctx->BITW_AND(), VObjectType::slBinOp_BitwAnd);
   } else if (ctx->LOGICAL_AND().size()) {
-    addVObject ((ParserRuleContext*)ctx->LOGICAL_AND()[0], VObjectType::slBinOp_LogicAnd);
+    addVObject ((antlr4::ParserRuleContext*)ctx->LOGICAL_AND()[0], VObjectType::slBinOp_LogicAnd);
   } else if (ctx->LOGICAL_OR()) {
-    addVObject ((ParserRuleContext*)ctx->LOGICAL_OR(), VObjectType::slBinOp_LogicOr);
+    addVObject ((antlr4::ParserRuleContext*)ctx->LOGICAL_OR(), VObjectType::slBinOp_LogicOr);
   } else if (ctx->IMPLY()) {
-    addVObject ((ParserRuleContext*)ctx->IMPLY(), VObjectType::slBinOp_Imply);
+    addVObject ((antlr4::ParserRuleContext*)ctx->IMPLY(), VObjectType::slBinOp_Imply);
   } else if (ctx->EQUIVALENCE()) {
-    addVObject ((ParserRuleContext*)ctx->EQUIVALENCE(), VObjectType::slBinOp_Equivalence);
-  } 
+    addVObject ((antlr4::ParserRuleContext*)ctx->EQUIVALENCE(), VObjectType::slBinOp_Equivalence);
+  }
   addVObject (ctx, VObjectType::slConstant_expression);
 }
 
@@ -1253,21 +1250,21 @@ void  SV3_1aTreeShapeListener::exitNet_type(SV3_1aParser::Net_typeContext * ctx)
   } else if (ctx->TRI()) {
     addVObject (ctx, VObjectType::slNetType_Tri);
   } else if (ctx->TRIAND()) {
-    addVObject (ctx, VObjectType::slNetType_TriAnd);  
+    addVObject (ctx, VObjectType::slNetType_TriAnd);
   } else if (ctx->TRIOR()) {
-    addVObject (ctx, VObjectType::slNetType_TriOr);  
+    addVObject (ctx, VObjectType::slNetType_TriOr);
   } else if (ctx->TRIREG()) {
-    addVObject (ctx, VObjectType::slNetType_TriReg); 
+    addVObject (ctx, VObjectType::slNetType_TriReg);
   } else if (ctx->TRI0()) {
-    addVObject (ctx, VObjectType::slNetType_Tri0);    
+    addVObject (ctx, VObjectType::slNetType_Tri0);
   } else if (ctx->TRI1()) {
-    addVObject (ctx, VObjectType::slNetType_Tri1);  
+    addVObject (ctx, VObjectType::slNetType_Tri1);
   } else if (ctx->UWIRE()) {
-    addVObject (ctx, VObjectType::slNetType_Uwire); 
+    addVObject (ctx, VObjectType::slNetType_Uwire);
   } else if (ctx->WIRE()) {
-    addVObject (ctx, VObjectType::slNetType_Wire);  
+    addVObject (ctx, VObjectType::slNetType_Wire);
   } else if (ctx->WAND()) {
-    addVObject (ctx, VObjectType::slNetType_Wand); 
+    addVObject (ctx, VObjectType::slNetType_Wand);
   } else if (ctx->WOR()) {
     addVObject (ctx, VObjectType::slNetType_Wor);
   }
@@ -1300,21 +1297,21 @@ void SV3_1aTreeShapeListener::exitAssignment_operator(SV3_1aParser::Assignment_o
     addVObject (ctx, VObjectType::slAssignOp_ArithShiftLeft);
   } else if (ctx->ARITH_SHIFT_RIGHT_ASSIGN()) {
     addVObject (ctx, VObjectType::slAssignOp_ArithShiftRight);
-  }   
+  }
 }
 
 void SV3_1aTreeShapeListener::exitInc_or_dec_operator(SV3_1aParser::Inc_or_dec_operatorContext* ctx)  {
-  if (ctx->PLUSPLUS()) 
+  if (ctx->PLUSPLUS())
     addVObject (ctx, VObjectType::slIncDec_PlusPlus);
-  else 
+  else
     addVObject (ctx, VObjectType::slIncDec_MinusMinus);
 }
 
 void SV3_1aTreeShapeListener::exitGate_instantiation(SV3_1aParser::Gate_instantiationContext * ctx) {
   if (ctx->PULLUP()) {
-    addVObject ((ParserRuleContext*)ctx->PULLUP(), VObjectType::slPullup);
+    addVObject ((antlr4::ParserRuleContext*)ctx->PULLUP(), VObjectType::slPullup);
   } else if (ctx->PULLDOWN()) {
-    addVObject ((ParserRuleContext*)ctx->PULLDOWN(), VObjectType::slPulldown);
+    addVObject ((antlr4::ParserRuleContext*)ctx->PULLDOWN(), VObjectType::slPulldown);
   }
   addVObject (ctx, VObjectType::slGate_instantiation);
 }
@@ -1322,10 +1319,10 @@ void SV3_1aTreeShapeListener::exitGate_instantiation(SV3_1aParser::Gate_instanti
 void SV3_1aTreeShapeListener::exitOutput_symbol(SV3_1aParser::Output_symbolContext * ctx) {
   if (ctx->Integral_number()) {
     auto number = ctx->Integral_number();
-    addVObject((ParserRuleContext*)ctx->Integral_number(), number->getText(), VObjectType::slIntConst);
+    addVObject((antlr4::ParserRuleContext*)ctx->Integral_number(), number->getText(), VObjectType::slIntConst);
   } else if (ctx->Simple_identifier()) {
     std::string ident = ctx->Simple_identifier()->getText();
-    addVObject((ParserRuleContext*)ctx->Simple_identifier(), ident, VObjectType::slStringConst);
+    addVObject((antlr4::ParserRuleContext*)ctx->Simple_identifier(), ident, VObjectType::slStringConst);
   }
   addVObject (ctx, VObjectType::slOutput_symbol);
 }
@@ -1333,34 +1330,34 @@ void SV3_1aTreeShapeListener::exitOutput_symbol(SV3_1aParser::Output_symbolConte
 void SV3_1aTreeShapeListener::exitCycle_delay(SV3_1aParser::Cycle_delayContext * ctx) {
   if (ctx->Integral_number()) {
     auto number = ctx->Integral_number();
-    addVObject((ParserRuleContext*)ctx->Integral_number(), number->getText(), VObjectType::slIntConst);
+    addVObject((antlr4::ParserRuleContext*)ctx->Integral_number(), number->getText(), VObjectType::slIntConst);
   }
   if (ctx->Pound_Pound_delay()) {
-    addVObject ((ParserRuleContext*)ctx->Pound_Pound_delay(), ctx->Pound_Pound_delay()->getText(), VObjectType::slPound_Pound_delay);
+    addVObject ((antlr4::ParserRuleContext*)ctx->Pound_Pound_delay(), ctx->Pound_Pound_delay()->getText(), VObjectType::slPound_Pound_delay);
   }
   addVObject (ctx, VObjectType::slCycle_delay);
 }
 
 void SV3_1aTreeShapeListener::exitCycle_delay_range(SV3_1aParser::Cycle_delay_rangeContext * ctx) {
   if (ctx->Pound_Pound_delay()) {
-    addVObject ((ParserRuleContext*)ctx->Pound_Pound_delay(), ctx->Pound_Pound_delay()->getText(), VObjectType::slPound_Pound_delay);
+    addVObject ((antlr4::ParserRuleContext*)ctx->Pound_Pound_delay(), ctx->Pound_Pound_delay()->getText(), VObjectType::slPound_Pound_delay);
   }
   if (ctx->PLUS()) {
-    addVObject ((ParserRuleContext*)ctx->PLUS(), VObjectType::slUnary_Plus);
+    addVObject ((antlr4::ParserRuleContext*)ctx->PLUS(), VObjectType::slUnary_Plus);
   }
   addVObject (ctx, VObjectType::slCycle_delay_range);
 }
- 
+
 
 void SV3_1aTreeShapeListener::exitLevel_symbol(SV3_1aParser::Level_symbolContext * ctx) {
   if (ctx->Integral_number()) {
     auto number = ctx->Integral_number();
-    addVObject((ParserRuleContext*)ctx->Integral_number(), number->getText(), VObjectType::slIntConst);
+    addVObject((antlr4::ParserRuleContext*)ctx->Integral_number(), number->getText(), VObjectType::slIntConst);
   } else if (ctx->Simple_identifier()) {
     std::string ident = ctx->Simple_identifier()->getText();
-    addVObject((ParserRuleContext*)ctx->Simple_identifier(), ident, VObjectType::slStringConst);
+    addVObject((antlr4::ParserRuleContext*)ctx->Simple_identifier(), ident, VObjectType::slStringConst);
   } else if (ctx->QMARK()) {
-    addVObject ((ParserRuleContext*)ctx->QMARK(), VObjectType::slQmark);
+    addVObject ((antlr4::ParserRuleContext*)ctx->QMARK(), VObjectType::slQmark);
   }
   addVObject (ctx, VObjectType::slLevel_symbol);
 }
@@ -1368,9 +1365,9 @@ void SV3_1aTreeShapeListener::exitLevel_symbol(SV3_1aParser::Level_symbolContext
 void SV3_1aTreeShapeListener::exitEdge_symbol(SV3_1aParser::Edge_symbolContext * ctx) {
   if (ctx->Simple_identifier()) {
     std::string ident = ctx->Simple_identifier()->getText();
-    addVObject((ParserRuleContext*)ctx->Simple_identifier(), ident, VObjectType::slStringConst);
+    addVObject((antlr4::ParserRuleContext*)ctx->Simple_identifier(), ident, VObjectType::slStringConst);
   } else if (ctx->STAR()) {
-    addVObject ((ParserRuleContext*)ctx->STAR(), VObjectType::slBinOp_Mult);
+    addVObject ((antlr4::ParserRuleContext*)ctx->STAR(), VObjectType::slBinOp_Mult);
   }
   addVObject (ctx, VObjectType::slEdge_symbol);
 }
@@ -1396,51 +1393,52 @@ void SV3_1aTreeShapeListener::exitEnd_keywords_directive(
 
 void SV3_1aTreeShapeListener::exitRandomize_call(SV3_1aParser::Randomize_callContext * ctx) {
   if (ctx->NULL_KEYWORD()) {
-    addVObject ((ParserRuleContext*)ctx->NULL_KEYWORD(), VObjectType::slNull);
+    addVObject ((antlr4::ParserRuleContext*)ctx->NULL_KEYWORD(), VObjectType::slNull);
   }
   if (ctx->WITH()) {
-    addVObject ((ParserRuleContext*)ctx->WITH(), VObjectType::slWith);
+    addVObject ((antlr4::ParserRuleContext*)ctx->WITH(), VObjectType::slWith);
   }
   addVObject (ctx, VObjectType::slRandomize_call);
 }
 
 void SV3_1aTreeShapeListener::exitDeferred_immediate_assert_statement(SV3_1aParser::Deferred_immediate_assert_statementContext * ctx) {
   if (ctx->Pound_delay()) {
-    addVObject ((ParserRuleContext*)ctx->Pound_delay(), ctx->Pound_delay()->getText(), VObjectType::slPound_delay);
+    addVObject ((antlr4::ParserRuleContext*)ctx->Pound_delay(), ctx->Pound_delay()->getText(), VObjectType::slPound_delay);
   } else if (ctx->Pound_Pound_delay()) {
-    addVObject ((ParserRuleContext*)ctx->Pound_Pound_delay(), ctx->Pound_Pound_delay()->getText(), VObjectType::slPound_Pound_delay);
-  } 
+    addVObject ((antlr4::ParserRuleContext*)ctx->Pound_Pound_delay(), ctx->Pound_Pound_delay()->getText(), VObjectType::slPound_Pound_delay);
+  }
   addVObject (ctx, VObjectType::slDeferred_immediate_assert_statement);
 }
 
 void SV3_1aTreeShapeListener::exitDeferred_immediate_assume_statement(SV3_1aParser::Deferred_immediate_assume_statementContext * ctx) {
   if (ctx->Pound_delay()) {
-    addVObject ((ParserRuleContext*)ctx->Pound_delay(), ctx->Pound_delay()->getText(), VObjectType::slPound_delay);
+    addVObject ((antlr4::ParserRuleContext*)ctx->Pound_delay(), ctx->Pound_delay()->getText(), VObjectType::slPound_delay);
   } else if (ctx->Pound_Pound_delay()) {
-    addVObject ((ParserRuleContext*)ctx->Pound_Pound_delay(), ctx->Pound_Pound_delay()->getText(), VObjectType::slPound_Pound_delay);
-  } 
+    addVObject ((antlr4::ParserRuleContext*)ctx->Pound_Pound_delay(), ctx->Pound_Pound_delay()->getText(), VObjectType::slPound_Pound_delay);
+  }
   addVObject (ctx, VObjectType::slDeferred_immediate_assume_statement);
 }
 
 void SV3_1aTreeShapeListener::exitDeferred_immediate_cover_statement(SV3_1aParser::Deferred_immediate_cover_statementContext * ctx) {
   if (ctx->Pound_delay()) {
-    addVObject ((ParserRuleContext*)ctx->Pound_delay(), ctx->Pound_delay()->getText(), VObjectType::slPound_delay);
+    addVObject ((antlr4::ParserRuleContext*)ctx->Pound_delay(), ctx->Pound_delay()->getText(), VObjectType::slPound_delay);
   } else if (ctx->Pound_Pound_delay()) {
-    addVObject ((ParserRuleContext*)ctx->Pound_Pound_delay(), ctx->Pound_Pound_delay()->getText(), VObjectType::slPound_Pound_delay);
-  } 
+    addVObject ((antlr4::ParserRuleContext*)ctx->Pound_Pound_delay(), ctx->Pound_Pound_delay()->getText(), VObjectType::slPound_Pound_delay);
+  }
   addVObject (ctx, VObjectType::slDeferred_immediate_cover_statement);
 }
 
 void SV3_1aTreeShapeListener::exitLocal_parameter_declaration(SV3_1aParser::Local_parameter_declarationContext * ctx)  {
   if (ctx->TYPE()) {
-    addVObject ((ParserRuleContext*)ctx->TYPE(), VObjectType::slType); 
+    addVObject ((antlr4::ParserRuleContext*)ctx->TYPE(), VObjectType::slType);
   }
-  addVObject (ctx, VObjectType::slLocal_parameter_declaration); 
+  addVObject (ctx, VObjectType::slLocal_parameter_declaration);
 }
-  
-void SV3_1aTreeShapeListener::exitParameter_declaration(SV3_1aParser::Parameter_declarationContext * ctx) { 
+
+void SV3_1aTreeShapeListener::exitParameter_declaration(SV3_1aParser::Parameter_declarationContext * ctx) {
   if (ctx->TYPE()) {
-    addVObject ((ParserRuleContext*)ctx->TYPE(), VObjectType::slType); 
+    addVObject ((antlr4::ParserRuleContext*)ctx->TYPE(), VObjectType::slType);
   }
-  addVObject (ctx, VObjectType::slParameter_declaration); 
+  addVObject (ctx, VObjectType::slParameter_declaration);
 }
+}  // namespace SURELOG

--- a/src/SourceCompile/SV3_1aTreeShapeListener.h
+++ b/src/SourceCompile/SV3_1aTreeShapeListener.h
@@ -39,6 +39,7 @@
 #include "SourceCompile/CompilationUnit.h"
 #include "SourceCompile/CompileSourceFile.h"
 #include "SourceCompile/SV3_1aTreeShapeHelper.h"
+#include "parser/SV3_1aParserBaseListener.h"
 
 namespace SURELOG {
 

--- a/src/SourceCompile/generate_parser_listener.tcl
+++ b/src/SourceCompile/generate_parser_listener.tcl
@@ -98,6 +98,7 @@ proc generate_header { listener } {
         puts $oid "#include \"SourceCompile/CompilationUnit.h\""
         puts $oid "#include \"SourceCompile/CompileSourceFile.h\""
         puts $oid "#include \"SourceCompile/SV3_1aTreeShapeHelper.h\""
+        puts $oid "#include \"parser/SV3_1aParserBaseListener.h\""
         puts $oid ""
         puts $oid "namespace SURELOG \{"
         puts $oid ""

--- a/src/Testbench/ClassDefinition.cpp
+++ b/src/Testbench/ClassDefinition.cpp
@@ -20,16 +20,16 @@
  *
  * Created on June 1, 2018, 10:12 PM
  */
+#include "Testbench/ClassDefinition.h"
+
 #include "SourceCompile/SymbolTable.h"
 #include "Design/FileContent.h"
-#include "ClassDefinition.h"
 
-using namespace SURELOG;
-
+namespace SURELOG {
 ClassDefinition::ClassDefinition(std::string name, Library* library,
                                  DesignComponent* container,
                                  const FileContent* fC,
-                                 NodeId nodeId, ClassDefinition* parent, 
+                                 NodeId nodeId, ClassDefinition* parent,
                                  UHDM::class_defn* uhdm_definition)
     : DesignComponent(container ? container : fC, NULL),
       DataType(fC, nodeId, name,
@@ -37,7 +37,7 @@ ClassDefinition::ClassDefinition(std::string name, Library* library,
       m_name(name),
       m_library(library),
       m_container(container),
-      m_parent(parent), 
+      m_parent(parent),
       m_uhdm_definition(uhdm_definition) {
   m_category = DataType::Category::CLASS;
   addFileContent(fC, nodeId);
@@ -209,3 +209,4 @@ bool ClassDefinition::hasCompleteBaseSpecification() const {
   }
   return true;
 }
+}  // namespace SURELOG

--- a/src/Testbench/ClassObject.cpp
+++ b/src/Testbench/ClassObject.cpp
@@ -20,12 +20,12 @@
  *
  * Created on March 24, 2019, 7:38 PM
  */
+#include "Testbench/ClassObject.h"
+
 #include "SourceCompile/SymbolTable.h"
 #include "Design/FileContent.h"
-#include "ClassObject.h"
 
-using namespace SURELOG;
-
+namespace SURELOG {
 bool ClassObject::setValue(const std::string& property, Value* value) {
   PropertyValueMap::iterator itr = m_properties.find(property);
   if (itr == m_properties.end()) {
@@ -44,3 +44,4 @@ Value* ClassObject::getValue(const std::string& property) const {
   auto found = m_properties.find(property);
   return found == m_properties.end() ? nullptr : found->second.second;
 }
+}  // namespace SURELOG

--- a/src/Testbench/FunctionMethod.cpp
+++ b/src/Testbench/FunctionMethod.cpp
@@ -21,13 +21,13 @@
  * Created on February 21, 2019, 8:20 PM
  */
 
-#include "FunctionMethod.h"
+#include "Testbench/FunctionMethod.h"
 
-using namespace SURELOG;
-
+namespace SURELOG {
 FunctionMethod::~FunctionMethod() {}
 
 bool FunctionMethod::compile(CompileHelper& compile_helper) {
   bool result = Function::compile(compile_helper);
   return result;
 }
+}  // namespace SURELOG

--- a/src/Testbench/Program.cpp
+++ b/src/Testbench/Program.cpp
@@ -20,13 +20,13 @@
  *
  * Created on June 1, 2018, 8:58 PM
  */
+#include "Testbench/Program.h"
+
 #include "SourceCompile/SymbolTable.h"
 #include "Design/FileContent.h"
 #include "Design/DesignComponent.h"
-#include "Program.h"
 
-using namespace SURELOG;
-
+namespace SURELOG {
 Program::~Program() {}
 
 unsigned int Program::getSize() const {
@@ -45,3 +45,4 @@ ClassDefinition* Program::getClassDefinition(const std::string& name) {
     return (*itr).second;
   }
 }
+}  // namespace SURELOG

--- a/src/Testbench/Property.cpp
+++ b/src/Testbench/Property.cpp
@@ -20,11 +20,8 @@
  *
  * Created on January 23, 2019, 9:17 PM
  */
-#include "SourceCompile/SymbolTable.h"
-#include "Design/FileContent.h"
-#include "Design/DesignComponent.h"
-#include "Property.h"
+#include "Testbench/Property.h"
 
-using namespace SURELOG;
-
+namespace SURELOG {
 Property::~Property() {}
+}  // namespace SURELOG

--- a/src/Testbench/TaskMethod.cpp
+++ b/src/Testbench/TaskMethod.cpp
@@ -21,13 +21,13 @@
  * Created on February 21, 2019, 8:21 PM
  */
 
-#include "TaskMethod.h"
+#include "Testbench/TaskMethod.h"
 
-using namespace SURELOG;
-
+namespace SURELOG {
 TaskMethod::~TaskMethod() {}
 
 bool TaskMethod::compile(CompileHelper& compile_helper) {
   bool result = Task::compile(compile_helper);
   return result;
 }
+}  // namespace SURELOG

--- a/src/Testbench/TypeDef.cpp
+++ b/src/Testbench/TypeDef.cpp
@@ -20,13 +20,13 @@
  *
  * Created on March 6, 2019, 9:14 PM
  */
+#include "Testbench/TypeDef.h"
+
 #include "SourceCompile/SymbolTable.h"
 #include "SourceCompile/VObjectTypes.h"
 #include "Design/FileContent.h"
-#include "TypeDef.h"
 
-using namespace SURELOG;
-
+namespace SURELOG {
 TypeDef::TypeDef(const FileContent* fC, NodeId id, NodeId the_def,
                  const std::string& name)
     : DataType(fC, id, name, fC->Type(id)), m_the_def(the_def), m_datatype(NULL) {
@@ -34,3 +34,4 @@ TypeDef::TypeDef(const FileContent* fC, NodeId id, NodeId the_def,
 }
 
 TypeDef::~TypeDef() {}
+}  // namespace SURELOG

--- a/src/Testbench/Variable.cpp
+++ b/src/Testbench/Variable.cpp
@@ -20,11 +20,8 @@
  *
  * Created on May 26, 2019, 10:42 AM
  */
-#include "SourceCompile/SymbolTable.h"
-#include "Design/FileContent.h"
-#include "Design/DesignComponent.h"
-#include "Variable.h"
+#include "Testbench/Variable.h"
 
-using namespace SURELOG;
-
+namespace SURELOG {
 Variable::~Variable() {}
+}  // namespace SURELOG

--- a/src/Testbench/Variable.h
+++ b/src/Testbench/Variable.h
@@ -26,6 +26,10 @@
 
 #include <string_view>
 
+#include "Design/DataType.h"
+#include "Design/FileContent.h"
+#include "SourceCompile/SymbolTable.h"
+
 namespace SURELOG {
 
 class Variable {


### PR DESCRIPTION
Much like the previous #1239 #1240 #1242 #1244 #1245

Signed-off-by: Henner Zeller <h.zeller@acm.org>