### PR TITLE
Add parsing parameters of type chandle

### DIFF
--- a/src/DesignCompile/CompileType.cpp
+++ b/src/DesignCompile/CompileType.cpp
@@ -1210,7 +1210,13 @@ UHDM::typespec* CompileHelper::compileTypespec(
       break;
     }
     case VObjectType::slChandle_type: {
-      result = nullptr;
+      UHDM::chandle_typespec* tps = s.MakeChandle_typespec();
+      tps->VpiFile(fC->getFileName());
+      tps->VpiLineNo(fC->Line(type));
+      tps->VpiColumnNo(fC->Column(type));
+      tps->VpiEndLineNo(fC->EndLine(type));
+      tps->VpiEndColumnNo(fC->EndColumn(type));
+      result = tps;
       break;
     }
     case VObjectType::slSigning_Signed:

--- a/tests/DpiChandle/DpiChandle.log
+++ b/tests/DpiChandle/DpiChandle.log
@@ -1,4 +1,4 @@
-[INF:CM0023] Creating log file ../../build/tests/DpiChandle/slpp_all/surelog.log.
+[INF:CM0023] Creating log file ./slpp_all/surelog.log.
 
 LIB:  work
 FILE: dut.sv
@@ -71,11 +71,11 @@ n<> u<40> t<Top_level_rule> l<1:0> el<8:0>
 
 [INF:UH0707] Elaborating UHDM...
 
-[INF:UH0708] Writing UHDM DB: ../../build/tests/DpiChandle/slpp_all//surelog.uhdm...
+[INF:UH0708] Writing UHDM DB: ./slpp_all//surelog.uhdm...
 
-[INF:UH0709] Writing UHDM Html Coverage: ../../build/tests/DpiChandle/slpp_all//surelog.uhdm.chk.html...
+[INF:UH0709] Writing UHDM Html Coverage: ./slpp_all//surelog.uhdm.chk.html...
 
-[INF:UH0710] Loading UHDM DB: ../../build/tests/DpiChandle/slpp_all//surelog.uhdm...
+[INF:UH0710] Loading UHDM DB: ./slpp_all//surelog.uhdm...
 
 [INF:UH0711] Decompling UHDM...
 
@@ -105,7 +105,7 @@ design: (work@top)
     |vpiName:system
     |vpiFullName:builtin::system
 |uhdmallClasses:
-\_class_defn: (work@mailbox) ${SURELOG_DIR}/build/bin/sv/builtin.sv:4: , endln:30:8, parent:work@top
+\_class_defn: (work@mailbox) /home/rrozak/Documents/verilator/Surelog/build/bin/sv/builtin.sv:4: , endln:30:8, parent:work@top
   |vpiName:work@mailbox
   |vpiMethod:
   \_function: (work@mailbox::new), line:6:2, endln:7:13, parent:work@mailbox
@@ -117,7 +117,7 @@ design: (work@top)
       |vpiTypespec:
       \_class_typespec: 
         |vpiClassDefn:
-        \_class_defn: (work@mailbox) ${SURELOG_DIR}/build/bin/sv/builtin.sv:4: , endln:30:8, parent:work@top
+        \_class_defn: (work@mailbox) /home/rrozak/Documents/verilator/Surelog/build/bin/sv/builtin.sv:4: , endln:30:8, parent:work@top
     |vpiIODecl:
     \_io_decl: (bound)
       |vpiName:bound
@@ -205,7 +205,7 @@ design: (work@top)
       |vpiName:message
       |vpiDirection:6
 |uhdmallClasses:
-\_class_defn: (work@process) ${SURELOG_DIR}/build/bin/sv/builtin.sv:33: , endln:55:8, parent:work@top
+\_class_defn: (work@process) /home/rrozak/Documents/verilator/Surelog/build/bin/sv/builtin.sv:33: , endln:55:8, parent:work@top
   |vpiName:work@process
   |vpiMethod:
   \_function: (work@process::self), line:37:2, endln:37:8, parent:work@process
@@ -326,7 +326,7 @@ design: (work@top)
       |INT:4
       |vpiSize:64
 |uhdmallClasses:
-\_class_defn: (work@semaphore) ${SURELOG_DIR}/build/bin/sv/builtin.sv:58: , endln:72:8, parent:work@top
+\_class_defn: (work@semaphore) /home/rrozak/Documents/verilator/Surelog/build/bin/sv/builtin.sv:58: , endln:72:8, parent:work@top
   |vpiName:work@semaphore
   |vpiMethod:
   \_function: (work@semaphore::new), line:60:2, endln:61:13, parent:work@semaphore
@@ -338,7 +338,7 @@ design: (work@top)
       |vpiTypespec:
       \_class_typespec: 
         |vpiClassDefn:
-        \_class_defn: (work@semaphore) ${SURELOG_DIR}/build/bin/sv/builtin.sv:58: , endln:72:8, parent:work@top
+        \_class_defn: (work@semaphore) /home/rrozak/Documents/verilator/Surelog/build/bin/sv/builtin.sv:58: , endln:72:8, parent:work@top
     |vpiIODecl:
     \_io_decl: (keyCount)
       |vpiName:keyCount
@@ -435,6 +435,8 @@ design: (work@top)
     \_io_decl: (in)
       |vpiName:in
       |vpiDirection:1
+      |vpiTypedef:
+      \_chandle_typespec: , line:6:27, endln:6:34
 |uhdmtopModules:
 \_module: work@top (work@top) dut.sv:1: , endln:7:9
   |vpiDefName:work@top
@@ -463,10 +465,11 @@ design: (work@top)
     \_io_decl: (in), parent:work@top.test_input
       |vpiName:in
       |vpiDirection:1
+      |vpiTypedef:
+      \_chandle_typespec: , line:6:27, endln:6:34
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0
 [  ERROR] : 0
 [WARNING] : 1
 [   NOTE] : 5
-


### PR DESCRIPTION
There was no type information about function parameter when it had type `chandle`. This PR fixes it. 

It should wait until https://github.com/alainmarcel/UHDM/pull/425 is merged. 