### PR TITLE
Fix chandle variables

### DIFF
--- a/src/DesignCompile/ElaborationStep.cpp
+++ b/src/DesignCompile/ElaborationStep.cpp
@@ -1286,6 +1286,9 @@ any* ElaborationStep::makeVar_(DesignComponent* component, Signal* sig,
     } else if (subnettype == slString_type) {
       UHDM::string_var* int_var = s.MakeString_var();
       var = int_var;
+    } else if (subnettype == slChandle_type) {
+      UHDM::chandle_var* int_var = s.MakeChandle_var();
+      var = int_var;
     } else {
       // default type (fallback)
       logic_var* logicv = s.MakeLogic_var();

--- a/src/DesignCompile/NetlistElaboration.cpp
+++ b/src/DesignCompile/NetlistElaboration.cpp
@@ -1042,7 +1042,8 @@ void NetlistElaboration::elabSignal(Signal* sig, ModuleInstance* instance,
       (subnettype == slString_type) || (subnettype == slNonIntType_Real) ||
       (subnettype == slNonIntType_RealTime) ||
       (subnettype == slNonIntType_ShortReal) ||
-      (subnettype == slIntVec_TypeBit)) {
+      (subnettype == slIntVec_TypeBit) ||
+      (subnettype == slChandle_type)) {
     isNet = false;
   }
 


### PR DESCRIPTION
This PR Fixes `chandle` handling when it is used as variable. Test case for this would be:
```
module top;
     chandle a;
endmodule
```
Before the change UHDM would have `vpiNet` and `logic_net`:
```
 |uhdmallModules:
 \_module: work@top (work@top) /home/korzen/work/yosys/uhdm-integration/tests/DpiChandle/top.sv:6: , parent:work@top
   |vpiDefName:work@top
   |vpiFullName:work@top
   |vpiNet:
   \_logic_net: (work@top.a), line:13, parent:work@top
     |vpiName:a
     |vpiFullName:work@top.a
 |uhdmtopModules:
 \_module: work@top (work@top) /home/korzen/work/yosys/uhdm-integration/tests/DpiChandle/top.sv:6:
   |vpiDefName:work@top
   |vpiName:work@top
   |vpiNet:
   \_logic_net: (work@top.a), line:13, parent:work@top
     |vpiName:a
     |vpiFullName:work@top.a
```

After applying the changes:
```
 |uhdmallModules:
 \_module: work@top (work@top) /home/korzen/work/yosys/uhdm-integration/tests/DpiChandle/top.sv:6: , parent:work@top
   |vpiDefName:work@top
   |vpiFullName:work@top
   |vpiNet:
   \_logic_net: (work@top.a), line:17, parent:work@top
     |vpiName:a
     |vpiFullName:work@top.a
 |uhdmtopModules:
 \_module: work@top (work@top) /home/korzen/work/yosys/uhdm-integration/tests/DpiChandle/top.sv:6:
   |vpiDefName:work@top
   |vpiName:work@top
   |vpiVariables:
   \_chandle_var: (work@top.a), line:17, parent:work@top
     |vpiName:a
     |vpiFullName:work@top.a
     |vpiAutomatic:1
     |vpiVisibility:1
```

Signed-off-by: Paweł Czarnecki <pczarnecki@antmicro.com>