### PR TITLE
Fix path handling on windows and include LogListener for installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -600,6 +600,7 @@ install(
         ${PROJECT_SOURCE_DIR}/src/ErrorReporting/Error.h
         ${PROJECT_SOURCE_DIR}/src/ErrorReporting/ErrorDefinition.h
         ${PROJECT_SOURCE_DIR}/src/ErrorReporting/ErrorContainer.h
+        ${PROJECT_SOURCE_DIR}/src/ErrorReporting/LogListener.h
         ${PROJECT_SOURCE_DIR}/src/ErrorReporting/Report.h
         ${PROJECT_SOURCE_DIR}/src/ErrorReporting/Waiver.h
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/surelog/ErrorReporting)

--- a/src/Utils/FileUtils.cpp
+++ b/src/Utils/FileUtils.cpp
@@ -264,7 +264,7 @@ std::string FileUtils::hashPath(const std::string& path) {
   if (last_dir.size()) last_dir.erase(last_dir.end() - 1);
   char c = separator[0];
   auto it1 = std::find_if(last_dir.rbegin(), last_dir.rend(),
-                          [c](char ch) { return (ch == c); });
+                          [](char ch) { return (ch == '/' || ch == '\\'); });
   if (it1 != last_dir.rend()) last_dir.erase(last_dir.begin(), it1.base());
 
   hashedpath = last_dir + "_" + std::to_string(val) + separator;


### PR DESCRIPTION
* Fix handling of absolute paths with forward slashes on windows.
* Include LogListener.h for install